### PR TITLE
Import human descriptions; add sku field; rename ai_description -> alt_text_long

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ scripts/.description-progress.json
 
 # CSV data (large)
 inventory_*.csv
+
+# Working directory for CSV imports/exports (input + generated artifacts)
+tmp/

--- a/PROJECT_HANDOFF.md
+++ b/PROJECT_HANDOFF.md
@@ -1,8 +1,46 @@
 # Project Handoff — Creative Growth CLIR Digital Gallery
 
-**Date:** 2026-04-02
+**Last updated:** 2026-04-23 (initial handoff: 2026-04-02)
 **Repo:** `cg_clir/` (git initialized, not yet pushed to remote)
 **Design doc:** `DESIGN.md` — comprehensive architecture, data model, and project plan
+
+> This is a living document. The "Updates Log" section captures changes made since the original 2026-04-02 handoff. Sections below have been edited inline where state has changed; check the log for a summary of what's new.
+
+---
+
+## Updates Log
+
+### 2026-04-09 — Description review SPA, CG header integration, artist bio scraper
+
+**M1 (image migration) and M2 (AI descriptions) appear to have completed** between 2026-04-02 and 2026-04-09 — inferred from:
+- Commit `19aae60` ("Add image migration + AI description pipeline, configure Next.js images")
+- Commit `f3d498a` ("Fix image URLs: add R2 public domain, resolve relative paths") — adds `resolveImageUrl()` utility, implies R2 is now the canonical image host
+- Commit `3ddd6c9` adds a description-review SPA, which would have nothing to review unless descriptions had been generated
+
+> ⚠ Verify exact row counts in `artworks.image_url` (should point to R2), `artworks.alt_text`, and `artworks.ai_description` before assuming 100% coverage. The original handoff reports 1,803 artworks pending image migration; that number is almost certainly stale but should be re-checked.
+
+**New: Description Review SPA** (`public/review.html`, 629 lines, vanilla JS — no React)
+- Single-page tool for gallery managers to triage AI-generated alt text + descriptions
+- Approve / edit / skip flow with keyboard shortcuts (`a` / `e` / `s` / arrows)
+- Search, filter (unreviewed / reviewed / all), inline editing with character count
+- localStorage persistence for current position, filter, and search (commit `3ff4521`)
+- Served as a static asset by Next.js — accessible at `/review.html`
+
+**New: Real Creative Growth header** (commit `7a160b4`)
+- `src/components/cg-header.html` — raw HTML extracted from creativegrowth.org via Playwright
+- `public/cg-header.css` — scoped styles for the CG nav (dropdowns, hover states)
+- `next.config.mjs` — webpack rule to import `.html` files as raw strings; `src/html.d.ts` for TS types
+- `src/components/Header.tsx` — rewritten to inject the real CG header above a CLIR sub-nav, so the gallery feels seamlessly part of creativegrowth.org
+
+**New: Artist bio scraper** (`scripts/scrape-bios.ts`, commit `cc2034a`)
+- Playwright crawler over 201 artist pages from the creativegrowth.org sitemap
+- Matches website artists to CLIR DB by slug → name → fuzzy match
+- Updated 36 CLIR artist rows with biographies; logs all 247+ artists from both sources to `scripts/artist-bios-log.csv` for Creative Growth's review
+- CSV updated 2026-04-09 (commit `f4e64d0`) to include admin links, artwork counts, and sort by prolific artists first
+
+**Page fixes** — `collection/page.tsx` and `search/page.tsx` had Supabase type errors fixed via wildcard select (commits `9d08fb4`, `5a2ac8f`); both pages presumably render real data now (verify by running `npm run dev`).
+
+**Not yet recorded in DESIGN.md or original handoff:** the bio scraper, review SPA, and header injection are all post-design additions. Worth eventually folding into DESIGN.md if any of these patterns will inform future work.
 
 ---
 
