### PR TITLE
Add image caption + Visual description to artwork detail page

### DIFF
--- a/TECH_INVESTMENTS.md
+++ b/TECH_INVESTMENTS.md
@@ -1,0 +1,27 @@
+# Future Tech Investments
+
+Things worth adding to our tooling and infrastructure that we haven't prioritized yet. Distinct from `TECH_DEBT.md` (which catalogs shortcuts already taken) — this file is for "things we'd benefit from building" that someone has flagged as potentially valuable.
+
+---
+
+## TI-001: Playwright test infrastructure for the public site
+
+**Priority:** Medium
+**Added:** 2026-04-23
+
+The project already depends on `playwright` (currently used by `scripts/scrape-bios.ts` for headless scraping), but has no test suite. UI changes are currently verified by ad-hoc curl smoke tests during PR review — useful for one-off checks, but they don't run on every change and don't catch regressions when someone refactors a conditional or restructures a layout.
+
+**What we'd build:**
+- Playwright test config + an npm test script
+- A small fixture / seed-data strategy. Simplest start: hit real Supabase with read-only assertions against known stable SKUs (e.g., `RB 25` for human-described, `JS 5` for AI-described). If staging diverges from prod we can revisit.
+- Initial coverage suggestions:
+  - Artwork detail page: `<figure>` + visible `<figcaption>` present, `<img alt>` is the short form
+  - Artwork detail page: "Visual description" metadata renders only when `description_origin === 'human'`
+  - Artwork detail page: Tags and Inventory Number do not appear in metadata
+  - Collection grid: image alts are ≤150 chars (no paragraph dumps)
+  - Search page returns results for a known query
+- Optionally: wire into CI so PRs surface test runs automatically
+
+**Why it'd pay off:** as the gallery grows more conditional UI (storytelling section, admin workflows, additional metadata fields), the cost of silent regressions rises. The figcaption + conditional metadata pattern landed in PR for `feat/artwork-detail-captions` is exactly the kind of thing that breaks silently if the conditional gets restructured.
+
+**Workaround for now:** ad-hoc smoke tests during PRs (curl + grep, dev-server-in-browser).

--- a/src/app/artwork/[id]/page.tsx
+++ b/src/app/artwork/[id]/page.tsx
@@ -119,7 +119,7 @@ export default async function ArtworkPage({ params }: ArtworkPageProps) {
     artwork.artist_id &&
     (await getArtistArtworks(artwork.artist_id, artwork.id));
 
-  const altText = artwork.alt_text_long || getAltText(artwork);
+  const altText = getAltText(artwork);
   const imageUrl = resolveImageUrl(artwork);
   const artistName = artwork.artist
     ? formatArtistName(artwork.artist.first_name, artwork.artist.last_name)
@@ -158,21 +158,28 @@ export default async function ArtworkPage({ params }: ArtworkPageProps) {
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-12">
         {/* Image */}
         <div className="lg:col-span-2">
-          <div className="bg-gray-100 aspect-square relative mb-4">
-            {imageUrl ? (
-              <Image
-                src={imageUrl}
-                alt={altText}
-                fill
-                className="object-cover"
-                priority
-              />
-            ) : (
-              <div className="w-full h-full flex items-center justify-center text-gray-400">
-                No image available
-              </div>
+          <figure>
+            <div className="bg-gray-100 aspect-square relative mb-3">
+              {imageUrl ? (
+                <Image
+                  src={imageUrl}
+                  alt={altText}
+                  fill
+                  className="object-cover"
+                  priority
+                />
+              ) : (
+                <div className="w-full h-full flex items-center justify-center text-gray-400">
+                  No image available
+                </div>
+              )}
+            </div>
+            {artwork.alt_text && (
+              <figcaption className="text-sm text-gray-600 italic">
+                {artwork.alt_text}
+              </figcaption>
             )}
-          </div>
+          </figure>
         </div>
 
         {/* Metadata */}
@@ -217,17 +224,6 @@ export default async function ArtworkPage({ params }: ArtworkPageProps) {
               </div>
             )}
 
-            {artwork.inventory_number && (
-              <div>
-                <dt className="text-sm font-semibold text-gray-600">
-                  Inventory Number
-                </dt>
-                <dd className="text-gray-900 font-mono">
-                  {artwork.inventory_number}
-                </dd>
-              </div>
-            )}
-
             {artwork.categories && artwork.categories.length > 0 && (
               <div>
                 <dt className="text-sm font-semibold text-gray-600">
@@ -247,19 +243,13 @@ export default async function ArtworkPage({ params }: ArtworkPageProps) {
               </div>
             )}
 
-            {artwork.tags && artwork.tags.length > 0 && (
+            {artwork.description_origin === "human" && artwork.alt_text_long && (
               <div>
-                <dt className="text-sm font-semibold text-gray-600">Tags</dt>
-                <dd className="flex flex-wrap gap-2">
-                  {artwork.tags.map((tag: string) => (
-                    <Link
-                      key={tag}
-                      href={`/collection?tag=${encodeURIComponent(tag)}`}
-                      className="text-xs bg-gray-100 hover:bg-gray-200 px-2 py-1 rounded transition-colors"
-                    >
-                      {tag}
-                    </Link>
-                  ))}
+                <dt className="text-sm font-semibold text-gray-600">
+                  Visual description
+                </dt>
+                <dd className="text-gray-900 leading-relaxed">
+                  {artwork.alt_text_long}
                 </dd>
               </div>
             )}


### PR DESCRIPTION
## Summary

- Wrap the artwork image in `<figure>` with a visible `<figcaption>` showing the short `alt_text`. Sighted users get a concise visual identifier; screen-reader users hear the alt attribute on encountering the image and the same text again as the caption.
- Switch the `<img alt>` on the detail page from the long form to `alt_text` (short). The long form is now rendered as visible text in the new "Visual description" metadata block, so duplicating it into the alt attribute would force screen-reader users through the same content twice.
- Add a "Visual description" metadata field below Categories, populated from `alt_text_long`. Conditional on `description_origin === 'human'` so we only surface human-vetted long descriptions on the public detail page; AI descriptions stay invisible until reviewed.
- Adopt the museum-a11y-standard label "Visual description" (Cooper Hewitt, Whitney, Smithsonian convention) so it reads as "what the image literally depicts" rather than artistic/historical commentary.
- Remove Tags and Inventory Number from the metadata section.
- Add `TECH_INVESTMENTS.md` (sibling to `TECH_DEBT.md`) with TI-001 capturing the case for adopting Playwright as a test runner — separate PR.

## Test plan

- [ ] Visit `/artwork/<id>` for a human-described work (e.g., SKU `RB 25` → `/artwork/388be60d-ede3-4ab1-9c1c-ecdcfaf677e9`):
  - Image has a visible italicized caption beneath it (the short alt)
  - Metadata section has Date, Medium, Dimensions, Categories, **Visual description** (in that order)
  - Visual description content is the full human paragraph
  - No Tags or Inventory Number rows
- [ ] Visit `/artwork/<id>` for an AI-described work (e.g., SKU `JS 5` → `/artwork/ecbf6ea3-06f5-44df-9eed-f89146a63f1e`):
  - Same caption + metadata structure
  - **No** Visual description row (since `description_origin = 'ai'`)
- [ ] Inspect element on the image: `<img alt>` is the short alt_text, not the long paragraph
- [ ] Spot-check one other detail page to confirm layout doesn't break with edge cases (no medium, no categories, etc.)