@@ -48,23 +86,24 @@ Schema migration: `supabase/migrations/001_initial.sql` (run manually via SQL Ed
 - CLIR Collection: 2,112 (all works)
 - Photography & Digital: 0 (no matches — consider removing)
 
-**Image migration — barely started:**
+**Image migration — appears complete (verify counts):**
 - R2 bucket `cg-clir` is live and writable
-- 2 artworks fully migrated (4 variants each: original, large_1600, medium_800, thumb_400)
-- 1,803 artworks have images that need migrating
-- The remaining `image_url` values still point to `cdn.artcld.com`
+- Variants per artwork: original, large_1600, medium_800, thumb_400
+- `R2_PUBLIC_URL` is now configured; `resolveImageUrl()` utility resolves R2 paths with Art Cloud fallback
+- 2026-04-02 status was "2 artworks migrated, 1,803 pending" — that is now stale; re-query before relying on a number
 
-**AI descriptions — not started:**
-- Script is written (`scripts/generate-descriptions.ts`) but has not been run
-- 0 artworks have `ai_description` or `alt_text` populated
+**AI descriptions — appears generated for catalog (verify counts):**
+- Pipeline added in commit `19aae60`; review SPA at `/review.html` exists, implying descriptions were populated
+- Original status said 0 artworks had `ai_description` or `alt_text` — verify current coverage
 
 ### What's NOT Done
 
-- **M1 (remaining):** Image migration to R2 — needs to complete for all 1,803 images
-- **M2:** AI description generation via Claude Vision — script ready, needs to run
-- **M3:** Public gallery frontend — route stubs exist, pages need real implementation
-- **M4:** Admin console — route stubs exist, needs full CRUD UI
+- ~~**M1 (remaining):** Image migration to R2~~ — appears complete; verify counts
+- ~~**M2:** AI description generation via Claude Vision~~ — appears complete; descriptions are now in human-review phase via `/review.html`
+- **M3:** Public gallery frontend — partially done. Collection and search pages now render (post type-fix); artwork detail, artist index/detail, about page need verification of completeness
+- **M4:** Admin console — route stubs exist (per handoff); CRUD UI status unknown — verify by visiting `/admin` with `NEXT_PUBLIC_AUTH_BYPASS=true`
 - **M5:** QA, accessibility audit, performance tuning, launch
+- **Post-design adds (not in original plan):** integrate bio scraper output into artist detail pages; productionize the description review workflow (currently a static SPA — could move into `/admin`); finalize CG header styling for mobile
 
 ---
 
@@ -144,35 +183,45 @@ cg_clir/
 ├── supabase/migrations/           # SQL schema
 │   └── 001_initial.sql            # Tables, RLS, indexes, triggers, FTS
 ├── scripts/
-│   ├── import-csv.ts              # CSV → Supabase (DONE, works)
-│   ├── seed-categories.ts         # Category creation + assignment (DONE, works)
-│   ├── migrate-images.ts          # Art Cloud → R2 (HAS SSL ISSUES)
-│   ├── generate-descriptions.ts   # Claude Vision descriptions (NOT YET RUN)
+│   ├── import-csv.ts              # CSV → Supabase (DONE)
+│   ├── seed-categories.ts         # Category creation + assignment (DONE)
+│   ├── migrate-images.ts          # Art Cloud → R2 (RAN; verify completeness)
+│   ├── generate-descriptions.ts   # Claude Vision descriptions (RAN; verify completeness)
+│   ├── migrate-and-describe.ts    # Combined migration + description pipeline
+│   ├── scrape-bios.ts             # NEW (2026-04-03): Playwright scraper for artist bios
+│   ├── artist-bios-log.csv        # NEW: review log of scraped bios for CG to vet
 │   └── run-migration.ts           # DDL helper (limited by sandbox)
+├── public/
+│   ├── review.html                # NEW (2026-04-09): description review SPA (vanilla JS)
+│   └── cg-header.css              # NEW (2026-04-03): scoped CSS for injected CG header
 ├── src/
+│   ├── html.d.ts                  # NEW: TS declaration for raw .html imports
 │   ├── lib/
 │   │   ├── supabase/              # Client, server, admin Supabase clients
 │   │   ├── r2.ts                  # R2 upload/download/presign helpers
 │   │   ├── posthog.ts             # Analytics client
 │   │   ├── types.ts               # TypeScript interfaces
-│   │   └── utils.ts               # Slugify, formatting, parsing
-│   ├── components/                # React components (stubs)
+│   │   └── utils.ts               # Slugify, formatting, parsing, resolveImageUrl()
+│   ├── components/                # React components
 │   │   ├── ArtworkCard.tsx
 │   │   ├── ArtworkGrid.tsx
 │   │   ├── CategoryTabs.tsx
 │   │   ├── DownloadButton.tsx
-│   │   ├── Header.tsx / Footer.tsx
+│   │   ├── Header.tsx             # Now injects real CG header + CLIR sub-nav
+│   │   ├── cg-header.html         # NEW: raw CG header markup, imported as string
+│   │   ├── Footer.tsx
 │   │   ├── Pagination.tsx
+│   │   ├── PostHogProvider.tsx
 │   │   ├── SearchBar.tsx
 │   │   └── SkipLink.tsx
 │   └── app/
-│       ├── page.tsx               # Landing page (stub)
-│       ├── collection/page.tsx    # Grid view (stub)
-│       ├── artwork/[id]/page.tsx  # Detail page (stub)
-│       ├── artists/               # Index + detail (stubs)
-│       ├── search/page.tsx        # Search (stub)
-│       ├── about/page.tsx         # About (stub)
-│       ├── admin/                 # Admin console (stubs, behind AUTH_BYPASS)
+│       ├── page.tsx               # Landing page
+│       ├── collection/page.tsx    # Grid view (renders real data post-fix)
+│       ├── artwork/[id]/page.tsx  # Detail page
+│       ├── artists/               # Index + detail
+│       ├── search/page.tsx        # Search (renders real data post-fix)
+│       ├── about/page.tsx         # About
+│       ├── admin/                 # Admin console (behind AUTH_BYPASS)
 │       └── api/download/route.ts  # Download tracking endpoint
 └── inventory_2026-04-02.csv       # Source data (gitignored)
 ```
@@ -181,23 +230,22 @@ cg_clir/
 
 ## Recommended Next Steps (in order)
 
-1. **Complete M1 — Image migration.** Run `npm run import:images` from a local machine (not the sandbox) to avoid SSL issues. The script checkpoints progress and can resume. Once done, all `artworks.image_url` values will point to R2 instead of `cdn.artcld.com`.
+1. ~~**Complete M1 — Image migration.**~~ Appears done (commit `f3d498a`). Verify by querying Supabase for any remaining `cdn.artcld.com` URLs.
 
-2. **Run M2 — AI descriptions.** Run `npm run generate:descriptions` (also best from local). This calls Claude Vision for each artwork, generating `alt_text` (≤125 chars) and `ai_description` (2-4 sentences). Estimated cost: ~$15-25 for all 2,112 images. The script checkpoints and resumes.
+2. ~~**Run M2 — AI descriptions.**~~ Appears done. Verify by counting `artworks` rows where `alt_text IS NOT NULL` and `ai_description IS NOT NULL`.
 
-3. **Set up R2 public URL.** Either enable the R2 bucket's public access (generates a `*.r2.dev` URL) or configure a custom domain. Put the URL in `R2_PUBLIC_URL` env var. Update `artworks.image_url` values to use it.
+3. ~~**Set up R2 public URL.**~~ Done — `R2_PUBLIC_URL` is wired up via `resolveImageUrl()`.
 
-4. **Build M3 — Public gallery pages.** The route stubs and components exist. Key pages to implement:
-   - `/collection` — artwork grid with category tabs and filters
-   - `/artwork/[id]` — detail page with image, metadata, download button
-   - `/artists` — alphabetical artist index
-   - `/artists/[slug]` — artist detail with their works
-   - `/search` — full-text search (Supabase FTS index already exists)
-   - Refer to DESIGN.md §7 for full specs and WCAG requirements
+4. **Finish M3 — Public gallery pages.** Stubs/initial implementations exist. Audit each route against DESIGN.md §7:
+   - `/collection` — type-fixed; verify category tabs + filters work
+   - `/artwork/[id]` — detail page; verify download button + metadata
+   - `/artists` and `/artists/[slug]` — verify scraped bios are surfaced
+   - `/search` — type-fixed; verify FTS results
+   - Run a WCAG audit (axe DevTools) on each
 
-5. **Build M4 — Admin console.** Protected by `NEXT_PUBLIC_AUTH_BYPASS=true` for now. When Google OAuth creds arrive, flip to Supabase Auth + Google SSO.
+5. **Build M4 — Admin console.** Protected by `NEXT_PUBLIC_AUTH_BYPASS=true` for now. When Google OAuth creds arrive, flip to Supabase Auth + Google SSO. Consider folding the description review SPA into `/admin/review` so reviewers don't need a separate URL.
 
-6. **Push to GitHub and deploy to Vercel.**
+6. **Push to GitHub and deploy to Vercel.** Repo is still local-only.
 
 ---
 

--- a/docs/superpowers/plans/2026-04-23-human-descriptions-import.md
+++ b/docs/superpowers/plans/2026-04-23-human-descriptions-import.md
@@ -1,0 +1,1145 @@
+# Human Descriptions Import Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Import 590 human-written paragraph descriptions from CSV, supersede AI-generated content for matched SKUs, produce a per-row update log and a full-catalog export with prior-AI snapshots; bundle the schema rename rollout (UI + scripts) needed because the DB column rename has already been applied.
+
+**Architecture:** Two phases. Phase 1 = the import + export script (independently runnable; produces both artifacts in one pass so prior values are captured at update time). Phase 2 = the rename rollout across UI components and adjacent scripts. Phase 1 ships first because the DB schema is already in the renamed state, so getting clean data in is the foundation; Phase 2 makes the codebase consistent with the data.
+
+**Tech Stack:** TypeScript, Node 20+, `tsx` runner, `csv-parse/sync`, `@supabase/supabase-js`, Node's built-in test runner (`node:test`) — no new dependencies.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-23-human-descriptions-import-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- `src/lib/text.ts` — pure utility function `truncateForAlt` that turns a paragraph into a ≤150-char alt text with ellipsis. Lives in `src/lib/` so both the import script and the admin form can import it cleanly.
+- `scripts/test-text.ts` — `node:test` assertions for `truncateForAlt`.
+- `scripts/import-human-descriptions.ts` — main script. Parses CSV, pages through artworks, updates matched rows, writes the two CSV artifacts.
+
+**Modified files (Phase 1):**
+- `package.json` — add `import:descriptions` npm script
+- `.gitignore` — add `tmp/` so input CSV and output artifacts stay out of git
+
+**Modified files (Phase 2):**
+- `src/lib/types.ts` — rename `ai_description` field on `Artwork` to `alt_text_long`; add `description_origin`
+- `src/lib/utils.ts` — `getAltText()` drops the fallback-to-long-form (the bug that motivated this work)
+- `src/app/artwork/[id]/page.tsx` — read `alt_text_long` for `<img alt>`; delete the "About This Work" section
+- `src/app/admin/artworks/[id]/page.tsx` — rename column references; relabel form fields; update copy-button to truncate
+- `public/review.html` — rename column references in fetch URLs and PATCH bodies
+- `scripts/generate-descriptions.ts` — rename column refs; set `description_origin: 'ai'` on insert
+- `scripts/migrate-and-describe.ts` — same as above
+- `supabase/migrations/001_initial.sql` — sync source-controlled schema with the applied state
+
+---
+
+## Phase 0: Pre-flight
+
+### Task 0: Verify the schema migration is in place
+
+**Files:** none (read-only)
+
+- [ ] **Step 1: Confirm columns exist in production**
+
+Run:
+```bash
+npx tsx --env-file=.env.local -e "
+import { createClient } from '@supabase/supabase-js';
+const c = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+c.from('artworks').select('id, alt_text, alt_text_long, description_origin').limit(1).then(({data, error}) => {
+  if (error) { console.error('SCHEMA MISMATCH:', error.message); process.exit(1); }
+  console.log('OK - columns exist:', Object.keys(data[0]));
+});
+"
+```
+
+Expected: `OK - columns exist: [ 'id', 'alt_text', 'alt_text_long', 'description_origin' ]`
+
+If this fails: stop. The schema migration was not applied as expected; user must re-run the SQL from the spec's "Schema (already migrated)" section before proceeding.
+
+---
+
+## Phase 1: Import + export script
+
+### Task 1: Add `tmp/` to `.gitignore`
+
+**Files:**
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Append `tmp/` to .gitignore**
+
+Edit `.gitignore`, append at the bottom:
+
+```
+# Working directory for CSV imports/exports (input + generated artifacts)
+tmp/
+```
+
+- [ ] **Step 2: Verify input CSV is now ignored**
+
+Run: `git check-ignore "tmp/CLIR Image Descriptions Sheet - Brief Descriptions.csv"`
+Expected: outputs the path, exit code 0.
+
+---
+
+### Task 2: Create truncation utility — failing test first
+
+**Files:**
+- Create: `scripts/test-text.ts`
+
+- [ ] **Step 1: Write the test file**
+
+Create `scripts/test-text.ts`:
+
+```typescript
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { truncateForAlt } from "../src/lib/text";
+
+test("returns short input verbatim, no ellipsis", () => {
+  const input = "A short description.";
+  assert.equal(truncateForAlt(input, 150), input);
+});
+
+test("trims leading and trailing whitespace", () => {
+  assert.equal(truncateForAlt("  hello  ", 150), "hello");
+});
+
+test("collapses newlines to single spaces", () => {
+  assert.equal(truncateForAlt("line one\nline two", 150), "line one line two");
+});
+
+test("collapses runs of whitespace to one space", () => {
+  assert.equal(truncateForAlt("a   b\t\tc", 150), "a b c");
+});
+
+test("returns empty string for empty input", () => {
+  assert.equal(truncateForAlt("", 150), "");
+});
+
+test("returns empty string for whitespace-only input", () => {
+  assert.equal(truncateForAlt("   \n\t  ", 150), "");
+});
+
+test("truncates long input at last word boundary, ending with ellipsis", () => {
+  const longInput = "The quick brown fox jumps over the lazy dog. ".repeat(10);
+  const result = truncateForAlt(longInput, 150);
+  assert.ok(result.length <= 150, `length ${result.length} > 150`);
+  assert.ok(result.endsWith("…"), `"${result}" should end with ellipsis`);
+  const charBeforeEllipsis = result.slice(-2, -1);
+  assert.notEqual(charBeforeEllipsis, " ", "should not have trailing space before ellipsis");
+});
+
+test("hard-cuts when no whitespace exists in first maxLen-1 chars", () => {
+  const noSpaces = "x".repeat(200);
+  const result = truncateForAlt(noSpaces, 150);
+  assert.equal(result.length, 150);
+  assert.equal(result, "x".repeat(149) + "…");
+});
+
+test("respects custom maxLen", () => {
+  const input = "abcdefghij ".repeat(5);
+  const result = truncateForAlt(input, 20);
+  assert.ok(result.length <= 20, `length ${result.length} > 20`);
+  assert.ok(result.endsWith("…"));
+});
+
+test("does not append ellipsis when input is exactly maxLen", () => {
+  const input = "x".repeat(150);
+  const result = truncateForAlt(input, 150);
+  assert.equal(result, input);
+  assert.ok(!result.endsWith("…"));
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `npx tsx --test scripts/test-text.ts`
+Expected: All tests fail with `Error: Cannot find module '../src/lib/text'` or similar.
+
+---
+
+### Task 3: Implement truncation utility
+
+**Files:**
+- Create: `src/lib/text.ts`
+
+- [ ] **Step 1: Write the implementation**
+
+Create `src/lib/text.ts`:
+
+```typescript
+/**
+ * Truncate a paragraph for use as a short alt text.
+ *
+ * Behavior:
+ * - Collapses all whitespace (newlines, tabs, runs of spaces) to single spaces, then trims.
+ * - If the result is <= maxLen chars, returns it verbatim with no ellipsis.
+ * - Otherwise, slices to (maxLen - 1) chars, finds the last whitespace within that slice,
+ *   cuts there, and appends a single Unicode ellipsis (U+2026). Total length <= maxLen.
+ * - If no whitespace exists in the first (maxLen - 1) chars, hard-cuts at (maxLen - 1) + ellipsis.
+ */
+export function truncateForAlt(input: string, maxLen: number = 150): string {
+  const collapsed = input.replace(/\s+/g, " ").trim();
+  if (collapsed.length <= maxLen) return collapsed;
+
+  const ellipsis = "…";
+  const slice = collapsed.slice(0, maxLen - 1);
+  const lastSpace = slice.lastIndexOf(" ");
+
+  if (lastSpace === -1) {
+    return slice + ellipsis;
+  }
+  return slice.slice(0, lastSpace) + ellipsis;
+}
+```
+
+- [ ] **Step 2: Run the test and verify it passes**
+
+Run: `npx tsx --test scripts/test-text.ts`
+Expected: All 10 tests pass.
+
+---
+
+### Task 4: Verify column types align with what the script will fetch
+
+**Files:** none (read-only verification)
+
+- [ ] **Step 1: Confirm `resolveImageUrl()` works without React/Next runtime**
+
+Run:
+```bash
+npx tsx --env-file=.env.local -e "
+import { resolveImageUrl } from './src/lib/utils';
+console.log(resolveImageUrl({ image_url: 'foo/bar.jpg', image_original: 'https://cdn.artcld.com/x.jpg' }));
+"
+```
+
+Expected: prints `https://cdn.artcld.com/x.jpg` (or, if `NEXT_PUBLIC_R2_PUBLIC_URL` is set, the constructed R2 URL). Either is fine — confirms the helper imports cleanly in a Node-only context.
+
+If this fails: the script's `resolveImageUrl` import needs replacement. Reproduce the same logic inline in the script instead of importing.
+
+---
+
+### Task 5: Implement the import + export script
+
+**Files:**
+- Create: `scripts/import-human-descriptions.ts`
+
+- [ ] **Step 1: Write the script**
+
+Create `scripts/import-human-descriptions.ts`:
+
+```typescript
+#!/usr/bin/env npx tsx
+/**
+ * import-human-descriptions.ts
+ *
+ * Reads the human-authored description CSV at HUMAN_CSV_PATH (default:
+ * tmp/CLIR Image Descriptions Sheet - Brief Descriptions.csv), updates
+ * matched artworks (alt_text_long, alt_text, description_origin='human'),
+ * and writes two timestamped CSV artifacts to tmp/:
+ *   - import-human-descriptions-log_<ISO>.csv  per-row update log
+ *   - descriptions-export_<ISO>.csv             full catalog snapshot
+ *
+ * Run: npx tsx --env-file=.env.local scripts/import-human-descriptions.ts
+ */
+
+import fs from "fs";
+import path from "path";
+import { parse } from "csv-parse/sync";
+import { createClient } from "@supabase/supabase-js";
+import { truncateForAlt } from "../src/lib/text";
+import { resolveImageUrl } from "../src/lib/utils";
+
+// ─── Config ───────────────────────────────────────────────────────────────
+const TMP_DIR = path.join(__dirname, "..", "tmp");
+const CSV_PATH =
+  process.env.HUMAN_CSV_PATH ||
+  path.join(TMP_DIR, "CLIR Image Descriptions Sheet - Brief Descriptions.csv");
+
+const TIMESTAMP = new Date().toISOString().replace(/[:.]/g, "-");
+const LOG_FILE = path.join(TMP_DIR, `import-human-descriptions-log_${TIMESTAMP}.csv`);
+const EXPORT_FILE = path.join(TMP_DIR, `descriptions-export_${TIMESTAMP}.csv`);
+
+const SUPABASE_URL =
+  process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error("Error: Set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY");
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+const PAGE_SIZE = 1000;
+const ALT_MAX_LEN = 150;
+
+// ─── Types ────────────────────────────────────────────────────────────────
+interface CsvRow {
+  SKU?: string;
+  "Item Description *"?: string;
+  [key: string]: string | undefined;
+}
+
+interface ArtworkRow {
+  id: string;
+  inventory_number: string | null;
+  image_url: string | null;
+  image_original: string | null;
+  alt_text: string | null;
+  alt_text_long: string | null;
+  description_origin: "human" | "ai" | null;
+}
+
+interface LogEntry {
+  sku: string;
+  status: "success" | "fail";
+  reason: string;
+  artwork_id: string;
+  prior_alt_text_long: string;
+  prior_alt_text: string;
+  new_alt_text_long: string;
+  new_alt_text: string;
+}
+
+interface ExportEntry {
+  sku: string;
+  image_url: string;
+  description_origin: string;
+  alt_text_long: string;
+  alt_text: string;
+  prior_ai_alt_text_long: string;
+  prior_ai_alt_text: string;
+}
+
+// ─── CSV output helpers ───────────────────────────────────────────────────
+function csvField(value: string | null | undefined): string {
+  if (value === null || value === undefined) return "";
+  const s = String(value);
+  if (/[",\n\r]/.test(s)) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+function writeCsv(filePath: string, columns: string[], rows: Record<string, string>[]): void {
+  const header = columns.join(",");
+  const body = rows.map((r) => columns.map((c) => csvField(r[c])).join(",")).join("\n");
+  fs.writeFileSync(filePath, header + "\n" + body + "\n");
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────
+async function main() {
+  // 1. Parse human CSV
+  if (!fs.existsSync(CSV_PATH)) {
+    console.error(`CSV not found: ${CSV_PATH}`);
+    process.exit(1);
+  }
+  const raw = fs.readFileSync(CSV_PATH, "utf-8");
+  const rows: CsvRow[] = parse(raw, {
+    columns: true,
+    skip_empty_lines: true,
+    relax_quotes: true,
+    relax_column_count: true,
+  });
+  console.log(`Parsed ${rows.length} rows from ${path.basename(CSV_PATH)}`);
+
+  // 2. Build SKU -> description map (last-wins; track duplicates for logging)
+  const skuMap = new Map<string, string>();
+  const duplicateSkus = new Set<string>();
+  for (const row of rows) {
+    const sku = (row.SKU || "").trim();
+    const desc = (row["Item Description *"] || "").trim();
+    if (!sku) continue;
+    if (skuMap.has(sku)) duplicateSkus.add(sku);
+    skuMap.set(sku, desc);
+  }
+  console.log(`Unique SKUs in CSV: ${skuMap.size} (${duplicateSkus.size} duplicates)`);
+
+  // 3. Page through every artwork
+  console.log("Fetching all artworks...");
+  const allArtworks: ArtworkRow[] = [];
+  let offset = 0;
+  while (true) {
+    const { data, error } = await supabase
+      .from("artworks")
+      .select("id, inventory_number, image_url, image_original, alt_text, alt_text_long, description_origin")
+      .order("inventory_number", { ascending: true, nullsFirst: false })
+      .range(offset, offset + PAGE_SIZE - 1);
+    if (error) {
+      console.error("Error fetching artworks:", error);
+      process.exit(1);
+    }
+    if (!data || data.length === 0) break;
+    allArtworks.push(...(data as ArtworkRow[]));
+    if (data.length < PAGE_SIZE) break;
+    offset += PAGE_SIZE;
+  }
+  console.log(`Fetched ${allArtworks.length} artworks`);
+
+  // 4. Process each artwork
+  const logEntries: LogEntry[] = [];
+  const exportEntries: ExportEntry[] = [];
+  const matchedSkus = new Set<string>();
+  let successCount = 0;
+  let failCount = 0;
+
+  for (const art of allArtworks) {
+    const sku = (art.inventory_number || "").trim();
+    const priorLong = art.alt_text_long || "";
+    const priorShort = art.alt_text || "";
+    const imageUrl = resolveImageUrl(art) || "";
+
+    if (sku && skuMap.has(sku)) {
+      const desc = skuMap.get(sku)!;
+      matchedSkus.add(sku);
+
+      if (!desc) {
+        logEntries.push({
+          sku, status: "fail", reason: "empty description",
+          artwork_id: art.id,
+          prior_alt_text_long: priorLong, prior_alt_text: priorShort,
+          new_alt_text_long: "", new_alt_text: "",
+        });
+        failCount++;
+        exportEntries.push({
+          sku, image_url: imageUrl,
+          description_origin: art.description_origin || "",
+          alt_text_long: priorLong, alt_text: priorShort,
+          prior_ai_alt_text_long: "", prior_ai_alt_text: "",
+        });
+        continue;
+      }
+
+      const newLong = desc;
+      const newShort = truncateForAlt(desc, ALT_MAX_LEN);
+
+      const { error: updateErr } = await supabase
+        .from("artworks")
+        .update({
+          alt_text_long: newLong,
+          alt_text: newShort,
+          description_origin: "human",
+        })
+        .eq("id", art.id);
+
+      if (updateErr) {
+        logEntries.push({
+          sku, status: "fail", reason: `update error: ${updateErr.message}`,
+          artwork_id: art.id,
+          prior_alt_text_long: priorLong, prior_alt_text: priorShort,
+          new_alt_text_long: newLong, new_alt_text: newShort,
+        });
+        failCount++;
+        exportEntries.push({
+          sku, image_url: imageUrl,
+          description_origin: art.description_origin || "",
+          alt_text_long: priorLong, alt_text: priorShort,
+          prior_ai_alt_text_long: "", prior_ai_alt_text: "",
+        });
+        continue;
+      }
+
+      logEntries.push({
+        sku, status: "success", reason: "",
+        artwork_id: art.id,
+        prior_alt_text_long: priorLong, prior_alt_text: priorShort,
+        new_alt_text_long: newLong, new_alt_text: newShort,
+      });
+      successCount++;
+
+      exportEntries.push({
+        sku, image_url: imageUrl,
+        description_origin: "human",
+        alt_text_long: newLong, alt_text: newShort,
+        prior_ai_alt_text_long: priorLong, prior_ai_alt_text: priorShort,
+      });
+    } else {
+      // Not in human CSV - export current state, no prior_ai_*
+      exportEntries.push({
+        sku, image_url: imageUrl,
+        description_origin: art.description_origin || "",
+        alt_text_long: priorLong, alt_text: priorShort,
+        prior_ai_alt_text_long: "", prior_ai_alt_text: "",
+      });
+    }
+  }
+
+  // 5. Log fails for CSV SKUs that didn't match any DB row
+  for (const sku of skuMap.keys()) {
+    if (!matchedSkus.has(sku)) {
+      logEntries.push({
+        sku, status: "fail", reason: "sku not found in db",
+        artwork_id: "",
+        prior_alt_text_long: "", prior_alt_text: "",
+        new_alt_text_long: "", new_alt_text: "",
+      });
+      failCount++;
+    }
+  }
+
+  // 6. Log fails for duplicate SKUs (earlier occurrences superseded by later ones)
+  for (const sku of duplicateSkus) {
+    logEntries.push({
+      sku, status: "fail", reason: "superseded by later row in csv",
+      artwork_id: "",
+      prior_alt_text_long: "", prior_alt_text: "",
+      new_alt_text_long: "", new_alt_text: "",
+    });
+  }
+
+  // 7. Write artifacts
+  if (!fs.existsSync(TMP_DIR)) fs.mkdirSync(TMP_DIR, { recursive: true });
+
+  writeCsv(LOG_FILE,
+    ["sku", "status", "reason", "artwork_id", "prior_alt_text_long", "prior_alt_text", "new_alt_text_long", "new_alt_text"],
+    logEntries
+  );
+
+  writeCsv(EXPORT_FILE,
+    ["sku", "image_url", "description_origin", "alt_text_long", "alt_text", "prior_ai_alt_text_long", "prior_ai_alt_text"],
+    exportEntries
+  );
+
+  // 8. Summary
+  console.log("\n=== Summary ===");
+  console.log(`Updated:     ${successCount}`);
+  console.log(`Failed:      ${failCount}`);
+  console.log(`Export rows: ${exportEntries.length}`);
+  console.log(`\nLog:    ${LOG_FILE}`);
+  console.log(`Export: ${EXPORT_FILE}`);
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 2: Confirm the script's modules resolve**
+
+Run:
+```bash
+npx tsx -e "import('./scripts/import-human-descriptions.ts').then(() => console.log('imports OK')).catch(e => { console.error(e); process.exit(1); })"
+```
+
+Expected: prints `imports OK`.
+
+(Don't run a full `tsc --noEmit` — the project's tsconfig is configured for Next.js and will surface unrelated noise in the script's standalone context. The tsx import check above is sufficient.)
+
+---
+
+### Task 6: Add npm script
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Add to scripts section**
+
+Edit `package.json`. In the `"scripts"` block, add:
+
+```json
+"import:descriptions": "tsx --env-file=.env.local scripts/import-human-descriptions.ts"
+```
+
+The block becomes (showing only the addition; preserve all existing scripts):
+
+```json
+"scripts": {
+  "dev": "next dev",
+  "build": "next build",
+  "start": "next start",
+  "lint": "next lint",
+  "import:csv": "tsx scripts/import-csv.ts",
+  "import:images": "tsx scripts/migrate-images.ts",
+  "seed:categories": "tsx scripts/seed-categories.ts",
+  "generate:descriptions": "tsx scripts/generate-descriptions.ts",
+  "import:descriptions": "tsx --env-file=.env.local scripts/import-human-descriptions.ts",
+  "migrate:all": "tsx --env-file=.env.local scripts/migrate-and-describe.ts",
+  "db:migrate": "tsx scripts/run-migration.ts"
+},
+```
+
+- [ ] **Step 2: Verify npm sees the script**
+
+Run: `npm run | grep import:descriptions`
+Expected: `import:descriptions`
+
+---
+
+### Task 7: Commit Phase 1 code
+
+**Files:** none (git only)
+
+- [ ] **Step 1: Stage and commit**
+
+Run:
+```bash
+git add .gitignore package.json src/lib/text.ts scripts/test-text.ts scripts/import-human-descriptions.ts
+git status
+```
+
+Expected: shows the 5 files staged. No untracked CSVs in `tmp/` because of the gitignore.
+
+- [ ] **Step 2: Create commit**
+
+Run:
+```bash
+git commit -m "$(cat <<'EOF'
+Add human descriptions import script with truncation utility
+
+scripts/import-human-descriptions.ts reads the human-authored CSV,
+updates matched artworks (alt_text_long, alt_text, description_origin),
+and produces two timestamped artifacts in tmp/:
+  - per-row update log with prior values for audit
+  - full-catalog export with prior AI snapshots for human-overwritten
+    rows so Creative Growth can compare AI vs human side-by-side
+
+Truncation logic for the short alt_text is extracted to
+scripts/lib/truncate.ts with node:test coverage. tmp/ is gitignored.
+
+The script writes to renamed columns (alt_text_long) which were
+established by a manual schema migration on 2026-04-23. The codebase
+side of that rename lands in the next commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 8: Run the import on real data
+
+**Files:** none (execution only — produces gitignored artifacts)
+
+- [ ] **Step 1: Run the script**
+
+Run: `npm run import:descriptions`
+
+Expected output ends with a summary block:
+```
+=== Summary ===
+Updated:     ~580-590
+Failed:      <small number, depending on SKU mismatches and duplicates>
+Export rows: ~2,112
+
+Log:    /Users/cullfam/code/cg_clir/tmp/import-human-descriptions-log_<timestamp>.csv
+Export: /Users/cullfam/code/cg_clir/tmp/descriptions-export_<timestamp>.csv
+```
+
+If the script errors out: do NOT attempt fixes blind — report the error to the user. Common causes: env vars missing, schema not migrated, network blocked, permission issues.
+
+- [ ] **Step 2: Spot-check the log**
+
+Run: `head -5 tmp/import-human-descriptions-log_*.csv`
+Expected: header row + 4 rows. Each row has populated `prior_alt_text_long` (the previous AI text being overwritten) and a `new_alt_text` ending with `…` for any description longer than 150 chars.
+
+- [ ] **Step 3: Spot-check the export**
+
+Run: `head -3 tmp/descriptions-export_*.csv`
+Expected: header row + 2 rows. The first data row should have `description_origin = human` if the artwork was matched, or `ai` if not.
+
+- [ ] **Step 4: Sanity-check counts**
+
+Run:
+```bash
+awk -F',' 'NR>1 {print $2}' tmp/import-human-descriptions-log_*.csv | sort | uniq -c
+```
+
+Expected: shows counts of `success` and `fail` rows. Success count should be close to 590 (the CSV row count). Report the actual numbers to the user before proceeding to Phase 2.
+
+- [ ] **Step 5: Verify a known artwork in the DB**
+
+Pick a SKU from the CSV's first row (e.g., `ABai 1`). Run:
+
+```bash
+npx tsx --env-file=.env.local -e "
+import { createClient } from '@supabase/supabase-js';
+const c = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+c.from('artworks').select('inventory_number, alt_text, alt_text_long, description_origin').eq('inventory_number', 'ABai 1').single().then(({data, error}) => {
+  if (error) { console.error(error); process.exit(1); }
+  console.log(JSON.stringify(data, null, 2));
+});
+"
+```
+
+Expected: `description_origin: 'human'`, `alt_text_long` is the full paragraph from the CSV, `alt_text` ends with `…` and is ≤150 chars.
+
+---
+
+## Phase 2: Rename rollout
+
+The rename rollout brings the codebase into agreement with the renamed schema. Production code is currently broken against the new schema (queries `ai_description` which no longer exists) — this phase fixes that. All file edits land in one commit because the rename is logically atomic.
+
+### Task 9: Update TypeScript types
+
+**Files:**
+- Modify: `src/lib/types.ts`
+
+- [ ] **Step 1: Rename field and add origin**
+
+In `src/lib/types.ts`, find the `Artwork` interface and replace these two lines:
+
+```typescript
+  ai_description: string | null;
+  alt_text: string | null;
+```
+
+with:
+
+```typescript
+  alt_text: string | null;
+  alt_text_long: string | null;
+  description_origin: "human" | "ai" | null;
+```
+
+- [ ] **Step 2: Verify nothing else in this file references the old name**
+
+Run: `grep -n "ai_description" src/lib/types.ts`
+Expected: no output.
+
+---
+
+### Task 10: Update getAltText helper
+
+**Files:**
+- Modify: `src/lib/utils.ts`
+
+- [ ] **Step 1: Replace getAltText**
+
+In `src/lib/utils.ts`, replace the existing `getAltText` function (currently at lines ~84-99) with:
+
+```typescript
+/**
+ * Get the short alt text for an artwork. Used in <img alt> on grid pages.
+ * Does NOT fall back to alt_text_long — that field is for the detail page,
+ * where dumping a paragraph into the alt attribute would force screen-reader
+ * users through a long announcement on every grid card. See
+ * docs/superpowers/specs/2026-04-23-human-descriptions-import-design.md.
+ */
+export function getAltText(artwork: {
+  alt_text: string | null;
+  title: string;
+  medium: string | null;
+}): string {
+  if (artwork.alt_text) return artwork.alt_text;
+  const parts = [artwork.title];
+  if (artwork.medium) parts.push(artwork.medium);
+  return parts.join(". ");
+}
+```
+
+- [ ] **Step 2: Verify no consumers expect the removed field in the signature**
+
+Run: `grep -rn "getAltText" src/ --include="*.ts" --include="*.tsx"`
+Expected: callers in `ArtworkCard.tsx` and `artwork/[id]/page.tsx` and `admin/artworks/[id]/page.tsx`. They pass full `artwork` objects so the narrower signature is fine.
+
+---
+
+### Task 11: Update artwork detail page — alt + remove "About This Work"
+
+**Files:**
+- Modify: `src/app/artwork/[id]/page.tsx`
+
+- [ ] **Step 1: Switch the `<img alt>` to the long form**
+
+Find this block (around line 162-169):
+
+```tsx
+            {imageUrl ? (
+              <Image
+                src={imageUrl}
+                alt={altText}
+                fill
+                className="object-cover"
+                priority
+              />
+```
+
+Above the JSX `return`, the current code computes `const altText = getAltText(artwork);`. The detail page should use the long form for the image alt, since this is the page where rich description is appropriate.
+
+Replace the `altText` declaration (around line 122):
+
+```typescript
+  const altText = getAltText(artwork);
+```
+
+with:
+
+```typescript
+  const altText = artwork.alt_text_long || getAltText(artwork);
+```
+
+This uses the long form when present, falls back to the short via the helper if it's missing.
+
+- [ ] **Step 2: Remove the "About This Work" section**
+
+Find and DELETE this entire block (around lines 273-283):
+
+```tsx
+      {/* Description */}
+      {artwork.ai_description && (
+        <section className="mt-12 pt-12 border-t border-gray-200 max-w-2xl">
+          <h2 className="font-serif text-2xl font-bold text-gray-900 mb-4">
+            About This Work
+          </h2>
+          <p className="text-gray-700 leading-relaxed">
+            {artwork.ai_description}
+          </p>
+        </section>
+      )}
+```
+
+Leave the surrounding `{/* More by Artist */}` block untouched.
+
+- [ ] **Step 3: Sanity check**
+
+Run: `grep -n "ai_description" src/app/artwork/\[id\]/page.tsx`
+Expected: no output.
+
+---
+
+### Task 12: Update admin edit page
+
+**Files:**
+- Modify: `src/app/admin/artworks/[id]/page.tsx`
+
+- [ ] **Step 1: Rename all field references**
+
+Run a find-and-replace across the file. Every occurrence of `ai_description` must become `alt_text_long` (10 spots: form-state init, DB-fetch destructuring, DB-update payload, copy-button source, label `htmlFor`, `<textarea id>`, `<textarea name>`, `value={formData.ai_description}`, the `formData.ai_description` guard, the `alt_text: prev.ai_description` assignment in the copy-button).
+
+Use the Edit tool with `replace_all: true` for `ai_description` → `alt_text_long`.
+
+- [ ] **Step 2: Update the form labels**
+
+Find the label for what is now `alt_text_long`. The current label text reads something like "AI Description" or "Description". Replace with: `Long alt text (detail page)`.
+
+Find the label for `alt_text`. Replace with: `Short alt text (grid page)`.
+
+- [ ] **Step 3: Fix the copy-button to truncate**
+
+The existing copy button copies `ai_description` (now `alt_text_long`) directly into `alt_text`. After the rename, this would copy a paragraph into the short field — defeating the truncation discipline.
+
+Find this code (formerly used the old name):
+
+```typescript
+    if (formData.alt_text_long) {
+      setFormData((prev) => ({
+        ...prev,
+        alt_text: prev.alt_text_long,
+      }));
+    }
+```
+
+Replace with:
+
+```typescript
+    if (formData.alt_text_long) {
+      setFormData((prev) => ({
+        ...prev,
+        alt_text: truncateForAlt(prev.alt_text_long || "", 150),
+      }));
+    }
+```
+
+Add the import at the top of the file (the project uses a `@/` alias for `src/`):
+
+```typescript
+import { truncateForAlt } from "@/lib/text";
+```
+
+If the alias isn't configured (check `tsconfig.json` for `paths`), use the relative path: `../../../../lib/text`.
+
+- [ ] **Step 4: Verify**
+
+Run: `grep -n "ai_description" src/app/admin/artworks/\[id\]/page.tsx`
+Expected: no output.
+
+---
+
+### Task 13: Update review SPA
+
+**Files:**
+- Modify: `public/review.html`
+
+- [ ] **Step 1: Rename column references**
+
+8 occurrences of `ai_description` need to become `alt_text_long`. They appear in:
+- Two SELECT URL strings (lines around 329 and 352)
+- Two `=not.is.null` filter strings (same lines)
+- Two display elements (`a.ai_description` rendering)
+- Two `${a.ai_description}` in textareas
+- Two PATCH payload bodies (`ai_description: desc`)
+- Four in-memory mutations (`a.ai_description = desc`)
+
+Use the Edit tool with `replace_all: true` for `ai_description` → `alt_text_long`.
+
+- [ ] **Step 2: Verify**
+
+Run: `grep -c "ai_description" public/review.html`
+Expected: `0`.
+
+- [ ] **Step 3: Verify internal element IDs survived the find-replace**
+
+Run: `grep -E "descDisplay|descEdit" public/review.html`
+Expected: both IDs appear at least once. They're internal labels for the textarea elements — they should NOT have been renamed by the find-replace because they don't contain `ai_description` as a substring.
+
+---
+
+### Task 14: Update generate-descriptions.ts
+
+**Files:**
+- Modify: `scripts/generate-descriptions.ts`
+
+- [ ] **Step 1: Rename column references**
+
+4 occurrences of `ai_description` need renaming:
+- The TypeScript interface field
+- The `select` clause (` ai_description, `)
+- The `.is("ai_description", null)` filter
+- The update payload key
+
+Use the Edit tool with `replace_all: true` for `ai_description` → `alt_text_long`.
+
+- [ ] **Step 2: Add description_origin to the update payload**
+
+Find the update payload (around line 237):
+
+```typescript
+        .update({
+          alt_text_long: result.description,
+          alt_text: result.alt_text,
+        })
+```
+
+Replace with:
+
+```typescript
+        .update({
+          alt_text_long: result.description,
+          alt_text: result.alt_text,
+          description_origin: "ai",
+        })
+```
+
+(Note: the JSON output keys from the AI prompt — `result.description`, `result.alt_text` — are unchanged. They're internal to the prompt contract.)
+
+- [ ] **Step 3: Verify**
+
+Run: `grep "ai_description" scripts/generate-descriptions.ts`
+Expected: no output.
+
+---
+
+### Task 15: Update migrate-and-describe.ts
+
+**Files:**
+- Modify: `scripts/migrate-and-describe.ts`
+
+- [ ] **Step 1: Rename column references**
+
+5 occurrences of `ai_description` need renaming. Use the Edit tool with `replace_all: true` for `ai_description` → `alt_text_long`.
+
+- [ ] **Step 2: Add description_origin to the update payload**
+
+Find the update payload (around line 371):
+
+```typescript
+        .update({
+          alt_text_long: desc.description,
+          alt_text: desc.alt_text,
+        })
+```
+
+Replace with:
+
+```typescript
+        .update({
+          alt_text_long: desc.description,
+          alt_text: desc.alt_text,
+          description_origin: "ai",
+        })
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `grep "ai_description" scripts/migrate-and-describe.ts`
+Expected: no output.
+
+---
+
+### Task 16: Sync the migration SQL with the applied state
+
+**Files:**
+- Modify: `supabase/migrations/001_initial.sql`
+
+- [ ] **Step 1: Update the column definition**
+
+Find this block:
+
+```sql
+  -- AI-generated accessibility content
+  ai_description    TEXT,
+  alt_text          TEXT,
+```
+
+Replace with:
+
+```sql
+  -- Accessibility alt text. alt_text_long is for <img alt> on the artwork
+  -- detail page; alt_text is the truncated form for grid pages.
+  alt_text          TEXT,
+  alt_text_long     TEXT,
+  description_origin TEXT CHECK (description_origin IN ('human', 'ai')),
+```
+
+- [ ] **Step 2: Update the FTS index**
+
+Find:
+
+```sql
+ALTER TABLE artworks ADD COLUMN IF NOT EXISTS fts tsvector
+  GENERATED ALWAYS AS (
+    setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(medium, '')), 'B') ||
+    setweight(to_tsvector('english', coalesce(alt_text, '')), 'C') ||
+    setweight(to_tsvector('english', coalesce(ai_description, '')), 'D')
+  ) STORED;
+```
+
+Replace with:
+
+```sql
+ALTER TABLE artworks ADD COLUMN IF NOT EXISTS fts tsvector
+  GENERATED ALWAYS AS (
+    setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(medium, '')), 'B') ||
+    setweight(to_tsvector('english', coalesce(alt_text, '')), 'C') ||
+    setweight(to_tsvector('english', coalesce(alt_text_long, '')), 'D')
+  ) STORED;
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `grep "ai_description" supabase/migrations/001_initial.sql`
+Expected: no output.
+
+---
+
+### Task 17: Verify dev server starts and pages render
+
+**Files:** none (verification)
+
+- [ ] **Step 1: Type-check the project**
+
+Run: `npm run lint`
+Expected: passes. If type errors appear referencing `ai_description`, you missed a file — grep again across `src/` and fix.
+
+Run: `grep -rn "ai_description" src/ scripts/ public/ supabase/ --include="*.ts" --include="*.tsx" --include="*.html" --include="*.sql"`
+Expected: no output.
+
+- [ ] **Step 2: Start the dev server in background**
+
+Run: `npm run dev` (use `run_in_background`).
+
+Wait until you see `Ready in <X>ms` in the output (use Monitor or BashOutput to check).
+
+- [ ] **Step 3: Smoke-test the collection page**
+
+Run: `curl -s http://localhost:3000/collection | grep -o 'alt="[^"]*"' | head -5`
+Expected: 5 alt attributes printed. Each should be ≤150 chars (eyeball it). For artworks updated by the import, the alt should end with `…`.
+
+- [ ] **Step 4: Smoke-test a known-overwritten artwork detail page**
+
+Pick a known SKU (e.g., `ABai 1`) and find its UUID:
+
+```bash
+npx tsx --env-file=.env.local -e "
+import { createClient } from '@supabase/supabase-js';
+const c = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+c.from('artworks').select('id').eq('inventory_number', 'ABai 1').single().then(({data}) => console.log(data?.id));
+"
+```
+
+Then: `curl -s http://localhost:3000/artwork/<UUID> | grep -E 'alt=|About This Work'`
+
+Expected:
+- One `alt="..."` containing the full human paragraph (no `…` — the long form goes here)
+- NO occurrence of `About This Work` (section was deleted)
+
+- [ ] **Step 5: Stop the dev server**
+
+Kill the background process.
+
+---
+
+### Task 18: Commit Phase 2
+
+**Files:** none (git only)
+
+- [ ] **Step 1: Stage the rename rollout**
+
+Run:
+```bash
+git add src/lib/types.ts src/lib/utils.ts src/app/artwork/\[id\]/page.tsx src/app/admin/artworks/\[id\]/page.tsx public/review.html scripts/generate-descriptions.ts scripts/migrate-and-describe.ts supabase/migrations/001_initial.sql
+git status
+```
+
+Expected: shows the 8 files staged.
+
+- [ ] **Step 2: Create commit**
+
+Run:
+```bash
+git commit -m "$(cat <<'EOF'
+Rename ai_description -> alt_text_long across UI and scripts
+
+Schema migration was applied manually on 2026-04-23 (rename plus new
+description_origin column). This commit catches the codebase up:
+
+- Types: rename field, add description_origin
+- getAltText: drop the dangerous fallback to the long form, which would
+  dump paragraphs into <img alt> on grid pages
+- Artwork detail page: <img alt> reads the long form; remove the
+  "About This Work" section that was wrongly rendering the alt text
+  as visible body content
+- Admin edit page: rename refs, relabel fields ("Long alt text /
+  detail page" vs "Short alt text / grid page"), make the copy button
+  truncate with the same logic as the import script
+- Review SPA: rename refs in fetch URLs, PATCH bodies, and renders
+- AI generation scripts: rename refs and set description_origin: 'ai'
+  on insert
+- Migration SQL: sync source-controlled file with applied schema
+
+See docs/superpowers/specs/2026-04-23-human-descriptions-import-design.md
+for the full rationale, especially on why the alt-text/long-alt-text
+distinction matters for screen-reader users on grid views.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: commit succeeds.
+
+---
+
+## Done
+
+At this point:
+- DB has 590 (give or take) human-described artworks with `description_origin='human'`, ~1,500 AI-described with `description_origin='ai'`
+- Two CSV artifacts in `tmp/` ready to share with Creative Growth
+- Codebase compiles, dev server renders correctly with the new schema
+- The misleading "About This Work" section is gone
+- Grid pages serve short alts; detail page serves long alts
+
+Hand off the two `tmp/` CSVs to Creative Growth. Open issues for follow-up work flagged in the spec under "Out of scope" if you want them tracked.

--- a/docs/superpowers/plans/2026-04-23-human-descriptions-import.md
+++ b/docs/superpowers/plans/2026-04-23-human-descriptions-import.md
@@ -2,11 +2,11 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Import 590 human-written paragraph descriptions from CSV, supersede AI-generated content for matched SKUs, produce a per-row update log and a full-catalog export with prior-AI snapshots; bundle the schema rename rollout (UI + scripts) needed because the DB column rename has already been applied.
+**Goal:** Import 590 human-written paragraph descriptions from CSV into `alt_text_long` only (leaving the existing short `alt_text` untouched), produce a per-row update log and a full-catalog export with prior-AI long-form snapshots; bundle the schema rename rollout (UI + scripts) needed because the DB column rename has already been applied.
 
 **Architecture:** Two phases. Phase 1 = the import + export script (independently runnable; produces both artifacts in one pass so prior values are captured at update time). Phase 2 = the rename rollout across UI components and adjacent scripts. Phase 1 ships first because the DB schema is already in the renamed state, so getting clean data in is the foundation; Phase 2 makes the codebase consistent with the data.
 
-**Tech Stack:** TypeScript, Node 20+, `tsx` runner, `csv-parse/sync`, `@supabase/supabase-js`, Node's built-in test runner (`node:test`) — no new dependencies.
+**Tech Stack:** TypeScript, Node 20+, `tsx` runner, `csv-parse/sync`, `@supabase/supabase-js`. No new dependencies.
 
 **Spec reference:** `docs/superpowers/specs/2026-04-23-human-descriptions-import-design.md`
 
@@ -15,8 +15,6 @@
 ## File Structure
 
 **New files:**
-- `src/lib/text.ts` — pure utility function `truncateForAlt` that turns a paragraph into a ≤150-char alt text with ellipsis. Lives in `src/lib/` so both the import script and the admin form can import it cleanly.
-- `scripts/test-text.ts` — `node:test` assertions for `truncateForAlt`.
 - `scripts/import-human-descriptions.ts` — main script. Parses CSV, pages through artworks, updates matched rows, writes the two CSV artifacts.
 
 **Modified files (Phase 1):**
@@ -27,7 +25,7 @@
 - `src/lib/types.ts` — rename `ai_description` field on `Artwork` to `alt_text_long`; add `description_origin`
 - `src/lib/utils.ts` — `getAltText()` drops the fallback-to-long-form (the bug that motivated this work)
 - `src/app/artwork/[id]/page.tsx` — read `alt_text_long` for `<img alt>`; delete the "About This Work" section
-- `src/app/admin/artworks/[id]/page.tsx` — rename column references; relabel form fields; update copy-button to truncate
+- `src/app/admin/artworks/[id]/page.tsx` — rename column references; relabel form fields; **delete** the "copy long → short" button
 - `public/review.html` — rename column references in fetch URLs and PATCH bodies
 - `scripts/generate-descriptions.ts` — rename column refs; set `description_origin: 'ai'` on insert
 - `scripts/migrate-and-describe.ts` — same as above
@@ -84,130 +82,11 @@ Expected: outputs the path, exit code 0.
 
 ---
 
-### Task 2: Create truncation utility — failing test first
-
-**Files:**
-- Create: `scripts/test-text.ts`
-
-- [ ] **Step 1: Write the test file**
-
-Create `scripts/test-text.ts`:
-
-```typescript
-import { strict as assert } from "node:assert";
-import { test } from "node:test";
-import { truncateForAlt } from "../src/lib/text";
-
-test("returns short input verbatim, no ellipsis", () => {
-  const input = "A short description.";
-  assert.equal(truncateForAlt(input, 150), input);
-});
-
-test("trims leading and trailing whitespace", () => {
-  assert.equal(truncateForAlt("  hello  ", 150), "hello");
-});
-
-test("collapses newlines to single spaces", () => {
-  assert.equal(truncateForAlt("line one\nline two", 150), "line one line two");
-});
-
-test("collapses runs of whitespace to one space", () => {
-  assert.equal(truncateForAlt("a   b\t\tc", 150), "a b c");
-});
-
-test("returns empty string for empty input", () => {
-  assert.equal(truncateForAlt("", 150), "");
-});
-
-test("returns empty string for whitespace-only input", () => {
-  assert.equal(truncateForAlt("   \n\t  ", 150), "");
-});
-
-test("truncates long input at last word boundary, ending with ellipsis", () => {
-  const longInput = "The quick brown fox jumps over the lazy dog. ".repeat(10);
-  const result = truncateForAlt(longInput, 150);
-  assert.ok(result.length <= 150, `length ${result.length} > 150`);
-  assert.ok(result.endsWith("…"), `"${result}" should end with ellipsis`);
-  const charBeforeEllipsis = result.slice(-2, -1);
-  assert.notEqual(charBeforeEllipsis, " ", "should not have trailing space before ellipsis");
-});
-
-test("hard-cuts when no whitespace exists in first maxLen-1 chars", () => {
-  const noSpaces = "x".repeat(200);
-  const result = truncateForAlt(noSpaces, 150);
-  assert.equal(result.length, 150);
-  assert.equal(result, "x".repeat(149) + "…");
-});
-
-test("respects custom maxLen", () => {
-  const input = "abcdefghij ".repeat(5);
-  const result = truncateForAlt(input, 20);
-  assert.ok(result.length <= 20, `length ${result.length} > 20`);
-  assert.ok(result.endsWith("…"));
-});
-
-test("does not append ellipsis when input is exactly maxLen", () => {
-  const input = "x".repeat(150);
-  const result = truncateForAlt(input, 150);
-  assert.equal(result, input);
-  assert.ok(!result.endsWith("…"));
-});
-```
-
-- [ ] **Step 2: Run the test and verify it fails**
-
-Run: `npx tsx --test scripts/test-text.ts`
-Expected: All tests fail with `Error: Cannot find module '../src/lib/text'` or similar.
-
----
-
-### Task 3: Implement truncation utility
-
-**Files:**
-- Create: `src/lib/text.ts`
-
-- [ ] **Step 1: Write the implementation**
-
-Create `src/lib/text.ts`:
-
-```typescript
-/**
- * Truncate a paragraph for use as a short alt text.
- *
- * Behavior:
- * - Collapses all whitespace (newlines, tabs, runs of spaces) to single spaces, then trims.
- * - If the result is <= maxLen chars, returns it verbatim with no ellipsis.
- * - Otherwise, slices to (maxLen - 1) chars, finds the last whitespace within that slice,
- *   cuts there, and appends a single Unicode ellipsis (U+2026). Total length <= maxLen.
- * - If no whitespace exists in the first (maxLen - 1) chars, hard-cuts at (maxLen - 1) + ellipsis.
- */
-export function truncateForAlt(input: string, maxLen: number = 150): string {
-  const collapsed = input.replace(/\s+/g, " ").trim();
-  if (collapsed.length <= maxLen) return collapsed;
-
-  const ellipsis = "…";
-  const slice = collapsed.slice(0, maxLen - 1);
-  const lastSpace = slice.lastIndexOf(" ");
-
-  if (lastSpace === -1) {
-    return slice + ellipsis;
-  }
-  return slice.slice(0, lastSpace) + ellipsis;
-}
-```
-
-- [ ] **Step 2: Run the test and verify it passes**
-
-Run: `npx tsx --test scripts/test-text.ts`
-Expected: All 10 tests pass.
-
----
-
-### Task 4: Verify column types align with what the script will fetch
+### Task 2: Verify `resolveImageUrl()` works in a Node-only context
 
 **Files:** none (read-only verification)
 
-- [ ] **Step 1: Confirm `resolveImageUrl()` works without React/Next runtime**
+- [ ] **Step 1: Smoke-test the helper outside Next**
 
 Run:
 ```bash
@@ -223,7 +102,7 @@ If this fails: the script's `resolveImageUrl` import needs replacement. Reproduc
 
 ---
 
-### Task 5: Implement the import + export script
+### Task 3: Implement the import + export script
 
 **Files:**
 - Create: `scripts/import-human-descriptions.ts`
@@ -239,10 +118,13 @@ Create `scripts/import-human-descriptions.ts`:
  *
  * Reads the human-authored description CSV at HUMAN_CSV_PATH (default:
  * tmp/CLIR Image Descriptions Sheet - Brief Descriptions.csv), updates
- * matched artworks (alt_text_long, alt_text, description_origin='human'),
- * and writes two timestamped CSV artifacts to tmp/:
+ * matched artworks (alt_text_long, description_origin='human'), and
+ * writes two timestamped CSV artifacts to tmp/:
  *   - import-human-descriptions-log_<ISO>.csv  per-row update log
  *   - descriptions-export_<ISO>.csv             full catalog snapshot
+ *
+ * The short alt_text is intentionally NOT modified — see the spec at
+ * docs/superpowers/specs/2026-04-23-human-descriptions-import-design.md.
  *
  * Run: npx tsx --env-file=.env.local scripts/import-human-descriptions.ts
  */
@@ -251,7 +133,6 @@ import fs from "fs";
 import path from "path";
 import { parse } from "csv-parse/sync";
 import { createClient } from "@supabase/supabase-js";
-import { truncateForAlt } from "../src/lib/text";
 import { resolveImageUrl } from "../src/lib/utils";
 
 // ─── Config ───────────────────────────────────────────────────────────────
@@ -278,7 +159,6 @@ const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
 });
 
 const PAGE_SIZE = 1000;
-const ALT_MAX_LEN = 150;
 
 // ─── Types ────────────────────────────────────────────────────────────────
 interface CsvRow {
@@ -303,9 +183,7 @@ interface LogEntry {
   reason: string;
   artwork_id: string;
   prior_alt_text_long: string;
-  prior_alt_text: string;
   new_alt_text_long: string;
-  new_alt_text: string;
 }
 
 interface ExportEntry {
@@ -315,7 +193,6 @@ interface ExportEntry {
   alt_text_long: string;
   alt_text: string;
   prior_ai_alt_text_long: string;
-  prior_ai_alt_text: string;
 }
 
 // ─── CSV output helpers ───────────────────────────────────────────────────
@@ -393,7 +270,7 @@ async function main() {
   for (const art of allArtworks) {
     const sku = (art.inventory_number || "").trim();
     const priorLong = art.alt_text_long || "";
-    const priorShort = art.alt_text || "";
+    const currentShort = art.alt_text || "";
     const imageUrl = resolveImageUrl(art) || "";
 
     if (sku && skuMap.has(sku)) {
@@ -404,27 +281,26 @@ async function main() {
         logEntries.push({
           sku, status: "fail", reason: "empty description",
           artwork_id: art.id,
-          prior_alt_text_long: priorLong, prior_alt_text: priorShort,
-          new_alt_text_long: "", new_alt_text: "",
+          prior_alt_text_long: priorLong,
+          new_alt_text_long: "",
         });
         failCount++;
         exportEntries.push({
           sku, image_url: imageUrl,
           description_origin: art.description_origin || "",
-          alt_text_long: priorLong, alt_text: priorShort,
-          prior_ai_alt_text_long: "", prior_ai_alt_text: "",
+          alt_text_long: priorLong,
+          alt_text: currentShort,
+          prior_ai_alt_text_long: "",
         });
         continue;
       }
 
       const newLong = desc;
-      const newShort = truncateForAlt(desc, ALT_MAX_LEN);
 
       const { error: updateErr } = await supabase
         .from("artworks")
         .update({
           alt_text_long: newLong,
-          alt_text: newShort,
           description_origin: "human",
         })
         .eq("id", art.id);
@@ -433,15 +309,16 @@ async function main() {
         logEntries.push({
           sku, status: "fail", reason: `update error: ${updateErr.message}`,
           artwork_id: art.id,
-          prior_alt_text_long: priorLong, prior_alt_text: priorShort,
-          new_alt_text_long: newLong, new_alt_text: newShort,
+          prior_alt_text_long: priorLong,
+          new_alt_text_long: newLong,
         });
         failCount++;
         exportEntries.push({
           sku, image_url: imageUrl,
           description_origin: art.description_origin || "",
-          alt_text_long: priorLong, alt_text: priorShort,
-          prior_ai_alt_text_long: "", prior_ai_alt_text: "",
+          alt_text_long: priorLong,
+          alt_text: currentShort,
+          prior_ai_alt_text_long: "",
         });
         continue;
       }
@@ -449,24 +326,26 @@ async function main() {
       logEntries.push({
         sku, status: "success", reason: "",
         artwork_id: art.id,
-        prior_alt_text_long: priorLong, prior_alt_text: priorShort,
-        new_alt_text_long: newLong, new_alt_text: newShort,
+        prior_alt_text_long: priorLong,
+        new_alt_text_long: newLong,
       });
       successCount++;
 
       exportEntries.push({
         sku, image_url: imageUrl,
         description_origin: "human",
-        alt_text_long: newLong, alt_text: newShort,
-        prior_ai_alt_text_long: priorLong, prior_ai_alt_text: priorShort,
+        alt_text_long: newLong,
+        alt_text: currentShort,
+        prior_ai_alt_text_long: priorLong,
       });
     } else {
-      // Not in human CSV - export current state, no prior_ai_*
+      // Not in human CSV - export current state, no prior_ai_alt_text_long
       exportEntries.push({
         sku, image_url: imageUrl,
         description_origin: art.description_origin || "",
-        alt_text_long: priorLong, alt_text: priorShort,
-        prior_ai_alt_text_long: "", prior_ai_alt_text: "",
+        alt_text_long: priorLong,
+        alt_text: currentShort,
+        prior_ai_alt_text_long: "",
       });
     }
   }
@@ -477,8 +356,8 @@ async function main() {
       logEntries.push({
         sku, status: "fail", reason: "sku not found in db",
         artwork_id: "",
-        prior_alt_text_long: "", prior_alt_text: "",
-        new_alt_text_long: "", new_alt_text: "",
+        prior_alt_text_long: "",
+        new_alt_text_long: "",
       });
       failCount++;
     }
@@ -489,8 +368,8 @@ async function main() {
     logEntries.push({
       sku, status: "fail", reason: "superseded by later row in csv",
       artwork_id: "",
-      prior_alt_text_long: "", prior_alt_text: "",
-      new_alt_text_long: "", new_alt_text: "",
+      prior_alt_text_long: "",
+      new_alt_text_long: "",
     });
   }
 
@@ -498,12 +377,12 @@ async function main() {
   if (!fs.existsSync(TMP_DIR)) fs.mkdirSync(TMP_DIR, { recursive: true });
 
   writeCsv(LOG_FILE,
-    ["sku", "status", "reason", "artwork_id", "prior_alt_text_long", "prior_alt_text", "new_alt_text_long", "new_alt_text"],
+    ["sku", "status", "reason", "artwork_id", "prior_alt_text_long", "new_alt_text_long"],
     logEntries
   );
 
   writeCsv(EXPORT_FILE,
-    ["sku", "image_url", "description_origin", "alt_text_long", "alt_text", "prior_ai_alt_text_long", "prior_ai_alt_text"],
+    ["sku", "image_url", "description_origin", "alt_text_long", "alt_text", "prior_ai_alt_text_long"],
     exportEntries
   );
 
@@ -535,7 +414,7 @@ Expected: prints `imports OK`.
 
 ---
 
-### Task 6: Add npm script
+### Task 4: Add npm script
 
 **Files:**
 - Modify: `package.json`
@@ -573,7 +452,7 @@ Expected: `import:descriptions`
 
 ---
 
-### Task 7: Commit Phase 1 code
+### Task 5: Commit Phase 1 code
 
 **Files:** none (git only)
 
@@ -581,28 +460,30 @@ Expected: `import:descriptions`
 
 Run:
 ```bash
-git add .gitignore package.json src/lib/text.ts scripts/test-text.ts scripts/import-human-descriptions.ts
+git add .gitignore package.json scripts/import-human-descriptions.ts
 git status
 ```
 
-Expected: shows the 5 files staged. No untracked CSVs in `tmp/` because of the gitignore.
+Expected: shows the 3 files staged. No untracked CSVs in `tmp/` because of the gitignore.
 
 - [ ] **Step 2: Create commit**
 
 Run:
 ```bash
 git commit -m "$(cat <<'EOF'
-Add human descriptions import script with truncation utility
+Add human descriptions import script
 
 scripts/import-human-descriptions.ts reads the human-authored CSV,
-updates matched artworks (alt_text_long, alt_text, description_origin),
+updates matched artworks (alt_text_long, description_origin='human'),
 and produces two timestamped artifacts in tmp/:
   - per-row update log with prior values for audit
-  - full-catalog export with prior AI snapshots for human-overwritten
-    rows so Creative Growth can compare AI vs human side-by-side
+  - full-catalog export with prior AI long-form snapshots for
+    human-overwritten rows so Creative Growth can compare AI vs human
+    side-by-side
 
-Truncation logic for the short alt_text is extracted to
-scripts/lib/truncate.ts with node:test coverage. tmp/ is gitignored.
+The short alt_text is intentionally NOT modified by this script —
+the human CSV has only paragraph-form content, and the existing
+AI-generated short alt remains in place. tmp/ is gitignored.
 
 The script writes to renamed columns (alt_text_long) which were
 established by a manual schema migration on 2026-04-23. The codebase
@@ -617,7 +498,7 @@ Expected: commit succeeds.
 
 ---
 
-### Task 8: Run the import on real data
+### Task 6: Run the import on real data
 
 **Files:** none (execution only — produces gitignored artifacts)
 
@@ -641,12 +522,12 @@ If the script errors out: do NOT attempt fixes blind — report the error to the
 - [ ] **Step 2: Spot-check the log**
 
 Run: `head -5 tmp/import-human-descriptions-log_*.csv`
-Expected: header row + 4 rows. Each row has populated `prior_alt_text_long` (the previous AI text being overwritten) and a `new_alt_text` ending with `…` for any description longer than 150 chars.
+Expected: header row (`sku,status,reason,artwork_id,prior_alt_text_long,new_alt_text_long`) plus 4 data rows. Each successful row has populated `prior_alt_text_long` (the previous AI text being overwritten) and `new_alt_text_long` (the human paragraph).
 
 - [ ] **Step 3: Spot-check the export**
 
 Run: `head -3 tmp/descriptions-export_*.csv`
-Expected: header row + 2 rows. The first data row should have `description_origin = human` if the artwork was matched, or `ai` if not.
+Expected: header row (`sku,image_url,description_origin,alt_text_long,alt_text,prior_ai_alt_text_long`) plus 2 data rows. The first data row should have `description_origin = human` if the artwork was matched, or `ai` if not.
 
 - [ ] **Step 4: Sanity-check counts**
 
@@ -672,7 +553,7 @@ c.from('artworks').select('inventory_number, alt_text, alt_text_long, descriptio
 "
 ```
 
-Expected: `description_origin: 'human'`, `alt_text_long` is the full paragraph from the CSV, `alt_text` ends with `…` and is ≤150 chars.
+Expected: `description_origin: 'human'`, `alt_text_long` is the full paragraph from the CSV, `alt_text` unchanged from its prior value (whatever the AI pipeline had set).
 
 ---
 
@@ -680,7 +561,7 @@ Expected: `description_origin: 'human'`, `alt_text_long` is the full paragraph f
 
 The rename rollout brings the codebase into agreement with the renamed schema. Production code is currently broken against the new schema (queries `ai_description` which no longer exists) — this phase fixes that. All file edits land in one commit because the rename is logically atomic.
 
-### Task 9: Update TypeScript types
+### Task 7: Update TypeScript types
 
 **Files:**
 - Modify: `src/lib/types.ts`
@@ -709,7 +590,7 @@ Expected: no output.
 
 ---
 
-### Task 10: Update getAltText helper
+### Task 8: Update getAltText helper
 
 **Files:**
 - Modify: `src/lib/utils.ts`
@@ -741,33 +622,18 @@ export function getAltText(artwork: {
 - [ ] **Step 2: Verify no consumers expect the removed field in the signature**
 
 Run: `grep -rn "getAltText" src/ --include="*.ts" --include="*.tsx"`
-Expected: callers in `ArtworkCard.tsx` and `artwork/[id]/page.tsx` and `admin/artworks/[id]/page.tsx`. They pass full `artwork` objects so the narrower signature is fine.
+Expected: callers in `ArtworkCard.tsx`, `artwork/[id]/page.tsx`, and `admin/artworks/[id]/page.tsx`. They pass full `artwork` objects so the narrower signature is fine.
 
 ---
 
-### Task 11: Update artwork detail page — alt + remove "About This Work"
+### Task 9: Update artwork detail page — alt + remove "About This Work"
 
 **Files:**
 - Modify: `src/app/artwork/[id]/page.tsx`
 
 - [ ] **Step 1: Switch the `<img alt>` to the long form**
 
-Find this block (around line 162-169):
-
-```tsx
-            {imageUrl ? (
-              <Image
-                src={imageUrl}
-                alt={altText}
-                fill
-                className="object-cover"
-                priority
-              />
-```
-
-Above the JSX `return`, the current code computes `const altText = getAltText(artwork);`. The detail page should use the long form for the image alt, since this is the page where rich description is appropriate.
-
-Replace the `altText` declaration (around line 122):
+The detail page should use the long form for the image alt, since this is the page where rich description is appropriate. Replace the `altText` declaration (around line 122):
 
 ```typescript
   const altText = getAltText(artwork);
@@ -808,28 +674,18 @@ Expected: no output.
 
 ---
 
-### Task 12: Update admin edit page
+### Task 10: Update admin edit page
 
 **Files:**
 - Modify: `src/app/admin/artworks/[id]/page.tsx`
 
 - [ ] **Step 1: Rename all field references**
 
-Run a find-and-replace across the file. Every occurrence of `ai_description` must become `alt_text_long` (10 spots: form-state init, DB-fetch destructuring, DB-update payload, copy-button source, label `htmlFor`, `<textarea id>`, `<textarea name>`, `value={formData.ai_description}`, the `formData.ai_description` guard, the `alt_text: prev.ai_description` assignment in the copy-button).
+Use the Edit tool with `replace_all: true` for `ai_description` → `alt_text_long` across the entire file (10 spots: form-state init, DB-fetch destructuring, DB-update payload, copy-button source, label `htmlFor`, `<textarea id>`, `<textarea name>`, `value={formData.ai_description}`, the `formData.ai_description` guard, the `alt_text: prev.ai_description` assignment).
 
-Use the Edit tool with `replace_all: true` for `ai_description` → `alt_text_long`.
+- [ ] **Step 2: Delete the "copy long → short" button**
 
-- [ ] **Step 2: Update the form labels**
-
-Find the label for what is now `alt_text_long`. The current label text reads something like "AI Description" or "Description". Replace with: `Long alt text (detail page)`.
-
-Find the label for `alt_text`. Replace with: `Short alt text (grid page)`.
-
-- [ ] **Step 3: Fix the copy-button to truncate**
-
-The existing copy button copies `ai_description` (now `alt_text_long`) directly into `alt_text`. After the rename, this would copy a paragraph into the short field — defeating the truncation discipline.
-
-Find this code (formerly used the old name):
+After the rename, the copy-button code now reads (approximately):
 
 ```typescript
     if (formData.alt_text_long) {
@@ -840,48 +696,32 @@ Find this code (formerly used the old name):
     }
 ```
 
-Replace with:
+Find the JSX that renders this button (look for the button element near `htmlFor="alt_text_long"` around line 317 — it has `disabled={!formData.alt_text_long}` after the rename). DELETE the entire button JSX element. Then DELETE the handler function above it (the `if (formData.alt_text_long) { ... }` block). The two fields become independent textareas with no copy affordance.
 
-```typescript
-    if (formData.alt_text_long) {
-      setFormData((prev) => ({
-        ...prev,
-        alt_text: truncateForAlt(prev.alt_text_long || "", 150),
-      }));
-    }
-```
+- [ ] **Step 3: Update the form labels**
 
-Add the import at the top of the file (the project uses a `@/` alias for `src/`):
+Find the label for `alt_text_long`. Its current text reads something like "AI Description" or "Description". Replace the visible text with: `Long alt text (detail page)`.
 
-```typescript
-import { truncateForAlt } from "@/lib/text";
-```
-
-If the alias isn't configured (check `tsconfig.json` for `paths`), use the relative path: `../../../../lib/text`.
+Find the label for `alt_text`. Replace its visible text with: `Short alt text (grid page)`.
 
 - [ ] **Step 4: Verify**
 
 Run: `grep -n "ai_description" src/app/admin/artworks/\[id\]/page.tsx`
 Expected: no output.
 
+Run: `grep -in "copy" src/app/admin/artworks/\[id\]/page.tsx`
+Expected: no output (or only unrelated occurrences). The copy-button is gone.
+
 ---
 
-### Task 13: Update review SPA
+### Task 11: Update review SPA
 
 **Files:**
 - Modify: `public/review.html`
 
 - [ ] **Step 1: Rename column references**
 
-8 occurrences of `ai_description` need to become `alt_text_long`. They appear in:
-- Two SELECT URL strings (lines around 329 and 352)
-- Two `=not.is.null` filter strings (same lines)
-- Two display elements (`a.ai_description` rendering)
-- Two `${a.ai_description}` in textareas
-- Two PATCH payload bodies (`ai_description: desc`)
-- Four in-memory mutations (`a.ai_description = desc`)
-
-Use the Edit tool with `replace_all: true` for `ai_description` → `alt_text_long`.
+Use the Edit tool with `replace_all: true` for `ai_description` → `alt_text_long` across the file. 8 occurrences should be replaced (2 SELECT URL strings, 2 `=not.is.null` filter strings, 2 display elements rendering `a.ai_description`, 2 textarea `${a.ai_description}` references, 2 PATCH payload bodies `ai_description: desc`, and 4 in-memory mutations `a.ai_description = desc`).
 
 - [ ] **Step 2: Verify**
 
@@ -895,20 +735,14 @@ Expected: both IDs appear at least once. They're internal labels for the textare
 
 ---
 
-### Task 14: Update generate-descriptions.ts
+### Task 12: Update generate-descriptions.ts
 
 **Files:**
 - Modify: `scripts/generate-descriptions.ts`
 
 - [ ] **Step 1: Rename column references**
 
-4 occurrences of `ai_description` need renaming:
-- The TypeScript interface field
-- The `select` clause (` ai_description, `)
-- The `.is("ai_description", null)` filter
-- The update payload key
-
-Use the Edit tool with `replace_all: true` for `ai_description` → `alt_text_long`.
+Use the Edit tool with `replace_all: true` for `ai_description` → `alt_text_long`. 4 occurrences should be replaced (the TypeScript interface field, the `select` clause, the `.is("ai_description", null)` filter, and the update payload key).
 
 - [ ] **Step 2: Add description_origin to the update payload**
 
@@ -940,14 +774,14 @@ Expected: no output.
 
 ---
 
-### Task 15: Update migrate-and-describe.ts
+### Task 13: Update migrate-and-describe.ts
 
 **Files:**
 - Modify: `scripts/migrate-and-describe.ts`
 
 - [ ] **Step 1: Rename column references**
 
-5 occurrences of `ai_description` need renaming. Use the Edit tool with `replace_all: true` for `ai_description` → `alt_text_long`.
+Use the Edit tool with `replace_all: true` for `ai_description` → `alt_text_long`. 5 occurrences should be replaced.
 
 - [ ] **Step 2: Add description_origin to the update payload**
 
@@ -977,7 +811,7 @@ Expected: no output.
 
 ---
 
-### Task 16: Sync the migration SQL with the applied state
+### Task 14: Sync the migration SQL with the applied state
 
 **Files:**
 - Modify: `supabase/migrations/001_initial.sql`
@@ -1035,7 +869,7 @@ Expected: no output.
 
 ---
 
-### Task 17: Verify dev server starts and pages render
+### Task 15: Verify dev server starts and pages render
 
 **Files:** none (verification)
 
@@ -1056,7 +890,7 @@ Wait until you see `Ready in <X>ms` in the output (use Monitor or BashOutput to 
 - [ ] **Step 3: Smoke-test the collection page**
 
 Run: `curl -s http://localhost:3000/collection | grep -o 'alt="[^"]*"' | head -5`
-Expected: 5 alt attributes printed. Each should be ≤150 chars (eyeball it). For artworks updated by the import, the alt should end with `…`.
+Expected: 5 alt attributes printed. Each should be the existing short AI alt — NOT the long human paragraph (since the script doesn't touch alt_text and the grid uses the short form).
 
 - [ ] **Step 4: Smoke-test a known-overwritten artwork detail page**
 
@@ -1073,7 +907,7 @@ c.from('artworks').select('id').eq('inventory_number', 'ABai 1').single().then((
 Then: `curl -s http://localhost:3000/artwork/<UUID> | grep -E 'alt=|About This Work'`
 
 Expected:
-- One `alt="..."` containing the full human paragraph (no `…` — the long form goes here)
+- One `alt="..."` containing the full human paragraph (long form goes here)
 - NO occurrence of `About This Work` (section was deleted)
 
 - [ ] **Step 5: Stop the dev server**
@@ -1082,7 +916,7 @@ Kill the background process.
 
 ---
 
-### Task 18: Commit Phase 2
+### Task 16: Commit Phase 2
 
 **Files:** none (git only)
 
@@ -1113,8 +947,9 @@ description_origin column). This commit catches the codebase up:
   "About This Work" section that was wrongly rendering the alt text
   as visible body content
 - Admin edit page: rename refs, relabel fields ("Long alt text /
-  detail page" vs "Short alt text / grid page"), make the copy button
-  truncate with the same logic as the import script
+  detail page" vs "Short alt text / grid page"), delete the
+  copy-long-to-short button (the two fields now serve different
+  purposes and shouldn't be derived from each other)
 - Review SPA: rename refs in fetch URLs, PATCH bodies, and renders
 - AI generation scripts: rename refs and set description_origin: 'ai'
   on insert
@@ -1136,10 +971,12 @@ Expected: commit succeeds.
 ## Done
 
 At this point:
-- DB has 590 (give or take) human-described artworks with `description_origin='human'`, ~1,500 AI-described with `description_origin='ai'`
+- DB has 590 (give or take) artworks with `description_origin='human'` and `alt_text_long` set to the human paragraph; ~1,500 AI-described with `description_origin='ai'`
+- `alt_text` (short form) is unchanged everywhere — still AI-generated
 - Two CSV artifacts in `tmp/` ready to share with Creative Growth
 - Codebase compiles, dev server renders correctly with the new schema
 - The misleading "About This Work" section is gone
-- Grid pages serve short alts; detail page serves long alts
+- Grid pages serve short alts (existing AI); detail page serves long alts (human where available, AI otherwise)
+- Admin form has independent textareas for short and long alt; no copy button
 
 Hand off the two `tmp/` CSVs to Creative Growth. Open issues for follow-up work flagged in the spec under "Out of scope" if you want them tracked.

--- a/docs/superpowers/plans/2026-04-23-human-descriptions-import.md
+++ b/docs/superpowers/plans/2026-04-23-human-descriptions-import.md
@@ -15,7 +15,11 @@
 ## File Structure
 
 **New files:**
+- `scripts/backfill-sku.ts` — one-shot backfill that reads `inventory_2026-04-02.csv` and populates the new `artworks.sku` column keyed on `inventory_number`.
 - `scripts/import-human-descriptions.ts` — main script. Parses CSV, pages through artworks, updates matched rows, writes the two CSV artifacts.
+
+**Modified files (Phase 0.5):**
+- `scripts/import-csv.ts` — also map the `SKU` source column to `artworks.sku` so future re-imports keep the field populated.
 
 **Modified files (Phase 1):**
 - `package.json` — add `import:descriptions` npm script
@@ -39,7 +43,7 @@
 
 **Files:** none (read-only)
 
-- [ ] **Step 1: Confirm columns exist in production**
+- [ ] **Step 1: Confirm rename + origin columns exist in production**
 
 Run:
 ```bash
@@ -56,6 +60,193 @@ c.from('artworks').select('id, alt_text, alt_text_long, description_origin').lim
 Expected: `OK - columns exist: [ 'id', 'alt_text', 'alt_text_long', 'description_origin' ]`
 
 If this fails: stop. The schema migration was not applied as expected; user must re-run the SQL from the spec's "Schema (already migrated)" section before proceeding.
+
+---
+
+## Phase 0.5: SKU column prep
+
+This phase exists because the original import never populated a SKU field. The human descriptions CSV keys on artist-coded SKUs (e.g., `ABai 1`), which live in column 31 of the source Art Cloud CSV — separate from `Inventory Number`. We add the column, backfill it from the source CSV, and update the existing import script so future runs keep it populated.
+
+### Task 0.5a: Verify the sku column exists
+
+**Files:** none (read-only verification, gated on user-run SQL)
+
+- [ ] **Step 1: User runs the SQL** (already provided in chat):
+
+```sql
+ALTER TABLE artworks ADD COLUMN sku TEXT;
+CREATE INDEX idx_artworks_sku ON artworks(sku);
+```
+
+- [ ] **Step 2: Confirm the column exists**
+
+Run:
+```bash
+npx tsx --env-file=.env.local -e "
+import { createClient } from '@supabase/supabase-js';
+const c = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+c.from('artworks').select('id, inventory_number, sku').limit(1).then(({data, error}) => {
+  if (error) { console.error('NOT YET:', error.message); process.exit(1); }
+  console.log('OK - sku column exists:', Object.keys(data[0]));
+});
+"
+```
+
+Expected: `OK - sku column exists: [ 'id', 'inventory_number', 'sku' ]`
+
+---
+
+### Task 0.5b: Write and run the backfill script
+
+**Files:**
+- Create: `scripts/backfill-sku.ts`
+
+- [ ] **Step 1: Write the backfill script**
+
+Create `scripts/backfill-sku.ts`:
+
+```typescript
+#!/usr/bin/env npx tsx
+/**
+ * backfill-sku.ts
+ *
+ * Reads inventory_2026-04-02.csv, populates artworks.sku from the source
+ * SKU column (column 31), keyed on inventory_number (column 28). One-shot.
+ *
+ * Run: npx tsx --env-file=.env.local scripts/backfill-sku.ts
+ */
+
+import fs from "fs";
+import path from "path";
+import { parse } from "csv-parse/sync";
+import { createClient } from "@supabase/supabase-js";
+
+const CSV_PATH = path.join(__dirname, "..", "inventory_2026-04-02.csv");
+
+const SUPABASE_URL =
+  process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error("Error: Set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY");
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+interface CsvRow {
+  "Inventory Number"?: string;
+  SKU?: string;
+  [key: string]: string | undefined;
+}
+
+async function main() {
+  const raw = fs.readFileSync(CSV_PATH, "utf-8");
+  const rows: CsvRow[] = parse(raw, {
+    columns: true,
+    skip_empty_lines: true,
+    relax_quotes: true,
+    relax_column_count: true,
+  });
+  console.log(`Parsed ${rows.length} rows from ${path.basename(CSV_PATH)}`);
+
+  let updated = 0;
+  let skippedNoInv = 0;
+  let skippedNoSku = 0;
+  let updateErrors = 0;
+
+  for (const row of rows) {
+    const inv = (row["Inventory Number"] || "").trim();
+    const sku = (row.SKU || "").trim();
+    if (!inv) { skippedNoInv++; continue; }
+    if (!sku) { skippedNoSku++; continue; }
+
+    const { error, count } = await supabase
+      .from("artworks")
+      .update({ sku }, { count: "exact" })
+      .eq("inventory_number", inv);
+
+    if (error) {
+      console.error(`Update error for inv=${inv}: ${error.message}`);
+      updateErrors++;
+      continue;
+    }
+    if (count && count > 0) updated++;
+  }
+
+  console.log("\n=== Summary ===");
+  console.log(`Total CSV rows:           ${rows.length}`);
+  console.log(`Skipped (no inv number):  ${skippedNoInv}`);
+  console.log(`Skipped (no SKU):         ${skippedNoSku}`);
+  console.log(`Update errors:            ${updateErrors}`);
+  console.log(`Rows updated in DB:       ${updated}`);
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 2: Run the backfill**
+
+Run: `npx tsx --env-file=.env.local scripts/backfill-sku.ts`
+
+Expected:
+```
+Parsed 2189 rows from inventory_2026-04-02.csv
+
+=== Summary ===
+Total CSV rows:           2189
+Skipped (no inv number):  1
+Skipped (no SKU):         0
+Update errors:            0
+Rows updated in DB:       ~2112
+```
+
+The "updated" count should match the artwork count in the DB (~2,112) minus any source rows whose inventory_number doesn't have a corresponding DB row.
+
+- [ ] **Step 3: Spot-check**
+
+Run:
+```bash
+npx tsx --env-file=.env.local -e "
+import { createClient } from '@supabase/supabase-js';
+const c = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+c.from('artworks').select('inventory_number, sku, title').not('sku', 'is', null).limit(5).then(({data}) => {
+  data.forEach(r => console.log(JSON.stringify(r)));
+});
+"
+```
+
+Expected: 5 rows, each with a populated `sku` field that matches the artist code embedded in `title` (e.g., title `"Untitled, JS 17"` → `sku: "JS 17"`).
+
+---
+
+### Task 0.5c: Update import-csv.ts for future runs
+
+**Files:**
+- Modify: `scripts/import-csv.ts`
+
+- [ ] **Step 1: Add SKU to the import payload**
+
+In `scripts/import-csv.ts`:
+
+1. Find the `CsvRow` interface (around line 38). Add `SKU: string;` to it.
+2. Find where the artwork record object is built (around line 142, where `inventory_number: inventoryNumber` appears). Add a sibling line:
+   ```typescript
+   sku: row.SKU?.trim() || null,
+   ```
+
+- [ ] **Step 2: Verify the script still parses**
+
+Run: `npx tsx -e "import('./scripts/import-csv.ts').then(() => console.log('imports OK'))"`
+
+This will start a real import — abort with Ctrl+C as soon as you see "imports OK" or "Parsed N rows" so it doesn't actually re-import. (The script doesn't have a no-op flag; if you'd rather not risk it, just rely on TypeScript not erroring out as your validation.)
+
+Alternative: just `grep -n "sku" scripts/import-csv.ts` to confirm the edits are present.
 
 ---
 
@@ -169,6 +360,7 @@ interface CsvRow {
 
 interface ArtworkRow {
   id: string;
+  sku: string | null;
   inventory_number: string | null;
   image_url: string | null;
   image_original: string | null;
@@ -188,6 +380,7 @@ interface LogEntry {
 
 interface ExportEntry {
   sku: string;
+  inventory_number: string;
   image_url: string;
   description_origin: string;
   alt_text_long: string;
@@ -246,8 +439,8 @@ async function main() {
   while (true) {
     const { data, error } = await supabase
       .from("artworks")
-      .select("id, inventory_number, image_url, image_original, alt_text, alt_text_long, description_origin")
-      .order("inventory_number", { ascending: true, nullsFirst: false })
+      .select("id, sku, inventory_number, image_url, image_original, alt_text, alt_text_long, description_origin")
+      .order("sku", { ascending: true, nullsFirst: false })
       .range(offset, offset + PAGE_SIZE - 1);
     if (error) {
       console.error("Error fetching artworks:", error);
@@ -268,7 +461,8 @@ async function main() {
   let failCount = 0;
 
   for (const art of allArtworks) {
-    const sku = (art.inventory_number || "").trim();
+    const sku = (art.sku || "").trim();
+    const inv = art.inventory_number || "";
     const priorLong = art.alt_text_long || "";
     const currentShort = art.alt_text || "";
     const imageUrl = resolveImageUrl(art) || "";
@@ -286,7 +480,7 @@ async function main() {
         });
         failCount++;
         exportEntries.push({
-          sku, image_url: imageUrl,
+          sku, inventory_number: inv, image_url: imageUrl,
           description_origin: art.description_origin || "",
           alt_text_long: priorLong,
           alt_text: currentShort,
@@ -314,7 +508,7 @@ async function main() {
         });
         failCount++;
         exportEntries.push({
-          sku, image_url: imageUrl,
+          sku, inventory_number: inv, image_url: imageUrl,
           description_origin: art.description_origin || "",
           alt_text_long: priorLong,
           alt_text: currentShort,
@@ -332,7 +526,7 @@ async function main() {
       successCount++;
 
       exportEntries.push({
-        sku, image_url: imageUrl,
+        sku, inventory_number: inv, image_url: imageUrl,
         description_origin: "human",
         alt_text_long: newLong,
         alt_text: currentShort,
@@ -341,7 +535,7 @@ async function main() {
     } else {
       // Not in human CSV - export current state, no prior_ai_alt_text_long
       exportEntries.push({
-        sku, image_url: imageUrl,
+        sku, inventory_number: inv, image_url: imageUrl,
         description_origin: art.description_origin || "",
         alt_text_long: priorLong,
         alt_text: currentShort,
@@ -382,7 +576,7 @@ async function main() {
   );
 
   writeCsv(EXPORT_FILE,
-    ["sku", "image_url", "description_origin", "alt_text_long", "alt_text", "prior_ai_alt_text_long"],
+    ["sku", "inventory_number", "image_url", "description_origin", "alt_text_long", "alt_text", "prior_ai_alt_text_long"],
     exportEntries
   );
 
@@ -546,14 +740,14 @@ Pick a SKU from the CSV's first row (e.g., `ABai 1`). Run:
 npx tsx --env-file=.env.local -e "
 import { createClient } from '@supabase/supabase-js';
 const c = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
-c.from('artworks').select('inventory_number, alt_text, alt_text_long, description_origin').eq('inventory_number', 'ABai 1').single().then(({data, error}) => {
+c.from('artworks').select('sku, inventory_number, alt_text, alt_text_long, description_origin').eq('sku', 'ABai 1').then(({data, error}) => {
   if (error) { console.error(error); process.exit(1); }
   console.log(JSON.stringify(data, null, 2));
 });
 "
 ```
 
-Expected: `description_origin: 'human'`, `alt_text_long` is the full paragraph from the CSV, `alt_text` unchanged from its prior value (whatever the AI pipeline had set).
+Expected: at least one row with `description_origin: 'human'`, `alt_text_long` is the full paragraph from the CSV, `alt_text` unchanged from its prior value (whatever the AI pipeline had set).
 
 ---
 

--- a/docs/superpowers/specs/2026-04-23-human-descriptions-import-design.md
+++ b/docs/superpowers/specs/2026-04-23-human-descriptions-import-design.md
@@ -1,0 +1,178 @@
+# Human Descriptions Import — Design
+
+**Date:** 2026-04-23
+**Status:** Ready for implementation
+
+---
+
+## Goal
+
+Import 590 manually-written, paragraph-length artwork descriptions from a CSV (`tmp/CLIR Image Descriptions Sheet - Brief Descriptions.csv`) into the artworks table, supersede the existing AI-generated descriptions for matched SKUs, and produce two artifacts: a per-row update log and a full-catalog export CSV that lets Creative Growth compare AI vs. human descriptions side-by-side for the ~1,500+ artworks still on AI-only descriptions.
+
+Bundled into the same change: a schema cleanup that renames the two description fields to reflect their actual purpose (alt-text for two different page contexts, not "ai" content vs. "alt"), drops the dangerous fallback that pumps long content into grid `<img alt>` attributes, and removes the "About This Work" section from the artwork detail page (which was wrongly using the long-form alt text as visible body content).
+
+---
+
+## Why this matters (accessibility context)
+
+Screen readers announce the alt attribute of every image they encounter, in order, before the user can decide whether to interact. On a grid page that shows two dozen artworks, that means the screen reader narrates an alt for each card in sequence. If every alt is a 300-word paragraph, what takes a sighted user a few seconds of skimming becomes several minutes of forced listening. A short alt — roughly the length of a tweet — gives enough text to identify the work and let the user decide whether to drill in; the full paragraph then lives on the detail page where the user has explicitly chosen to engage. WCAG and WebAIM both encode this: alt text should be "as concise as possible while serving the equivalent purpose for that context," and "context" includes whether the image stands alone or sits in a grid of fifty.
+
+This is the model the schema and UI now need to reflect cleanly.
+
+---
+
+## Schema (already migrated)
+
+The following SQL was run by the user in the Supabase SQL Editor on 2026-04-23:
+
+```sql
+ALTER TABLE artworks RENAME COLUMN ai_description TO alt_text_long;
+ALTER TABLE artworks ADD COLUMN description_origin TEXT
+  CHECK (description_origin IN ('human', 'ai'));
+UPDATE artworks SET description_origin = 'ai'
+  WHERE alt_text_long IS NOT NULL;
+ALTER TABLE artworks DROP COLUMN fts;
+ALTER TABLE artworks ADD COLUMN fts tsvector GENERATED ALWAYS AS (
+  setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
+  setweight(to_tsvector('english', coalesce(medium, '')), 'B') ||
+  setweight(to_tsvector('english', coalesce(alt_text, '')), 'C') ||
+  setweight(to_tsvector('english', coalesce(alt_text_long, '')), 'D')
+) STORED;
+CREATE INDEX idx_artworks_fts ON artworks USING GIN(fts);
+```
+
+**Resulting field semantics:**
+- `alt_text` — short alt text (≤150 chars, may end with `…`), used in `<img alt>` on grid pages
+- `alt_text_long` — full alt text (paragraph), used in `<img alt>` on artwork detail page
+- `description_origin` — `'human'` for human-authored, `'ai'` for AI-generated, `NULL` if neither field has content
+
+The migration file `supabase/migrations/001_initial.sql` should be updated in source control to reflect the new state, even though the schema change has already been applied — otherwise a fresh environment built from migrations will diverge from production.
+
+---
+
+## Component 1: Update + export script
+
+**File:** `scripts/import-human-descriptions.ts`
+**npm script:** `import:descriptions`
+
+### Inputs
+
+- `tmp/CLIR Image Descriptions Sheet - Brief Descriptions.csv` (path configurable via env var `HUMAN_CSV_PATH`, default as written)
+- Supabase service role key (from `.env.local`, same pattern as other scripts)
+
+### Behavior
+
+1. Parse the CSV. Required columns: `SKU`, `Item Description *`. Other columns are ignored.
+2. Build an in-memory map: `inventory_number → { description, source_row }`.
+3. Page through every artwork in `artworks` (using existing pagination pattern from `seed-categories.ts` / `migrate-images.ts` — the REST API caps at 1,000 rows per page). For each artwork:
+   - Capture `prior_alt_text_long` and `prior_alt_text` (current values).
+   - If `inventory_number` is present in the human-CSV map:
+     - Compute `new_alt_text_long` = the human paragraph, with leading/trailing whitespace stripped.
+     - Compute `new_alt_text`:
+       - Collapse newlines to single spaces, collapse runs of whitespace to one space.
+       - If the result is ≤150 chars, use it verbatim, no ellipsis.
+       - Otherwise: take the first 149 characters, find the last whitespace character within that slice, cut there, and append `…` (single Unicode ellipsis, U+2026). The total length including the ellipsis is therefore ≤150 chars. If no whitespace exists in the first 149 chars (extremely unlikely with prose), hard-cut at 149 + ellipsis.
+     - UPDATE the row: `alt_text_long = new_alt_text_long`, `alt_text = new_alt_text`, `description_origin = 'human'`.
+     - Append a log entry: `status='success'`, `prior_alt_text_long`, `prior_alt_text`, `new_alt_text_long`, `new_alt_text`.
+     - Append an export entry with both prior and new values populated.
+   - Else (artwork not in CSV): no DB update; add an export entry with current values only (`prior_ai_*` columns left blank since current = prior).
+4. After processing all artworks, also report any SKUs in the CSV that did not match any DB row — append fail log entries with `status='fail'`, `reason='sku not found in db'`.
+5. Write the two CSV artifacts to `tmp/`.
+
+### Edge cases
+
+- **Empty description in CSV row:** log as `fail`, `reason='empty description'`. Do not update.
+- **Whitespace-only description:** treated as empty after strip.
+- **Multi-line descriptions:** preserved as-is in `alt_text_long` (newlines kept). For `alt_text`, newlines are collapsed to single spaces before truncation (so the short version reads as one line).
+- **Description shorter than 150 chars:** copied verbatim to `alt_text`, no ellipsis appended.
+- **SKU collision (CSV has multiple rows with same SKU):** last one wins, prior occurrences logged with `status='fail'`, `reason='superseded by later row in csv'`.
+- **DB update failure (network, RLS, etc.):** log as `fail`, `reason=<error message>`. Continue with next row.
+- **Idempotency:** the script can be re-run safely. It overwrites with the same values and produces fresh log + export artifacts each run (filenames carry timestamps).
+
+### Output: artifact 1 — update log
+
+**File:** `tmp/import-human-descriptions-log_<ISO-timestamp>.csv`
+
+| Column | Notes |
+|---|---|
+| `sku` | The CSV's SKU value |
+| `status` | `success` or `fail` |
+| `reason` | Empty on success; explanation on fail |
+| `artwork_id` | UUID if matched, empty if not |
+| `prior_alt_text_long` | Snapshot of what was overwritten (empty if no prior content) |
+| `prior_alt_text` | Snapshot of what was overwritten |
+| `new_alt_text_long` | The human paragraph as written |
+| `new_alt_text` | The truncated short version (with ellipsis if truncation occurred) |
+
+One row per CSV input row, plus one row per CSV SKU that didn't match the DB.
+
+### Output: artifact 2 — catalog export
+
+**File:** `tmp/descriptions-export_<ISO-timestamp>.csv`
+
+| Column | Notes |
+|---|---|
+| `sku` | `inventory_number` from DB |
+| `image_url` | Resolved via the same `resolveImageUrl()` helper the UI uses, so URLs match what's served |
+| `description_origin` | `'human'` / `'ai'` / empty |
+| `alt_text_long` | Current value (post-update) |
+| `alt_text` | Current value (post-update) |
+| `prior_ai_alt_text_long` | The pre-update AI-generated long alt text — populated only for `description_origin='human'` rows where prior content existed; empty for AI rows (since current = prior) and for rows that had no prior content |
+| `prior_ai_alt_text` | Same logic for the short field |
+
+One row per artwork in the database. Sorted by `inventory_number` for stable diffing.
+
+The asymmetric `prior_ai_*` population (only for human-overwritten rows) is intentional: it lets Creative Growth compare AI vs. human side-by-side for the 590 overwritten rows without bloating the export with redundant duplicate columns for the ~1,500 AI-only rows.
+
+---
+
+## Component 2: UI + scripts updates (rename rollout)
+
+These ship together with the new import script in a single commit. The schema rename is already applied, so the codebase is currently broken against production — these edits are the catch-up.
+
+### Files
+
+- **`src/lib/types.ts`** — rename `ai_description` → `alt_text_long`; add `description_origin: 'human' | 'ai' | null`.
+- **`src/lib/utils.ts`** — `getAltText()` returns `alt_text` only. The fallback to the long form is removed (rationale above; the fallback would dump paragraphs into `<img alt>`). The fallback chain becomes: `alt_text` → title + medium fallback. (No fallback to `alt_text_long` even though it exists, because using the long form in `<img alt>` is exactly the bug we're fixing.)
+- **`src/app/artwork/[id]/page.tsx`** — `<img alt>` reads from `alt_text_long`; **delete the entire "About This Work" `<section>`** (lines 273-283). The section was rendering the alt text as visible body content, which is the wrong purpose for that field.
+- **`src/components/ArtworkCard.tsx`** — no functional change; continues to call `getAltText()` which now returns short form only.
+- **`src/app/admin/artworks/[id]/page.tsx`** — rename all `ai_description` → `alt_text_long` field references in the form state, fetch, and submit. Relabel the form fields: "Long alt text (detail page)" and "Short alt text (grid page)". The existing "copy long → short" button should also truncate to 150 chars + ellipsis to match the import script's logic. (Keep the button; it's useful when an admin writes a fresh long description and wants a starter short version.)
+- **`public/review.html`** — rename all `ai_description` references (8 spots: query URLs, PATCH bodies, display markup, edit markup, in-memory mutations). Element IDs (`descDisplay`, `descEdit`) can stay as-is — they're internal labels, not column names.
+- **`scripts/generate-descriptions.ts`** — rename all `ai_description` references (4 spots: type, select, filter, update payload). Update payload should also set `description_origin: 'ai'`. Note: the JSON keys in the AI prompt response (`alt_text`, `description`) are internal to the prompt contract and do not need to change.
+- **`scripts/migrate-and-describe.ts`** — same rename (5 spots). Same `description_origin: 'ai'` addition on the update payload.
+- **`supabase/migrations/001_initial.sql`** — update column names and FTS index to match the applied state, and add the `description_origin` column. (No new migration file; just edit in place since this represents what should be created on a fresh environment.)
+- **`.gitignore`** — add `tmp/` so the input CSV and the two output artifacts don't accidentally get committed. The `tmp/` folder currently exists with the input CSV but isn't ignored.
+
+### Order of operations
+
+1. Schema migration (DONE, manually applied)
+2. All UI/script renames committed in one go (this commit also adds the new import script)
+3. `npm run import:descriptions` against production
+4. Manual verification:
+   - Visit `/collection` and inspect alt attributes in DevTools — should be ≤150 char, ending with `…` for human-overwritten rows
+   - Visit a known-overwritten artwork's detail page and inspect the `<img alt>` — should be the full paragraph
+   - Confirm the "About This Work" section is no longer rendered
+   - Spot-check the export CSV against 2-3 known SKUs
+5. Open the two artifacts, share with Creative Growth
+
+---
+
+## Out of scope (explicit)
+
+- **Repurposing the "About This Work" section** for narrative / artist-voice content. Section is removed in this work; a future feature can reintroduce it pointed at a new field (e.g., `narrative` or `artist_statement`).
+- **Re-running AI generation** for the ~1,500 artworks not in the human CSV. Their existing AI descriptions are preserved.
+- **Cleaning up the `description_reviewed` schema drift** — `public/review.html` references a `description_reviewed` column that isn't in the migration file. Acknowledged but not fixed here; address in a separate cleanup.
+- **Alt text quality audit** for the AI-generated short alts on the ~1,500 remaining artworks. They've been reviewed via the existing review SPA; no rework planned.
+- **Rebuilding the description review SPA** to support the new schema beyond the minimal rename. The SPA continues to work with the same approve/edit/skip flow against the renamed fields.
+
+---
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Rename breaks production until the code-side updates land | Migration was applied immediately before the code changes; minimize the gap by landing all rename edits in one commit |
+| Truncation at last word boundary could occasionally produce a too-short result (e.g., a 145-char paragraph that ends right before a long word starting at 130) | Acceptable; human descriptions average well above 150 chars, so this is a corner case. Anything ≤150 chars is copied verbatim (no truncation logic engages). |
+| CSV SKU format mismatch (e.g., trailing whitespace in `inventory_number` from import-csv.ts) | Trim both sides of the comparison. Log any unmatched SKUs in the fail log so we can spot-check whether the issue is data drift vs. genuine missing artworks. |
+| Existing AI descriptions are lost on overwrite | Captured in the per-row log (`prior_alt_text_long`, `prior_alt_text`) for any row touched. Recoverable from the timestamped log file in `tmp/`. |
+| FTS index recreation is non-trivial on 2,000+ rows | Migration was already run by user; not a concern at script-run time. |

--- a/docs/superpowers/specs/2026-04-23-human-descriptions-import-design.md
+++ b/docs/superpowers/specs/2026-04-23-human-descriptions-import-design.md
@@ -7,7 +7,9 @@
 
 ## Goal
 
-Import 590 manually-written, paragraph-length artwork descriptions from a CSV (`tmp/CLIR Image Descriptions Sheet - Brief Descriptions.csv`) into the artworks table, supersede the existing AI-generated descriptions for matched SKUs, and produce two artifacts: a per-row update log and a full-catalog export CSV that lets Creative Growth compare AI vs. human descriptions side-by-side for the ~1,500+ artworks still on AI-only descriptions.
+Import 590 manually-written, paragraph-length artwork descriptions from a CSV (`tmp/CLIR Image Descriptions Sheet - Brief Descriptions.csv`) into the `alt_text_long` field of the artworks table, supersede the existing AI-generated long descriptions for matched SKUs, and produce two artifacts: a per-row update log and a full-catalog export CSV that lets Creative Growth compare AI vs. human long descriptions side-by-side for the ~1,500+ artworks still on AI-only.
+
+The existing short `alt_text` (used by `<img alt>` on grid pages) is **left untouched** — the human CSV has only paragraph-form content, and there is no good algorithmic way to derive a screen-reader-quality short alt from it. The existing AI-generated short alt remains in place; an admin can later improve it manually via the admin console.
 
 Bundled into the same change: a schema cleanup that renames the two description fields to reflect their actual purpose (alt-text for two different page contexts, not "ai" content vs. "alt"), drops the dangerous fallback that pumps long content into grid `<img alt>` attributes, and removes the "About This Work" section from the artwork detail page (which was wrongly using the long-form alt text as visible body content).
 
@@ -65,17 +67,13 @@ The migration file `supabase/migrations/001_initial.sql` should be updated in so
 1. Parse the CSV. Required columns: `SKU`, `Item Description *`. Other columns are ignored.
 2. Build an in-memory map: `inventory_number → { description, source_row }`.
 3. Page through every artwork in `artworks` (using existing pagination pattern from `seed-categories.ts` / `migrate-images.ts` — the REST API caps at 1,000 rows per page). For each artwork:
-   - Capture `prior_alt_text_long` and `prior_alt_text` (current values).
+   - Capture `prior_alt_text_long` (current value).
    - If `inventory_number` is present in the human-CSV map:
      - Compute `new_alt_text_long` = the human paragraph, with leading/trailing whitespace stripped.
-     - Compute `new_alt_text`:
-       - Collapse newlines to single spaces, collapse runs of whitespace to one space.
-       - If the result is ≤150 chars, use it verbatim, no ellipsis.
-       - Otherwise: take the first 149 characters, find the last whitespace character within that slice, cut there, and append `…` (single Unicode ellipsis, U+2026). The total length including the ellipsis is therefore ≤150 chars. If no whitespace exists in the first 149 chars (extremely unlikely with prose), hard-cut at 149 + ellipsis.
-     - UPDATE the row: `alt_text_long = new_alt_text_long`, `alt_text = new_alt_text`, `description_origin = 'human'`.
-     - Append a log entry: `status='success'`, `prior_alt_text_long`, `prior_alt_text`, `new_alt_text_long`, `new_alt_text`.
-     - Append an export entry with both prior and new values populated.
-   - Else (artwork not in CSV): no DB update; add an export entry with current values only (`prior_ai_*` columns left blank since current = prior).
+     - UPDATE the row: `alt_text_long = new_alt_text_long`, `description_origin = 'human'`. The existing `alt_text` (short form) is **not** modified.
+     - Append a log entry: `status='success'`, `prior_alt_text_long`, `new_alt_text_long`.
+     - Append an export entry with the prior long-form value populated alongside the new one.
+   - Else (artwork not in CSV): no DB update; add an export entry with current values only (`prior_ai_alt_text_long` left blank since current = prior).
 4. After processing all artworks, also report any SKUs in the CSV that did not match any DB row — append fail log entries with `status='fail'`, `reason='sku not found in db'`.
 5. Write the two CSV artifacts to `tmp/`.
 
@@ -83,8 +81,7 @@ The migration file `supabase/migrations/001_initial.sql` should be updated in so
 
 - **Empty description in CSV row:** log as `fail`, `reason='empty description'`. Do not update.
 - **Whitespace-only description:** treated as empty after strip.
-- **Multi-line descriptions:** preserved as-is in `alt_text_long` (newlines kept). For `alt_text`, newlines are collapsed to single spaces before truncation (so the short version reads as one line).
-- **Description shorter than 150 chars:** copied verbatim to `alt_text`, no ellipsis appended.
+- **Multi-line descriptions:** preserved as-is in `alt_text_long` (newlines kept).
 - **SKU collision (CSV has multiple rows with same SKU):** last one wins, prior occurrences logged with `status='fail'`, `reason='superseded by later row in csv'`.
 - **DB update failure (network, RLS, etc.):** log as `fail`, `reason=<error message>`. Continue with next row.
 - **Idempotency:** the script can be re-run safely. It overwrites with the same values and produces fresh log + export artifacts each run (filenames carry timestamps).
@@ -100,9 +97,7 @@ The migration file `supabase/migrations/001_initial.sql` should be updated in so
 | `reason` | Empty on success; explanation on fail |
 | `artwork_id` | UUID if matched, empty if not |
 | `prior_alt_text_long` | Snapshot of what was overwritten (empty if no prior content) |
-| `prior_alt_text` | Snapshot of what was overwritten |
 | `new_alt_text_long` | The human paragraph as written |
-| `new_alt_text` | The truncated short version (with ellipsis if truncation occurred) |
 
 One row per CSV input row, plus one row per CSV SKU that didn't match the DB.
 
@@ -115,14 +110,13 @@ One row per CSV input row, plus one row per CSV SKU that didn't match the DB.
 | `sku` | `inventory_number` from DB |
 | `image_url` | Resolved via the same `resolveImageUrl()` helper the UI uses, so URLs match what's served |
 | `description_origin` | `'human'` / `'ai'` / empty |
-| `alt_text_long` | Current value (post-update) |
-| `alt_text` | Current value (post-update) |
+| `alt_text_long` | Current value (post-update — human for matched rows, AI for the rest) |
+| `alt_text` | Current value (untouched by this script — AI for all rows that ever ran through the AI pipeline) |
 | `prior_ai_alt_text_long` | The pre-update AI-generated long alt text — populated only for `description_origin='human'` rows where prior content existed; empty for AI rows (since current = prior) and for rows that had no prior content |
-| `prior_ai_alt_text` | Same logic for the short field |
 
 One row per artwork in the database. Sorted by `inventory_number` for stable diffing.
 
-The asymmetric `prior_ai_*` population (only for human-overwritten rows) is intentional: it lets Creative Growth compare AI vs. human side-by-side for the 590 overwritten rows without bloating the export with redundant duplicate columns for the ~1,500 AI-only rows.
+The asymmetric `prior_ai_alt_text_long` population (only for human-overwritten rows) is intentional: it lets Creative Growth compare AI vs. human long-descriptions side-by-side for the 590 overwritten rows without bloating the export with redundant duplicate columns for the ~1,500 AI-only rows. The short `alt_text` column is included so CG sees the complete current state of each row, even though this script never modifies it.
 
 ---
 
@@ -136,7 +130,7 @@ These ship together with the new import script in a single commit. The schema re
 - **`src/lib/utils.ts`** — `getAltText()` returns `alt_text` only. The fallback to the long form is removed (rationale above; the fallback would dump paragraphs into `<img alt>`). The fallback chain becomes: `alt_text` → title + medium fallback. (No fallback to `alt_text_long` even though it exists, because using the long form in `<img alt>` is exactly the bug we're fixing.)
 - **`src/app/artwork/[id]/page.tsx`** — `<img alt>` reads from `alt_text_long`; **delete the entire "About This Work" `<section>`** (lines 273-283). The section was rendering the alt text as visible body content, which is the wrong purpose for that field.
 - **`src/components/ArtworkCard.tsx`** — no functional change; continues to call `getAltText()` which now returns short form only.
-- **`src/app/admin/artworks/[id]/page.tsx`** — rename all `ai_description` → `alt_text_long` field references in the form state, fetch, and submit. Relabel the form fields: "Long alt text (detail page)" and "Short alt text (grid page)". The existing "copy long → short" button should also truncate to 150 chars + ellipsis to match the import script's logic. (Keep the button; it's useful when an admin writes a fresh long description and wants a starter short version.)
+- **`src/app/admin/artworks/[id]/page.tsx`** — rename all `ai_description` → `alt_text_long` field references in the form state, fetch, and submit. Relabel the form fields: "Long alt text (detail page)" and "Short alt text (grid page)". **Delete the existing "copy long → short" button** — under the new model `alt_text_long` and `alt_text` serve different page contexts and have different content sources (long is human-or-AI prose, short is concise screen-reader text), so direct copying no longer makes sense. An admin who wants a fresh short alt should write one.
 - **`public/review.html`** — rename all `ai_description` references (8 spots: query URLs, PATCH bodies, display markup, edit markup, in-memory mutations). Element IDs (`descDisplay`, `descEdit`) can stay as-is — they're internal labels, not column names.
 - **`scripts/generate-descriptions.ts`** — rename all `ai_description` references (4 spots: type, select, filter, update payload). Update payload should also set `description_origin: 'ai'`. Note: the JSON keys in the AI prompt response (`alt_text`, `description`) are internal to the prompt contract and do not need to change.
 - **`scripts/migrate-and-describe.ts`** — same rename (5 spots). Same `description_origin: 'ai'` addition on the update payload.
@@ -172,7 +166,7 @@ These ship together with the new import script in a single commit. The schema re
 | Risk | Mitigation |
 |---|---|
 | Rename breaks production until the code-side updates land | Migration was applied immediately before the code changes; minimize the gap by landing all rename edits in one commit |
-| Truncation at last word boundary could occasionally produce a too-short result (e.g., a 145-char paragraph that ends right before a long word starting at 130) | Acceptable; human descriptions average well above 150 chars, so this is a corner case. Anything ≤150 chars is copied verbatim (no truncation logic engages). |
 | CSV SKU format mismatch (e.g., trailing whitespace in `inventory_number` from import-csv.ts) | Trim both sides of the comparison. Log any unmatched SKUs in the fail log so we can spot-check whether the issue is data drift vs. genuine missing artworks. |
-| Existing AI descriptions are lost on overwrite | Captured in the per-row log (`prior_alt_text_long`, `prior_alt_text`) for any row touched. Recoverable from the timestamped log file in `tmp/`. |
+| Existing AI long descriptions are lost on overwrite | Captured in the per-row log (`prior_alt_text_long`) for any row touched. Recoverable from the timestamped log file in `tmp/`. |
 | FTS index recreation is non-trivial on 2,000+ rows | Migration was already run by user; not a concern at script-run time. |
+| Short `alt_text` becomes inconsistent with the long form for human rows (long is human-authored, short is still AI-generated) | Acknowledged tradeoff. `alt_text_long` and `alt_text` serve different contexts and don't need to match in tone or content. If CG eventually wants human-authored short alts too, that is a follow-up CSV import or admin-form workflow. |

--- a/docs/superpowers/specs/2026-04-23-human-descriptions-import-design.md
+++ b/docs/superpowers/specs/2026-04-23-human-descriptions-import-design.md
@@ -9,6 +9,8 @@
 
 Import 590 manually-written, paragraph-length artwork descriptions from a CSV (`tmp/CLIR Image Descriptions Sheet - Brief Descriptions.csv`) into the `alt_text_long` field of the artworks table, supersede the existing AI-generated long descriptions for matched SKUs, and produce two artifacts: a per-row update log and a full-catalog export CSV that lets Creative Growth compare AI vs. human long descriptions side-by-side for the ~1,500+ artworks still on AI-only.
 
+**Spec revision 2026-04-23 (mid-execution):** First execution attempt revealed that the human CSV's `SKU` column does NOT correspond to the DB's `inventory_number` column. They are two separate columns in the original Art Cloud export (column 28 = "Inventory Number", numeric like `38754`; column 31 = "SKU", artist-coded like `ABai 1`), and only "Inventory Number" was imported on the original load. Before the human descriptions can be matched, a new `sku` column must be added to `artworks` and backfilled from `inventory_2026-04-02.csv` keyed on `inventory_number`. See "Schema (already migrated)" and "Component 0: SKU column" sections below.
+
 The existing short `alt_text` (used by `<img alt>` on grid pages) is **left untouched** — the human CSV has only paragraph-form content, and there is no good algorithmic way to derive a screen-reader-quality short alt from it. The existing AI-generated short alt remains in place; an admin can later improve it manually via the admin console.
 
 Bundled into the same change: a schema cleanup that renames the two description fields to reflect their actual purpose (alt-text for two different page contexts, not "ai" content vs. "alt"), drops the dangerous fallback that pumps long content into grid `<img alt>` attributes, and removes the "About This Work" section from the artwork detail page (which was wrongly using the long-form alt text as visible body content).
@@ -43,12 +45,35 @@ ALTER TABLE artworks ADD COLUMN fts tsvector GENERATED ALWAYS AS (
 CREATE INDEX idx_artworks_fts ON artworks USING GIN(fts);
 ```
 
+**Additional SQL (mid-execution revision, 2026-04-23):** Adding the SKU column required by Component 0:
+
+```sql
+ALTER TABLE artworks ADD COLUMN sku TEXT;
+CREATE INDEX idx_artworks_sku ON artworks(sku);
+```
+
+The `sku` column is intentionally **not** UNIQUE — the source Art Cloud CSV has 2 duplicate SKUs (`DMi 662`, `JS 27`) representing distinct artworks that share an artist code. They have different `inventory_number` values, so primary-key uniqueness is preserved.
+
 **Resulting field semantics:**
 - `alt_text` — short alt text (≤150 chars, may end with `…`), used in `<img alt>` on grid pages
 - `alt_text_long` — full alt text (paragraph), used in `<img alt>` on artwork detail page
 - `description_origin` — `'human'` for human-authored, `'ai'` for AI-generated, `NULL` if neither field has content
+- `sku` — artist-coded identifier from the Art Cloud `SKU` column (e.g., `ABai 1`, `CLIR2022.25`). Distinct from `inventory_number` (which is a numeric Art Cloud ID). Both are preserved.
 
 The migration file `supabase/migrations/001_initial.sql` should be updated in source control to reflect the new state, even though the schema change has already been applied — otherwise a fresh environment built from migrations will diverge from production.
+
+---
+
+## Component 0: SKU column add and backfill
+
+The `sku` column was missing from the original import; the human-descriptions CSV keys on it. Backfilling restores parity with the Art Cloud source.
+
+**Backfill script** (`scripts/backfill-sku.ts`, one-shot):
+1. Read `inventory_2026-04-02.csv`. For each row, read `Inventory Number` (column 28) and `SKU` (column 31).
+2. For each row with both values present: `UPDATE artworks SET sku = :sku WHERE inventory_number = :inv`.
+3. Log a summary: rows in CSV, rows with both values, rows updated, rows skipped (no inv match).
+
+**Going-forward import** (`scripts/import-csv.ts`): add `sku` to the upsert payload so subsequent CSV refreshes also map the SKU column. The conflict key remains `inventory_number` (still unique).
 
 ---
 
@@ -66,14 +91,16 @@ The migration file `supabase/migrations/001_initial.sql` should be updated in so
 
 1. Parse the CSV. Required columns: `SKU`, `Item Description *`. Other columns are ignored.
 2. Build an in-memory map: `inventory_number → { description, source_row }`.
-3. Page through every artwork in `artworks` (using existing pagination pattern from `seed-categories.ts` / `migrate-images.ts` — the REST API caps at 1,000 rows per page). For each artwork:
+3. Page through every artwork in `artworks` (using existing pagination pattern from `seed-categories.ts` / `migrate-images.ts` — the REST API caps at 1,000 rows per page). Select must include the new `sku` column. For each artwork:
    - Capture `prior_alt_text_long` (current value).
-   - If `inventory_number` is present in the human-CSV map:
+   - If `sku` is present in the human-CSV map:
      - Compute `new_alt_text_long` = the human paragraph, with leading/trailing whitespace stripped.
      - UPDATE the row: `alt_text_long = new_alt_text_long`, `description_origin = 'human'`. The existing `alt_text` (short form) is **not** modified.
      - Append a log entry: `status='success'`, `prior_alt_text_long`, `new_alt_text_long`.
      - Append an export entry with the prior long-form value populated alongside the new one.
    - Else (artwork not in CSV): no DB update; add an export entry with current values only (`prior_ai_alt_text_long` left blank since current = prior).
+
+   Note: when two DB rows share the same SKU (the `DMi 662` / `JS 27` case), both will be updated with the same human description if that SKU appears in the human CSV — intentional, since the CSV speaks of artworks by SKU and ambiguity in the source data should propagate to both copies.
 4. After processing all artworks, also report any SKUs in the CSV that did not match any DB row — append fail log entries with `status='fail'`, `reason='sku not found in db'`.
 5. Write the two CSV artifacts to `tmp/`.
 
@@ -107,7 +134,8 @@ One row per CSV input row, plus one row per CSV SKU that didn't match the DB.
 
 | Column | Notes |
 |---|---|
-| `sku` | `inventory_number` from DB |
+| `sku` | `sku` field from DB (artist-coded, e.g., `ABai 1`) |
+| `inventory_number` | `inventory_number` field from DB (numeric Art Cloud ID) — included so CG can cross-reference with their internal records |
 | `image_url` | Resolved via the same `resolveImageUrl()` helper the UI uses, so URLs match what's served |
 | `description_origin` | `'human'` / `'ai'` / empty |
 | `alt_text_long` | Current value (post-update — human for matched rows, AI for the rest) |

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "import:images": "tsx scripts/migrate-images.ts",
     "seed:categories": "tsx scripts/seed-categories.ts",
     "generate:descriptions": "tsx scripts/generate-descriptions.ts",
+    "import:descriptions": "tsx --env-file=.env.local scripts/import-human-descriptions.ts",
     "migrate:all": "tsx --env-file=.env.local scripts/migrate-and-describe.ts",
     "db:migrate": "tsx scripts/run-migration.ts"
   },

--- a/public/review.html
+++ b/public/review.html
@@ -326,7 +326,7 @@
     let offset = 0;
     const limit = 1000;
     while (true) {
-      const url = `${SUPABASE_URL}/rest/v1/artworks?select=id,title,medium,image_url,image_original,ai_description,alt_text,description_reviewed,inventory_number,artist:artists(first_name,last_name)&ai_description=not.is.null&order=title.asc&offset=${offset}&limit=${limit}`;
+      const url = `${SUPABASE_URL}/rest/v1/artworks?select=id,title,medium,image_url,image_original,alt_text_long,alt_text,description_reviewed,inventory_number,artist:artists(first_name,last_name)&alt_text_long=not.is.null&order=title.asc&offset=${offset}&limit=${limit}`;
       const res = await fetch(url, { headers });
       if (!res.ok) {
         // If description_reviewed column doesn't exist, retry without it
@@ -349,7 +349,7 @@
     let offset = 0;
     const limit = 1000;
     while (true) {
-      const url = `${SUPABASE_URL}/rest/v1/artworks?select=id,title,medium,image_url,image_original,ai_description,alt_text,inventory_number,artist:artists(first_name,last_name)&ai_description=not.is.null&order=title.asc&offset=${offset}&limit=${limit}`;
+      const url = `${SUPABASE_URL}/rest/v1/artworks?select=id,title,medium,image_url,image_original,alt_text_long,alt_text,inventory_number,artist:artists(first_name,last_name)&alt_text_long=not.is.null&order=title.asc&offset=${offset}&limit=${limit}`;
       const res = await fetch(url, { headers });
       const data = await res.json();
       // Add synthetic description_reviewed field
@@ -448,7 +448,7 @@
 
           <div class="desc-section">
             <div class="desc-label">AI Description</div>
-            <div class="desc-text" id="descDisplay">${a.ai_description || '<em style="color:#999">No description</em>'}</div>
+            <div class="desc-text" id="descDisplay">${a.alt_text_long || '<em style="color:#999">No description</em>'}</div>
           </div>
 
           <div class="actions" id="actionButtons">
@@ -503,7 +503,7 @@
       <div class="char-count" id="altCharCount">${(a.alt_text || '').length} / 125</div>
     `;
     descDisplay.outerHTML = `
-      <textarea class="desc-edit" id="descEdit">${a.ai_description || ''}</textarea>
+      <textarea class="desc-edit" id="descEdit">${a.alt_text_long || ''}</textarea>
     `;
     actions.innerHTML = `
       <button class="btn btn-save" onclick="saveEdit()">Save</button>
@@ -528,12 +528,12 @@
 
     const ok = await updateArtwork(a.id, {
       alt_text: altText,
-      ai_description: desc,
+      alt_text_long: desc,
     });
 
     if (ok) {
       a.alt_text = altText;
-      a.ai_description = desc;
+      a.alt_text_long = desc;
       editing = false;
       showToast('Saved!');
       renderCurrent();
@@ -549,13 +549,13 @@
 
     const ok = await updateArtwork(a.id, {
       alt_text: altText,
-      ai_description: desc,
+      alt_text_long: desc,
       description_reviewed: true,
     });
 
     if (ok) {
       a.alt_text = altText;
-      a.ai_description = desc;
+      a.alt_text_long = desc;
       a.description_reviewed = true;
       editing = false;
       showToast('Saved & Approved!');

--- a/scripts/backfill-sku.ts
+++ b/scripts/backfill-sku.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env npx tsx
+/**
+ * backfill-sku.ts
+ *
+ * Reads inventory_2026-04-02.csv, populates artworks.sku from the source
+ * SKU column (column 31), keyed on inventory_number (column 28). One-shot.
+ *
+ * Run: npx tsx --env-file=.env.local scripts/backfill-sku.ts
+ */
+
+import fs from "fs";
+import path from "path";
+import { parse } from "csv-parse/sync";
+import { createClient } from "@supabase/supabase-js";
+
+const CSV_PATH = path.join(__dirname, "..", "inventory_2026-04-02.csv");
+
+const SUPABASE_URL =
+  process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error("Error: Set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY");
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+interface CsvRow {
+  "Inventory Number"?: string;
+  SKU?: string;
+  [key: string]: string | undefined;
+}
+
+async function main() {
+  const raw = fs.readFileSync(CSV_PATH, "utf-8");
+  const rows: CsvRow[] = parse(raw, {
+    columns: true,
+    skip_empty_lines: true,
+    relax_quotes: true,
+    relax_column_count: true,
+  });
+  console.log(`Parsed ${rows.length} rows from ${path.basename(CSV_PATH)}`);
+
+  let updated = 0;
+  let skippedNoInv = 0;
+  let skippedNoSku = 0;
+  let updateErrors = 0;
+
+  for (const row of rows) {
+    const inv = (row["Inventory Number"] || "").trim();
+    const sku = (row.SKU || "").trim();
+    if (!inv) { skippedNoInv++; continue; }
+    if (!sku) { skippedNoSku++; continue; }
+
+    const { error, count } = await supabase
+      .from("artworks")
+      .update({ sku }, { count: "exact" })
+      .eq("inventory_number", inv);
+
+    if (error) {
+      console.error(`Update error for inv=${inv}: ${error.message}`);
+      updateErrors++;
+      continue;
+    }
+    if (count && count > 0) updated++;
+  }
+
+  console.log("\n=== Summary ===");
+  console.log(`Total CSV rows:           ${rows.length}`);
+  console.log(`Skipped (no inv number):  ${skippedNoInv}`);
+  console.log(`Skipped (no SKU):         ${skippedNoSku}`);
+  console.log(`Update errors:            ${updateErrors}`);
+  console.log(`Rows updated in DB:       ${updated}`);
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/scripts/generate-descriptions.ts
+++ b/scripts/generate-descriptions.ts
@@ -164,7 +164,7 @@ async function main() {
     width: number | null;
     image_original: string | null;
     image_url: string | null;
-    ai_description: string | null;
+    alt_text_long: string | null;
     artist: { first_name: string; last_name: string } | null;
   };
   let allArtworks: ArtworkRow[] = [];
@@ -174,8 +174,8 @@ async function main() {
   while (true) {
     const { data, error } = await supabase
       .from("artworks")
-      .select("id, title, medium, height, width, image_original, image_url, ai_description, artist:artists(first_name, last_name)")
-      .is("ai_description", null)
+      .select("id, title, medium, height, width, image_original, image_url, alt_text_long, artist:artists(first_name, last_name)")
+      .is("alt_text_long", null)
       .not("image_original", "is", null)
       .range(offset, offset + PAGE_SIZE - 1);
 
@@ -234,8 +234,9 @@ async function main() {
       const { error: updateErr } = await supabase
         .from("artworks")
         .update({
-          ai_description: result.description,
+          alt_text_long: result.description,
           alt_text: result.alt_text,
+          description_origin: "ai",
         })
         .eq("id", artwork.id);
 

--- a/scripts/import-csv.ts
+++ b/scripts/import-csv.ts
@@ -45,6 +45,7 @@ interface CsvRow {
   Width: string;
   Depth: string;
   "Inventory Number": string;
+  SKU: string;
   Tags: string;
   Genre: string;
   Notes: string;
@@ -147,6 +148,7 @@ async function main() {
         width: parseNumeric(row.Width),
         depth: parseNumeric(row.Depth),
         inventory_number: inventoryNumber,
+        sku: row.SKU?.trim() || null,
         image_original: row.Image?.trim() || null,
         image_url: row.Image?.trim() || null, // Will be updated after R2 migration
         tags: parseTags(row.Tags),

--- a/scripts/import-human-descriptions.ts
+++ b/scripts/import-human-descriptions.ts
@@ -1,0 +1,290 @@
+#!/usr/bin/env npx tsx
+/**
+ * import-human-descriptions.ts
+ *
+ * Reads the human-authored description CSV at HUMAN_CSV_PATH (default:
+ * tmp/CLIR Image Descriptions Sheet - Brief Descriptions.csv), updates
+ * matched artworks (alt_text_long, description_origin='human'), and
+ * writes two timestamped CSV artifacts to tmp/:
+ *   - import-human-descriptions-log_<ISO>.csv  per-row update log
+ *   - descriptions-export_<ISO>.csv             full catalog snapshot
+ *
+ * The short alt_text is intentionally NOT modified — see the spec at
+ * docs/superpowers/specs/2026-04-23-human-descriptions-import-design.md.
+ *
+ * Run: npx tsx --env-file=.env.local scripts/import-human-descriptions.ts
+ */
+
+import fs from "fs";
+import path from "path";
+import { parse } from "csv-parse/sync";
+import { createClient } from "@supabase/supabase-js";
+import { resolveImageUrl } from "../src/lib/utils";
+
+// ─── Config ───────────────────────────────────────────────────────────────
+const TMP_DIR = path.join(__dirname, "..", "tmp");
+const CSV_PATH =
+  process.env.HUMAN_CSV_PATH ||
+  path.join(TMP_DIR, "CLIR Image Descriptions Sheet - Brief Descriptions.csv");
+
+const TIMESTAMP = new Date().toISOString().replace(/[:.]/g, "-");
+const LOG_FILE = path.join(TMP_DIR, `import-human-descriptions-log_${TIMESTAMP}.csv`);
+const EXPORT_FILE = path.join(TMP_DIR, `descriptions-export_${TIMESTAMP}.csv`);
+
+const SUPABASE_URL =
+  process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error("Error: Set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY");
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+const PAGE_SIZE = 1000;
+
+// ─── Types ────────────────────────────────────────────────────────────────
+interface CsvRow {
+  SKU?: string;
+  "Item Description *"?: string;
+  [key: string]: string | undefined;
+}
+
+interface ArtworkRow {
+  id: string;
+  sku: string | null;
+  inventory_number: string | null;
+  image_url: string | null;
+  image_original: string | null;
+  alt_text: string | null;
+  alt_text_long: string | null;
+  description_origin: "human" | "ai" | null;
+}
+
+interface LogEntry {
+  sku: string;
+  status: "success" | "fail";
+  reason: string;
+  artwork_id: string;
+  prior_alt_text_long: string;
+  new_alt_text_long: string;
+}
+
+interface ExportEntry {
+  sku: string;
+  inventory_number: string;
+  image_url: string;
+  description_origin: string;
+  alt_text_long: string;
+  alt_text: string;
+  prior_ai_alt_text_long: string;
+}
+
+// ─── CSV output helpers ───────────────────────────────────────────────────
+function csvField(value: string | null | undefined): string {
+  if (value === null || value === undefined) return "";
+  const s = String(value);
+  if (/[",\n\r]/.test(s)) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+function writeCsv(filePath: string, columns: string[], rows: Record<string, string>[]): void {
+  const header = columns.join(",");
+  const body = rows.map((r) => columns.map((c) => csvField(r[c])).join(",")).join("\n");
+  fs.writeFileSync(filePath, header + "\n" + body + "\n");
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────
+async function main() {
+  // 1. Parse human CSV
+  if (!fs.existsSync(CSV_PATH)) {
+    console.error(`CSV not found: ${CSV_PATH}`);
+    process.exit(1);
+  }
+  const raw = fs.readFileSync(CSV_PATH, "utf-8");
+  const rows: CsvRow[] = parse(raw, {
+    columns: true,
+    skip_empty_lines: true,
+    relax_quotes: true,
+    relax_column_count: true,
+  });
+  console.log(`Parsed ${rows.length} rows from ${path.basename(CSV_PATH)}`);
+
+  // 2. Build SKU -> description map (last-wins; track duplicates for logging)
+  const skuMap = new Map<string, string>();
+  const duplicateSkus = new Set<string>();
+  for (const row of rows) {
+    const sku = (row.SKU || "").trim();
+    const desc = (row["Item Description *"] || "").trim();
+    if (!sku) continue;
+    if (skuMap.has(sku)) duplicateSkus.add(sku);
+    skuMap.set(sku, desc);
+  }
+  console.log(`Unique SKUs in CSV: ${skuMap.size} (${duplicateSkus.size} duplicates)`);
+
+  // 3. Page through every artwork
+  console.log("Fetching all artworks...");
+  const allArtworks: ArtworkRow[] = [];
+  let offset = 0;
+  while (true) {
+    const { data, error } = await supabase
+      .from("artworks")
+      .select("id, sku, inventory_number, image_url, image_original, alt_text, alt_text_long, description_origin")
+      .order("sku", { ascending: true, nullsFirst: false })
+      .range(offset, offset + PAGE_SIZE - 1);
+    if (error) {
+      console.error("Error fetching artworks:", error);
+      process.exit(1);
+    }
+    if (!data || data.length === 0) break;
+    allArtworks.push(...(data as ArtworkRow[]));
+    if (data.length < PAGE_SIZE) break;
+    offset += PAGE_SIZE;
+  }
+  console.log(`Fetched ${allArtworks.length} artworks`);
+
+  // 4. Process each artwork
+  const logEntries: LogEntry[] = [];
+  const exportEntries: ExportEntry[] = [];
+  const matchedSkus = new Set<string>();
+  let successCount = 0;
+  let failCount = 0;
+
+  for (const art of allArtworks) {
+    const sku = (art.sku || "").trim();
+    const inv = art.inventory_number || "";
+    const priorLong = art.alt_text_long || "";
+    const currentShort = art.alt_text || "";
+    const imageUrl = resolveImageUrl(art) || "";
+
+    if (sku && skuMap.has(sku)) {
+      const desc = skuMap.get(sku)!;
+      matchedSkus.add(sku);
+
+      if (!desc) {
+        logEntries.push({
+          sku, status: "fail", reason: "empty description",
+          artwork_id: art.id,
+          prior_alt_text_long: priorLong,
+          new_alt_text_long: "",
+        });
+        failCount++;
+        exportEntries.push({
+          sku, inventory_number: inv, image_url: imageUrl,
+          description_origin: art.description_origin || "",
+          alt_text_long: priorLong,
+          alt_text: currentShort,
+          prior_ai_alt_text_long: "",
+        });
+        continue;
+      }
+
+      const newLong = desc;
+
+      const { error: updateErr } = await supabase
+        .from("artworks")
+        .update({
+          alt_text_long: newLong,
+          description_origin: "human",
+        })
+        .eq("id", art.id);
+
+      if (updateErr) {
+        logEntries.push({
+          sku, status: "fail", reason: `update error: ${updateErr.message}`,
+          artwork_id: art.id,
+          prior_alt_text_long: priorLong,
+          new_alt_text_long: newLong,
+        });
+        failCount++;
+        exportEntries.push({
+          sku, inventory_number: inv, image_url: imageUrl,
+          description_origin: art.description_origin || "",
+          alt_text_long: priorLong,
+          alt_text: currentShort,
+          prior_ai_alt_text_long: "",
+        });
+        continue;
+      }
+
+      logEntries.push({
+        sku, status: "success", reason: "",
+        artwork_id: art.id,
+        prior_alt_text_long: priorLong,
+        new_alt_text_long: newLong,
+      });
+      successCount++;
+
+      exportEntries.push({
+        sku, inventory_number: inv, image_url: imageUrl,
+        description_origin: "human",
+        alt_text_long: newLong,
+        alt_text: currentShort,
+        prior_ai_alt_text_long: priorLong,
+      });
+    } else {
+      // Not in human CSV - export current state, no prior_ai_alt_text_long
+      exportEntries.push({
+        sku, inventory_number: inv, image_url: imageUrl,
+        description_origin: art.description_origin || "",
+        alt_text_long: priorLong,
+        alt_text: currentShort,
+        prior_ai_alt_text_long: "",
+      });
+    }
+  }
+
+  // 5. Log fails for CSV SKUs that didn't match any DB row
+  for (const sku of skuMap.keys()) {
+    if (!matchedSkus.has(sku)) {
+      logEntries.push({
+        sku, status: "fail", reason: "sku not found in db",
+        artwork_id: "",
+        prior_alt_text_long: "",
+        new_alt_text_long: "",
+      });
+      failCount++;
+    }
+  }
+
+  // 6. Log fails for duplicate SKUs (earlier occurrences superseded by later ones)
+  for (const sku of duplicateSkus) {
+    logEntries.push({
+      sku, status: "fail", reason: "superseded by later row in csv",
+      artwork_id: "",
+      prior_alt_text_long: "",
+      new_alt_text_long: "",
+    });
+  }
+
+  // 7. Write artifacts
+  if (!fs.existsSync(TMP_DIR)) fs.mkdirSync(TMP_DIR, { recursive: true });
+
+  writeCsv(LOG_FILE,
+    ["sku", "status", "reason", "artwork_id", "prior_alt_text_long", "new_alt_text_long"],
+    logEntries
+  );
+
+  writeCsv(EXPORT_FILE,
+    ["sku", "inventory_number", "image_url", "description_origin", "alt_text_long", "alt_text", "prior_ai_alt_text_long"],
+    exportEntries
+  );
+
+  // 8. Summary
+  console.log("\n=== Summary ===");
+  console.log(`Updated:     ${successCount}`);
+  console.log(`Failed:      ${failCount}`);
+  console.log(`Export rows: ${exportEntries.length}`);
+  console.log(`\nLog:    ${LOG_FILE}`);
+  console.log(`Export: ${EXPORT_FILE}`);
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/scripts/migrate-and-describe.ts
+++ b/scripts/migrate-and-describe.ts
@@ -226,7 +226,7 @@ type ArtworkRow = {
   width: number | null;
   image_original: string | null;
   image_url: string | null;
-  ai_description: string | null;
+  alt_text_long: string | null;
   artist: { first_name: string; last_name: string } | null;
 };
 
@@ -241,7 +241,7 @@ async function main() {
     const { data, error } = await supabase
       .from("artworks")
       .select(
-        "id, inventory_number, title, medium, height, width, image_original, image_url, ai_description, artist:artists(first_name, last_name)"
+        "id, inventory_number, title, medium, height, width, image_original, image_url, alt_text_long, artist:artists(first_name, last_name)"
       )
       .not("image_original", "is", null)
       .not("inventory_number", "is", null)
@@ -271,7 +271,7 @@ async function main() {
   const remaining = allArtworks.filter(
     (a) =>
       !imageDoneSet.has(a.inventory_number!) ||
-      (!descDoneSet.has(a.id) && !a.ai_description)
+      (!descDoneSet.has(a.id) && !a.alt_text_long)
   );
 
   console.log(`Total artworks with images: ${allArtworks.length}`);
@@ -292,7 +292,7 @@ async function main() {
   async function processArtwork(artwork: ArtworkRow) {
     const invNum = artwork.inventory_number!;
     const needsImage = !imageDoneSet.has(invNum);
-    const needsDesc = !SKIP_DESCRIPTIONS && !descDoneSet.has(artwork.id) && !artwork.ai_description;
+    const needsDesc = !SKIP_DESCRIPTIONS && !descDoneSet.has(artwork.id) && !artwork.alt_text_long;
 
     // If we only need a description but the image is already migrated,
     // we still need to download the image for Claude Vision
@@ -368,8 +368,9 @@ async function main() {
 
         // Build the DB update — include image_url if we also migrated
         const update: Record<string, string> = {
-          ai_description: desc.description,
+          alt_text_long: desc.description,
           alt_text: desc.alt_text,
+          description_origin: "ai",
         };
         if (newUrl) {
           update.image_url = newUrl;

--- a/src/app/admin/artworks/[id]/page.tsx
+++ b/src/app/admin/artworks/[id]/page.tsx
@@ -34,7 +34,7 @@ export default function EditArtworkPage() {
     depth: "",
     tags: "",
     alt_text: "",
-    ai_description: "",
+    alt_text_long: "",
     on_website: true,
   });
 
@@ -66,7 +66,7 @@ export default function EditArtworkPage() {
             depth: artData.depth?.toString() || "",
             tags: artData.tags?.join(", ") || "",
             alt_text: artData.alt_text || "",
-            ai_description: artData.ai_description || "",
+            alt_text_long: artData.alt_text_long || "",
             on_website: artData.on_website || true,
           });
         }
@@ -113,7 +113,7 @@ export default function EditArtworkPage() {
         depth: formData.depth ? parseFloat(formData.depth) : null,
         tags: parseTags(formData.tags),
         alt_text: formData.alt_text || null,
-        ai_description: formData.ai_description || null,
+        alt_text_long: formData.alt_text_long || null,
         on_website: formData.on_website,
         updated_at: new Date().toISOString(),
       };
@@ -130,15 +130,6 @@ export default function EditArtworkPage() {
       setError(err instanceof Error ? err.message : "Error saving artwork");
     } finally {
       setSaving(false);
-    }
-  };
-
-  const copyAiToAlt = () => {
-    if (formData.ai_description) {
-      setFormData((prev) => ({
-        ...prev,
-        alt_text: prev.ai_description,
-      }));
     }
   };
 
@@ -311,35 +302,25 @@ export default function EditArtworkPage() {
           />
         </div>
 
-        {/* AI Description */}
+        {/* Long alt text - detail page */}
         <div className="mb-6">
-          <div className="flex justify-between items-center mb-2">
-            <label htmlFor="ai_description" className="block text-sm font-bold text-gray-700">
-              AI Description (Suggestion)
-            </label>
-            <button
-              type="button"
-              onClick={copyAiToAlt}
-              disabled={!formData.ai_description}
-              className="text-xs text-blue-600 hover:text-blue-800 disabled:text-gray-400"
-            >
-              Copy to Alt Text
-            </button>
-          </div>
+          <label htmlFor="alt_text_long" className="block text-sm font-bold text-gray-700 mb-2">
+            Long alt text (detail page)
+          </label>
           <textarea
-            id="ai_description"
-            name="ai_description"
-            value={formData.ai_description}
+            id="alt_text_long"
+            name="alt_text_long"
+            value={formData.alt_text_long}
             onChange={handleChange}
             rows={4}
             className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
         </div>
 
-        {/* Alt Text */}
+        {/* Short alt text - grid page */}
         <div className="mb-6">
           <label htmlFor="alt_text" className="block text-sm font-bold text-gray-700 mb-2">
-            Alt Text (for accessibility)
+            Short alt text (grid page)
           </label>
           <textarea
             id="alt_text"

--- a/src/app/artwork/[id]/page.tsx
+++ b/src/app/artwork/[id]/page.tsx
@@ -119,7 +119,7 @@ export default async function ArtworkPage({ params }: ArtworkPageProps) {
     artwork.artist_id &&
     (await getArtistArtworks(artwork.artist_id, artwork.id));
 
-  const altText = getAltText(artwork);
+  const altText = artwork.alt_text_long || getAltText(artwork);
   const imageUrl = resolveImageUrl(artwork);
   const artistName = artwork.artist
     ? formatArtistName(artwork.artist.first_name, artwork.artist.last_name)
@@ -269,18 +269,6 @@ export default async function ArtworkPage({ params }: ArtworkPageProps) {
           <DownloadButton artworkId={artwork.id} title={artwork.title} />
         </div>
       </div>
-
-      {/* Description */}
-      {artwork.ai_description && (
-        <section className="mt-12 pt-12 border-t border-gray-200 max-w-2xl">
-          <h2 className="font-serif text-2xl font-bold text-gray-900 mb-4">
-            About This Work
-          </h2>
-          <p className="text-gray-700 leading-relaxed">
-            {artwork.ai_description}
-          </p>
-        </section>
-      )}
 
       {/* More by Artist */}
       {moreArtworks && moreArtworks.length > 0 && (

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -32,10 +32,12 @@ export interface Artwork {
   width: number | null;
   depth: number | null;
   inventory_number: string | null;
+  sku: string | null;
   image_url: string | null;
   image_original: string | null;
-  ai_description: string | null;
   alt_text: string | null;
+  alt_text_long: string | null;
+  description_origin: "human" | "ai" | null;
   tags: string[] | null;
   genre: string | null;
   notes: string | null;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -82,17 +82,18 @@ export function resolveImageUrl(artwork: {
 }
 
 /**
- * Get the effective alt text for an artwork (admin-edited takes priority).
+ * Get the short alt text for an artwork. Used in <img alt> on grid pages.
+ * Does NOT fall back to alt_text_long — that field is for the detail page,
+ * where dumping a paragraph into the alt attribute would force screen-reader
+ * users through a long announcement on every grid card. See
+ * docs/superpowers/specs/2026-04-23-human-descriptions-import-design.md.
  */
 export function getAltText(artwork: {
   alt_text: string | null;
-  ai_description: string | null;
   title: string;
   medium: string | null;
 }): string {
   if (artwork.alt_text) return artwork.alt_text;
-  if (artwork.ai_description) return artwork.ai_description;
-  // Fallback: title + medium
   const parts = [artwork.title];
   if (artwork.medium) parts.push(artwork.medium);
   return parts.join(". ");

--- a/supabase/migrations/001_initial.sql
+++ b/supabase/migrations/001_initial.sql
@@ -41,9 +41,12 @@ CREATE TABLE artworks (
   image_url         TEXT,
   image_original    TEXT,
 
-  -- AI-generated accessibility content
-  ai_description    TEXT,
+  -- Accessibility alt text. alt_text_long is for <img alt> on the artwork
+  -- detail page; alt_text is the short form for grid pages.
   alt_text          TEXT,
+  alt_text_long     TEXT,
+  description_origin TEXT CHECK (description_origin IN ('human', 'ai')),
+  sku               TEXT,
 
   -- Metadata
   tags              TEXT[],
@@ -59,6 +62,7 @@ CREATE TABLE artworks (
 CREATE INDEX idx_artworks_artist ON artworks(artist_id);
 CREATE INDEX idx_artworks_tags ON artworks USING GIN(tags);
 CREATE INDEX idx_artworks_inventory ON artworks(inventory_number);
+CREATE INDEX idx_artworks_sku ON artworks(sku);
 
 CREATE TABLE artwork_categories (
   artwork_id   UUID REFERENCES artworks(id) ON DELETE CASCADE,
@@ -172,7 +176,7 @@ ALTER TABLE artworks ADD COLUMN IF NOT EXISTS fts tsvector
     setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
     setweight(to_tsvector('english', coalesce(medium, '')), 'B') ||
     setweight(to_tsvector('english', coalesce(alt_text, '')), 'C') ||
-    setweight(to_tsvector('english', coalesce(ai_description, '')), 'D')
+    setweight(to_tsvector('english', coalesce(alt_text_long, '')), 'D')
   ) STORED;
 
 CREATE INDEX idx_artworks_fts ON artworks USING GIN(fts);


### PR DESCRIPTION
## Summary

Three logically-distinct commits, sequenced because they build on each other:

1. **Add `sku` as a first-class field** (commit `b70f3c7`) — the original Art Cloud import only mapped `Inventory Number` (numeric ID), not the artist-coded `SKU` column (e.g., `RB 25`, `CLIR2022.25`). The human descriptions CSV keys on SKU, so we add the column, backfill from `inventory_2026-04-02.csv` (2,111 of 2,112 DB rows populated), and update `import-csv.ts` to keep the field populated on future imports. Index added; no UNIQUE constraint because the source has 2 legitimate duplicates.

2. **Import human descriptions** (commit `3c5437b`) — `scripts/import-human-descriptions.ts` reads `tmp/CLIR Image Descriptions Sheet - Brief Descriptions.csv` and updates matched rows: `alt_text_long` ← human paragraph, `description_origin` ← `'human'`. The short `alt_text` is intentionally NOT touched. Two timestamped artifacts land in `tmp/`: a per-row update log with prior values, and a full-catalog export with prior-AI snapshots so Creative Growth can compare AI vs. human side-by-side.

3. **Rename `ai_description` → `alt_text_long` across UI and scripts** (commit `1750046`) — schema migration was applied manually before the import; this commit catches the codebase up. Bundles three accessibility cleanups: `getAltText()` no longer falls back to the long form (preventing paragraph-length grid alts), the misleading "About This Work" section is removed from the artwork detail page, and admin form labels reflect the two fields' actual purposes.

## Run results

- **Backfill:** 2,111 of 2,112 artworks got SKU populated (1 row in source has no inventory number)
- **Import:** 89 artworks got human descriptions; 381 CSV rows had blank descriptions (CG started but didn't fill in); 325 unique SKUs in CSV don't exist in the CLIR catalog at all (likely a separate inventory or typos for CG to triage); 15 SKU duplicates within the CSV resolved last-wins

## Spec & plan

- Spec: `docs/superpowers/specs/2026-04-23-human-descriptions-import-design.md`
- Plan: `docs/superpowers/plans/2026-04-23-human-descriptions-import.md`

## Test plan

- [ ] On the deployed branch, visit `/collection` and verify grid alts are short (≤150 chars, drawn from `alt_text`)
- [ ] Visit a known human-described artwork's detail page (e.g., SKU `RB 25` at `/artwork/388be60d-ede3-4ab1-9c1c-ecdcfaf677e9`) and verify the `<img alt>` is the full human paragraph
- [ ] Confirm "About This Work" section no longer appears on the detail page
- [ ] Open `tmp/descriptions-export_*.csv` (gitignored) and spot-check 5 human-overwritten rows: `prior_ai_alt_text_long` populated, `description_origin = 'human'`, `alt_text_long` matches the CSV input
- [ ] Visit `/admin/artworks/<id>` and verify the form has two independent textareas labeled "Long alt text (detail page)" and "Short alt text (grid page)" with no copy button between them
- [ ] Visit `/review.html` and confirm it loads and renders the renamed `alt_text_long` field