### PR TITLE
Catalog triage report: per-artwork, per-artist, tag-frequency CSVs

### DIFF
--- a/docs/superpowers/plans/2026-04-24-catalog-triage-report.md
+++ b/docs/superpowers/plans/2026-04-24-catalog-triage-report.md
@@ -1,0 +1,773 @@
+# Catalog Triage Report Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Produce three timestamped CSVs (per-artwork audit, per-artist summary, tag-frequency comparison) that let Creative Growth triage the artworks DB by comparing two source datasets — `MC APR 2` (the original Art Cloud export) and `1stdibs_clir_picks_2026-03-17` (the curated picks).
+
+**Architecture:** A single read-only `tsx` script that parses both source CSVs into in-memory sets, pages through the DB once for full artwork+artist+theme-count data, computes per-artwork classification + per-artist + per-tag aggregates in memory, and writes three CSVs to `tmp/`. No DB writes, no concurrency, no checkpointing — runtime under a minute on the current ~3,260-row catalog.
+
+**Tech Stack:** TypeScript, Node 20+, `tsx`, `csv-parse/sync`, `@supabase/supabase-js`, Node's built-in `node:test`.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-24-catalog-triage-report-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- `src/lib/dates.ts` — pure utility `extractYear(raw: string | null): number | null`. Lives in `src/lib/` because Project B's decade-dropdown UI will need the same parsing logic.
+- `scripts/test-dates.ts` — `node:test` assertions for `extractYear`.
+- `scripts/catalog-triage-report.ts` — main script.
+
+**Modified files:**
+- `package.json` — add `triage:report` npm script.
+
+---
+
+## Phase 0: Pre-flight
+
+### Task 0: Confirm DB has the expected shape
+
+**Files:** none (read-only verification)
+
+- [ ] **Step 1: Check artworks columns + at least one theme row**
+
+Run:
+```bash
+npx tsx --env-file=.env.local -e "
+import { createClient } from '@supabase/supabase-js';
+const c = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+Promise.all([
+  c.from('artworks').select('id, sku, image_url, description_origin, on_website, tags, date_created, medium, title').limit(1),
+  c.from('categories').select('id', { count: 'exact', head: true }).eq('kind', 'theme'),
+]).then(([a, t]) => {
+  if (a.error || t.error) { console.error(a.error || t.error); process.exit(1); }
+  console.log('OK - artworks columns:', Object.keys(a.data[0]));
+  console.log('OK - theme categories:', t.count);
+});
+"
+```
+
+Expected: prints both artwork columns (must include `sku`, `image_url`, `description_origin`, `on_website`, `tags`) and a non-zero theme category count (should be 8 from the prior PR).
+
+- [ ] **Step 2: Check both source CSVs are readable**
+
+Run:
+```bash
+ls -la inventory_2026-04-02.csv "tmp/ADD TAGS TO CREATIVE GROWTH PUBLIC ARCHIVE - 1stdibs_clir_picks_2026-03-17.csv"
+```
+
+Expected: both files listed with non-zero size.
+
+If either is missing, stop and report.
+
+---
+
+## Phase 1: Code
+
+### Task 1: TDD year extractor — failing tests first
+
+**Files:**
+- Create: `scripts/test-dates.ts`
+
+- [ ] **Step 1: Write the test file**
+
+Create `scripts/test-dates.ts`:
+
+```typescript
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { extractYear } from "../src/lib/dates";
+
+test("returns null for null input", () => {
+  assert.equal(extractYear(null), null);
+});
+
+test("returns null for empty string", () => {
+  assert.equal(extractYear(""), null);
+  assert.equal(extractYear("   "), null);
+});
+
+test("returns null for 'ND' (no date)", () => {
+  assert.equal(extractYear("ND"), null);
+  assert.equal(extractYear("nd"), null);
+});
+
+test("parses a four-digit year", () => {
+  assert.equal(extractYear("1992"), 1992);
+});
+
+test("parses a four-digit year with surrounding whitespace", () => {
+  assert.equal(extractYear("  2007  "), 2007);
+});
+
+test("parses a year out of a M/D/YYYY date", () => {
+  assert.equal(extractYear("7/20/1987"), 1987);
+});
+
+test("parses a year out of an ISO date", () => {
+  assert.equal(extractYear("1987-07-20"), 1987);
+});
+
+test("parses a year out of a circa string", () => {
+  assert.equal(extractYear("c. 1990"), 1990);
+  assert.equal(extractYear("circa 2003"), 2003);
+});
+
+test("parses a year out of a decade-style string by taking the first valid year", () => {
+  assert.equal(extractYear("1990s"), 1990);
+});
+
+test("returns null when no four-digit year is present", () => {
+  assert.equal(extractYear("nineteen ninety"), null);
+  assert.equal(extractYear("?"), null);
+});
+
+test("rejects implausibly small or large years (< 1900 or > current year + 1)", () => {
+  assert.equal(extractYear("0042"), null);
+  assert.equal(extractYear("1850"), null);
+  assert.equal(extractYear("9999"), null);
+});
+
+test("takes the first 4-digit year if multiple are present", () => {
+  assert.equal(extractYear("1985-1990"), 1985);
+});
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `npx tsx --test scripts/test-dates.ts`
+Expected: All tests fail with `Error: Cannot find module '../src/lib/dates'`.
+
+---
+
+### Task 2: Implement year extractor
+
+**Files:**
+- Create: `src/lib/dates.ts`
+
+- [ ] **Step 1: Write the implementation**
+
+Create `src/lib/dates.ts`:
+
+```typescript
+/**
+ * Date parsing utilities for the artworks catalog.
+ *
+ * Source dates come from the Art Cloud CSVs as free-form strings:
+ * "1992", "ND", "c. 1990", "7/20/1987", "1985-1990", etc. We need
+ * to derive a year for the decade dropdown (Project B) and the
+ * triage report's date_range aggregation (this PR).
+ */
+
+const MIN_PLAUSIBLE_YEAR = 1900;
+const MAX_PLAUSIBLE_YEAR = new Date().getFullYear() + 1;
+
+/**
+ * Extract a four-digit year from a free-form date string.
+ *
+ * Rules:
+ * - Returns null for null, empty, "ND" (case-insensitive), or any
+ *   string with no four-digit substring.
+ * - Returns the FIRST four-digit year found in the string.
+ * - Years outside [MIN_PLAUSIBLE_YEAR, MAX_PLAUSIBLE_YEAR] are
+ *   rejected as null (filters out things like "0042" or accidental
+ *   inventory numbers that look like years).
+ */
+export function extractYear(raw: string | null): number | null {
+  if (raw === null) return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  if (trimmed.toLowerCase() === "nd") return null;
+
+  const match = trimmed.match(/\d{4}/);
+  if (!match) return null;
+
+  const year = parseInt(match[0], 10);
+  if (year < MIN_PLAUSIBLE_YEAR || year > MAX_PLAUSIBLE_YEAR) return null;
+  return year;
+}
+```
+
+- [ ] **Step 2: Run the tests and verify they pass**
+
+Run: `npx tsx --test scripts/test-dates.ts`
+Expected: All 12 tests pass.
+
+---
+
+### Task 3: Implement the triage report script
+
+**Files:**
+- Create: `scripts/catalog-triage-report.ts`
+
+- [ ] **Step 1: Write the script**
+
+Create `scripts/catalog-triage-report.ts`:
+
+```typescript
+#!/usr/bin/env npx tsx
+/**
+ * catalog-triage-report.ts
+ *
+ * Read-only audit of the artworks catalog. Compares two source
+ * datasets — MC APR 2 (inventory_2026-04-02.csv, the original Art
+ * Cloud export) and 1stdibs_clir_picks_2026-03-17 (the curated
+ * picks) — and produces three CSVs in tmp/:
+ *
+ *   1. triage-per-artwork_<ts>.csv   one row per DB artwork
+ *   2. triage-per-artist_<ts>.csv    one row per artist
+ *   3. triage-tag-frequency_<ts>.csv one row per distinct tag
+ *
+ * Spec: docs/superpowers/specs/2026-04-24-catalog-triage-report-design.md
+ *
+ * Run: npx tsx --env-file=.env.local scripts/catalog-triage-report.ts
+ */
+
+import fs from "fs";
+import path from "path";
+import { parse } from "csv-parse/sync";
+import { createClient } from "@supabase/supabase-js";
+import { extractYear } from "../src/lib/dates";
+
+// ─── Config ───────────────────────────────────────────────────────────────
+const TMP_DIR = path.join(__dirname, "..", "tmp");
+const MC_APR_2_PATH = path.join(__dirname, "..", "inventory_2026-04-02.csv");
+const ONESTDIBS_PATH = path.join(
+  TMP_DIR,
+  "ADD TAGS TO CREATIVE GROWTH PUBLIC ARCHIVE - 1stdibs_clir_picks_2026-03-17.csv"
+);
+
+const TIMESTAMP = new Date().toISOString().replace(/[:.]/g, "-");
+const PER_ARTWORK_FILE = path.join(TMP_DIR, `triage-per-artwork_${TIMESTAMP}.csv`);
+const PER_ARTIST_FILE = path.join(TMP_DIR, `triage-per-artist_${TIMESTAMP}.csv`);
+const TAG_FREQ_FILE = path.join(TMP_DIR, `triage-tag-frequency_${TIMESTAMP}.csv`);
+
+const SUPABASE_URL =
+  process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error("Error: Set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY");
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+const PAGE_SIZE = 1000;
+
+// ─── Types ────────────────────────────────────────────────────────────────
+interface ArtworkRow {
+  id: string;
+  sku: string | null;
+  title: string;
+  medium: string | null;
+  date_created: string | null;
+  image_url: string | null;
+  description_origin: "human" | "ai" | null;
+  on_website: boolean;
+  tags: string[] | null;
+  artist: { first_name: string; last_name: string } | null;
+  categories: { category: { kind: string | null } | null }[] | null;
+}
+
+type Bucket = "both" | "mc_apr_2_only" | "1stdibs_only" | "unknown_source";
+
+interface PerArtworkRow {
+  sku: string;
+  artist: string;
+  title: string;
+  medium: string;
+  date_created: string;
+  bucket: Bucket;
+  image_state: "r2" | "artcld" | "null";
+  recovery_source: string;
+  recovery_url: string;
+  description_origin: string;
+  theme_count: string;
+  tag_count: string;
+  tags: string;
+  on_website: string;
+}
+
+interface PerArtistRow {
+  artist: string;
+  total_artworks: string;
+  mc_apr_2_count: string;
+  "1stdibs_count": string;
+  both_count: string;
+  mc_apr_2_only_count: string;
+  mediums: string;
+  date_range: string;
+  null_image_count: string;
+  top_tags: string;
+}
+
+interface TagFreqRow {
+  tag: string;
+  total_count: string;
+  mc_apr_2_only_count: string;
+  "1stdibs_count": string;
+  signal_ratio: string;
+}
+
+// ─── CSV helpers ──────────────────────────────────────────────────────────
+function csvField(value: string | null | undefined): string {
+  if (value === null || value === undefined) return "";
+  const s = String(value);
+  if (/[",\n\r]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+  return s;
+}
+
+function writeCsv(filePath: string, columns: string[], rows: Record<string, string>[]): void {
+  const header = columns.join(",");
+  const body = rows.map((r) => columns.map((c) => csvField(r[c])).join(",")).join("\n");
+  fs.writeFileSync(filePath, header + "\n" + body + "\n");
+}
+
+// ─── Source-CSV parsing ───────────────────────────────────────────────────
+function loadMcApr2Skus(): Set<string> {
+  if (!fs.existsSync(MC_APR_2_PATH)) {
+    console.error(`MC APR 2 CSV not found: ${MC_APR_2_PATH}`);
+    process.exit(1);
+  }
+  const rows = parse(fs.readFileSync(MC_APR_2_PATH, "utf-8"), {
+    columns: true,
+    skip_empty_lines: true,
+    relax_quotes: true,
+    relax_column_count: true,
+  }) as { SKU?: string }[];
+  const skus = new Set<string>();
+  for (const r of rows) {
+    const sku = (r.SKU || "").trim();
+    if (sku) skus.add(sku);
+  }
+  return skus;
+}
+
+function load1stdibsSkuMap(): Map<string, string> {
+  if (!fs.existsSync(ONESTDIBS_PATH)) {
+    console.error(`1stdibs picks CSV not found: ${ONESTDIBS_PATH}`);
+    process.exit(1);
+  }
+  const rows = parse(fs.readFileSync(ONESTDIBS_PATH, "utf-8"), {
+    columns: true,
+    skip_empty_lines: true,
+    relax_quotes: true,
+    relax_column_count: true,
+  }) as { SKU?: string; "Link 1"?: string }[];
+  const map = new Map<string, string>();
+  for (const r of rows) {
+    const sku = (r.SKU || "").trim();
+    const link = (r["Link 1"] || "").trim();
+    if (sku) map.set(sku, link);
+  }
+  return map;
+}
+
+// ─── Image-state classification ───────────────────────────────────────────
+function classifyImage(url: string | null): "r2" | "artcld" | "null" {
+  if (!url) return "null";
+  if (url.includes("artcld.com")) return "artcld";
+  return "r2"; // any non-null, non-artcld URL is treated as R2 / R2-relative
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────
+async function main() {
+  console.log("Loading source CSVs...");
+  const mcApr2 = loadMcApr2Skus();
+  const onestdibs = load1stdibsSkuMap();
+  console.log(`  MC APR 2: ${mcApr2.size} unique SKUs`);
+  console.log(`  1stdibs:  ${onestdibs.size} unique SKUs`);
+
+  console.log("Fetching artworks from DB...");
+  const artworks: ArtworkRow[] = [];
+  let offset = 0;
+  while (true) {
+    const { data, error } = await supabase
+      .from("artworks")
+      .select(`
+        id, sku, title, medium, date_created, image_url,
+        description_origin, on_website, tags,
+        artist:artists(first_name, last_name),
+        categories:artwork_categories(category:categories(kind))
+      `)
+      .order("sku", { ascending: true, nullsFirst: false })
+      .range(offset, offset + PAGE_SIZE - 1);
+    if (error) {
+      console.error("Error fetching artworks:", error);
+      process.exit(1);
+    }
+    if (!data || data.length === 0) break;
+    artworks.push(...(data as unknown as ArtworkRow[]));
+    if (data.length < PAGE_SIZE) break;
+    offset += PAGE_SIZE;
+  }
+  console.log(`  ${artworks.length} artworks fetched`);
+
+  // ── Per-artwork rows ────────────────────────────────────────────────────
+  let unknownSourceCount = 0;
+  const perArtwork: PerArtworkRow[] = [];
+  for (const a of artworks) {
+    const sku = (a.sku || "").trim();
+    const inMc = sku && mcApr2.has(sku);
+    const inOd = sku && onestdibs.has(sku);
+
+    let bucket: Bucket;
+    if (inMc && inOd) bucket = "both";
+    else if (inMc) bucket = "mc_apr_2_only";
+    else if (inOd) bucket = "1stdibs_only";
+    else { bucket = "unknown_source"; unknownSourceCount++; }
+
+    const imageState = classifyImage(a.image_url);
+    const recovery_source =
+      imageState === "null" && inOd && onestdibs.get(sku) ? "1stdibs_link_1_available" : "";
+    const recovery_url =
+      recovery_source === "1stdibs_link_1_available" ? (onestdibs.get(sku) || "") : "";
+
+    const themeCount = (a.categories || []).filter((c) => c.category?.kind === "theme").length;
+    const tagCount = (a.tags || []).length;
+
+    const artistName = a.artist
+      ? `${a.artist.first_name} ${a.artist.last_name}`.trim() || "Unknown"
+      : "Unknown";
+
+    perArtwork.push({
+      sku,
+      artist: artistName,
+      title: a.title || "",
+      medium: a.medium || "",
+      date_created: a.date_created || "",
+      bucket,
+      image_state: imageState,
+      recovery_source,
+      recovery_url,
+      description_origin: a.description_origin || "",
+      theme_count: String(themeCount),
+      tag_count: String(tagCount),
+      tags: (a.tags || []).join("; "),
+      on_website: a.on_website ? "true" : "false",
+    });
+  }
+
+  // Sort: artist, then sku
+  perArtwork.sort((x, y) => {
+    if (x.artist !== y.artist) return x.artist.localeCompare(y.artist);
+    return x.sku.localeCompare(y.sku);
+  });
+
+  // ── Per-artist aggregation ──────────────────────────────────────────────
+  interface ArtistAgg {
+    artist: string;
+    total: number;
+    inMc: number;
+    inOd: number;
+    inBoth: number;
+    mcOnly: number;
+    mediums: Set<string>;
+    years: number[];
+    nullImages: number;
+    tagCounts: Map<string, number>;
+  }
+  const byArtist = new Map<string, ArtistAgg>();
+  for (const r of perArtwork) {
+    const agg = byArtist.get(r.artist) || {
+      artist: r.artist, total: 0, inMc: 0, inOd: 0, inBoth: 0, mcOnly: 0,
+      mediums: new Set(), years: [], nullImages: 0, tagCounts: new Map(),
+    };
+    agg.total++;
+    if (r.bucket === "both") { agg.inMc++; agg.inOd++; agg.inBoth++; }
+    else if (r.bucket === "mc_apr_2_only") { agg.inMc++; agg.mcOnly++; }
+    else if (r.bucket === "1stdibs_only") { agg.inOd++; }
+    if (r.medium) agg.mediums.add(r.medium.toLowerCase().trim());
+    const y = extractYear(r.date_created);
+    if (y !== null) agg.years.push(y);
+    if (r.image_state === "null") agg.nullImages++;
+    if (r.tags) {
+      for (const t of r.tags.split(";").map((s) => s.trim().toLowerCase()).filter(Boolean)) {
+        agg.tagCounts.set(t, (agg.tagCounts.get(t) || 0) + 1);
+      }
+    }
+    byArtist.set(r.artist, agg);
+  }
+
+  const perArtist: PerArtistRow[] = [...byArtist.values()]
+    .sort((a, b) => b.total - a.total)
+    .map((agg) => {
+      const dateRange = agg.years.length > 0
+        ? `${Math.min(...agg.years)}–${Math.max(...agg.years)}`
+        : "";
+      const topTags = [...agg.tagCounts.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 5)
+        .map(([t]) => t)
+        .join(", ");
+      return {
+        artist: agg.artist,
+        total_artworks: String(agg.total),
+        mc_apr_2_count: String(agg.inMc),
+        "1stdibs_count": String(agg.inOd),
+        both_count: String(agg.inBoth),
+        mc_apr_2_only_count: String(agg.mcOnly),
+        mediums: [...agg.mediums].sort().join(", "),
+        date_range: dateRange,
+        null_image_count: String(agg.nullImages),
+        top_tags: topTags,
+      };
+    });
+
+  // ── Tag frequency ───────────────────────────────────────────────────────
+  interface TagAgg {
+    tag: string;
+    total: number;
+    mcOnly: number;
+    inOd: number;
+  }
+  const byTag = new Map<string, TagAgg>();
+  for (const r of perArtwork) {
+    if (!r.tags) continue;
+    const tags = r.tags.split(";").map((s) => s.trim().toLowerCase()).filter(Boolean);
+    const seen = new Set<string>(); // dedup tags within a single artwork's tag list
+    for (const t of tags) {
+      if (seen.has(t)) continue;
+      seen.add(t);
+      const agg = byTag.get(t) || { tag: t, total: 0, mcOnly: 0, inOd: 0 };
+      agg.total++;
+      if (r.bucket === "mc_apr_2_only") agg.mcOnly++;
+      if (r.bucket === "both" || r.bucket === "1stdibs_only") agg.inOd++;
+      byTag.set(t, agg);
+    }
+  }
+
+  const tagFreq: TagFreqRow[] = [...byTag.values()]
+    .map((agg) => ({
+      tag: agg.tag,
+      total_count: String(agg.total),
+      mc_apr_2_only_count: String(agg.mcOnly),
+      "1stdibs_count": String(agg.inOd),
+      signal_ratio: agg.total > 0 ? (agg.mcOnly / agg.total).toFixed(2) : "0.00",
+    }))
+    .sort((a, b) => parseFloat(b.signal_ratio) - parseFloat(a.signal_ratio));
+
+  // ── Write outputs ───────────────────────────────────────────────────────
+  if (!fs.existsSync(TMP_DIR)) fs.mkdirSync(TMP_DIR, { recursive: true });
+
+  writeCsv(PER_ARTWORK_FILE,
+    ["sku", "artist", "title", "medium", "date_created", "bucket", "image_state",
+     "recovery_source", "recovery_url", "description_origin", "theme_count",
+     "tag_count", "tags", "on_website"],
+    perArtwork
+  );
+  writeCsv(PER_ARTIST_FILE,
+    ["artist", "total_artworks", "mc_apr_2_count", "1stdibs_count", "both_count",
+     "mc_apr_2_only_count", "mediums", "date_range", "null_image_count", "top_tags"],
+    perArtist
+  );
+  writeCsv(TAG_FREQ_FILE,
+    ["tag", "total_count", "mc_apr_2_only_count", "1stdibs_count", "signal_ratio"],
+    tagFreq
+  );
+
+  // ── Summary ─────────────────────────────────────────────────────────────
+  const byBucket = perArtwork.reduce<Record<string, number>>((acc, r) => {
+    acc[r.bucket] = (acc[r.bucket] || 0) + 1;
+    return acc;
+  }, {});
+  console.log("\n=== Summary ===");
+  console.log(`Per-artwork rows: ${perArtwork.length}`);
+  Object.entries(byBucket).forEach(([k, v]) => console.log(`  ${k.padEnd(18)} ${v}`));
+  console.log(`Per-artist rows:  ${perArtist.length}`);
+  console.log(`Tag-freq rows:    ${tagFreq.length}`);
+  if (unknownSourceCount > 0) {
+    console.log(`\nWARNING: ${unknownSourceCount} artworks in DB but in neither source CSV (bucket='unknown_source'). Investigate.`);
+  }
+  console.log(`\nPer-artwork: ${PER_ARTWORK_FILE}`);
+  console.log(`Per-artist:  ${PER_ARTIST_FILE}`);
+  console.log(`Tag-freq:    ${TAG_FREQ_FILE}`);
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 2: Confirm the script's modules resolve**
+
+Run:
+```bash
+npx tsx scripts/catalog-triage-report.ts 2>&1 | head -3
+```
+
+Expected: `Error: Set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY` — the script's env-var guard fires before any DB activity, proving imports resolved cleanly.
+
+If you see a "module not found" or syntax error: investigate before continuing.
+
+---
+
+### Task 4: Add npm script
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Add to scripts block**
+
+In `package.json`, locate the `"scripts"` block. Add this entry after `"import:archive"`:
+
+```json
+"triage:report": "tsx --env-file=.env.local scripts/catalog-triage-report.ts"
+```
+
+The block (showing only the addition; preserve all existing scripts):
+
+```json
+"scripts": {
+  "dev": "next dev",
+  "build": "next build",
+  "start": "next start",
+  "lint": "next lint",
+  "import:csv": "tsx scripts/import-csv.ts",
+  "import:images": "tsx scripts/migrate-images.ts",
+  "seed:categories": "tsx scripts/seed-categories.ts",
+  "generate:descriptions": "tsx scripts/generate-descriptions.ts",
+  "import:descriptions": "tsx --env-file=.env.local scripts/import-human-descriptions.ts",
+  "import:archive": "tsx --env-file=.env.local scripts/import-archive.ts",
+  "triage:report": "tsx --env-file=.env.local scripts/catalog-triage-report.ts",
+  "migrate:all": "tsx --env-file=.env.local scripts/migrate-and-describe.ts",
+  "db:migrate": "tsx scripts/run-migration.ts"
+},
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `npm run | grep triage:report`
+Expected: prints `triage:report`.
+
+---
+
+### Task 5: Commit Phase 1 code
+
+**Files:** none (git only)
+
+- [ ] **Step 1: Stage and commit**
+
+Run:
+```bash
+git add src/lib/dates.ts scripts/test-dates.ts scripts/catalog-triage-report.ts package.json
+git status
+```
+
+Expected: 4 files staged. No untracked CSV artifacts (tmp/ is gitignored).
+
+- [ ] **Step 2: Create commit**
+
+Run:
+```bash
+git commit -m "$(cat <<'EOF'
+Add catalog triage report script
+
+scripts/catalog-triage-report.ts is a read-only audit that compares
+two source datasets — MC APR 2 (the original Art Cloud export) and
+1stdibs_clir_picks_2026-03-17 (the curated picks) — against the DB
+and produces three timestamped CSVs in tmp/:
+
+  - triage-per-artwork: bucket (both/mc_apr_2_only/1stdibs_only),
+                        image_state, recovery_url for null images
+                        whose SKU is in the picks
+  - triage-per-artist:  total + per-source counts, mediums seen,
+                        date range, null_image_count, top tags
+  - triage-tag-frequency: signal_ratio surfaces tags that appear
+                        disproportionately on mc_apr_2_only artworks
+                        (an "ephemera-like" signal)
+
+Pure year-extraction helper at src/lib/dates.ts (will be reused by
+Project B's decade dropdown). node:test covers the parser including
+"ND", "c. 1990", "7/20/1987", out-of-range filtering.
+
+Read-only; no DB writes, no concurrency. Runtime well under a minute
+on the current ~3,260-row catalog.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: commit succeeds.
+
+---
+
+## Phase 2: Run + verify
+
+### Task 6: Run the report and spot-check
+
+**Files:** none (execution only — produces gitignored artifacts)
+
+- [ ] **Step 1: Run it**
+
+Run: `npm run triage:report`
+
+Expected output ends with a summary block:
+
+```
+=== Summary ===
+Per-artwork rows: ~3260
+  both              ~975
+  mc_apr_2_only     ~1200
+  1stdibs_only      ~1085
+Per-artist rows:  ~100
+Tag-freq rows:    ~varies (depends on how many distinct tags exist)
+
+Per-artwork: /Users/cullfam/code/cg_clir/tmp/triage-per-artwork_<timestamp>.csv
+Per-artist:  /Users/cullfam/code/cg_clir/tmp/triage-per-artist_<timestamp>.csv
+Tag-freq:    /Users/cullfam/code/cg_clir/tmp/triage-tag-frequency_<timestamp>.csv
+```
+
+Should complete in under 30 seconds. Three CSVs appear in `tmp/`.
+
+If you see `WARNING: N artworks in DB but in neither source CSV`: report the count to the user. The bucket='unknown_source' rows in the per-artwork CSV identify them.
+
+- [ ] **Step 2: Spot-check the per-artwork CSV**
+
+Run: `head -3 tmp/triage-per-artwork_*.csv`
+Expected: header row (`sku,artist,title,medium,date_created,bucket,image_state,recovery_source,recovery_url,description_origin,theme_count,tag_count,tags,on_website`) plus 2 sample rows. Sanity-check the first row's bucket and image_state values look plausible.
+
+Run:
+```bash
+awk -F',' 'NR>1 {print $6}' tmp/triage-per-artwork_*.csv | sort | uniq -c
+```
+Expected: counts by bucket. Should be roughly `~975 both`, `~1200 mc_apr_2_only`, `~1085 1stdibs_only`, `0 unknown_source`.
+
+- [ ] **Step 3: Spot-check the per-artist CSV**
+
+Run: `head -5 tmp/triage-per-artist_*.csv`
+Expected: header row (`artist,total_artworks,mc_apr_2_count,1stdibs_count,both_count,mc_apr_2_only_count,mediums,date_range,null_image_count,top_tags`) plus 4 artist rows, sorted by `total_artworks` descending. The most prolific artists (Judith Scott, Dan Miller, etc., based on prior context) should be at the top.
+
+- [ ] **Step 4: Spot-check the tag-frequency CSV**
+
+Run: `head -10 tmp/triage-tag-frequency_*.csv`
+Expected: header row (`tag,total_count,mc_apr_2_only_count,1stdibs_count,signal_ratio`) plus 9 tag rows, sorted by `signal_ratio` descending. The tags at the top (signal_ratio near 1.0) are candidate "this tag mostly appears on triage-cohort artworks" signals — these are what CG should look at first.
+
+If you see something like `ephemera` near the top with a non-trivial `total_count`: that's the kind of signal we hoped to surface. Report any standout tags to the user.
+
+- [ ] **Step 5: Verify a known artwork's row**
+
+The Ron Veasey artwork the user mentioned (`CLIR2024.233`) should appear in the per-artwork CSV with `image_state=null`. Check whether it has a `recovery_url` (only if its SKU is in the 1stdibs picks):
+
+Run:
+```bash
+grep "^CLIR2024.233," tmp/triage-per-artwork_*.csv
+```
+Expected: one row showing the artwork's full state. Report whether `recovery_url` is populated (meaning we have a 1stdibs source for the missing image) or empty (meaning we don't, and CG needs to provide one).
+
+---
+
+## Done
+
+At this point:
+- Three CSV artifacts in `tmp/` ready to share with Creative Growth.
+- The user can open each in Sheets and start triaging:
+  - **Per-artist** to make per-artist keep/remove decisions in bulk.
+  - **Tag-frequency** to spot triage-signal tags (high `signal_ratio` with non-trivial `total_count`).
+  - **Per-artwork** for cross-checking specific SKUs and pulling recovery URLs for null images.
+- Follow-up projects can now make data-driven decisions about what to do with the `mc_apr_2_only` cohort (~1,200 artworks), the null-image cohort (~308 artworks), or anything else the report surfaces.

--- a/docs/superpowers/specs/2026-04-24-catalog-triage-report-design.md
+++ b/docs/superpowers/specs/2026-04-24-catalog-triage-report-design.md
@@ -1,0 +1,164 @@
+# Catalog Triage Report — Design
+
+**Date:** 2026-04-24
+**Status:** Ready for implementation
+
+---
+
+## Goal
+
+Produce a static, read-only set of CSV reports that lets Creative Growth staff triage the artworks DB. Specifically: which of the ~3,260 artworks should remain on the public site, which are missing images, and what patterns (per artist or per tag) might guide the decision.
+
+The work is bookkeeping — not a UI, not a public surface, not a database write. The outputs land in `tmp/` (gitignored) and get shared with CG outside this codebase.
+
+The naming convention for the two source datasets we compare:
+- **MC APR 2** — `inventory_2026-04-02.csv`, the original Art Cloud export that seeded the DB (~2,189 rows).
+- **1stdibs_clir_picks_2026-03-17** — `tmp/ADD TAGS TO CREATIVE GROWTH PUBLIC ARCHIVE - 1stdibs_clir_picks_2026-03-17.csv`, the curated subset CG prepared for 1stDibs (~2,059 rows). Imported via the prior `feat/archive-import` PR.
+
+Each SKU known to the DB falls in one of three buckets:
+- **`both`** — present in both source CSVs
+- **`mc_apr_2_only`** — in the original April catalog but NOT in the 1stDibs picks (~1,200 expected; this is the cohort CG most needs to triage)
+- **`1stdibs_only`** — in the picks but NOT in the original April catalog (~1,150; freshly inserted by the prior import)
+
+---
+
+## Outputs
+
+A single `npm run` produces three timestamped CSVs in `tmp/`. All artifacts are read-only descriptions of current DB + source-CSV state.
+
+### Output 1: `triage-per-artwork_<ISO-timestamp>.csv`
+
+One row per SKU known to the DB. Sorted by `artist`, then `sku`. Columns:
+
+| Column | Notes |
+|---|---|
+| `sku` | from `artworks.sku` |
+| `artist` | resolved `<first_name> <last_name>`; `Unknown` if `artist_id` is null |
+| `title` | from DB |
+| `medium` | from DB |
+| `date_created` | from DB (raw text — may be year, full date, or "ND") |
+| `bucket` | `both` / `mc_apr_2_only` / `1stdibs_only` |
+| `image_state` | `r2` / `artcld` / `null` (based on `image_url` substring matching) |
+| `recovery_source` | `1stdibs_link_1_available` if the SKU is in the 1stdibs CSV AND `image_url` is null; else empty |
+| `recovery_url` | The `Link 1` URL from 1stdibs picks if `recovery_source` is set; else empty |
+| `description_origin` | `human` / `ai` / empty |
+| `theme_count` | count of attached `kind='theme'` categories |
+| `tag_count` | length of `artworks.tags` array |
+| `tags` | `artworks.tags` joined with `; ` |
+| `on_website` | true / false |
+
+Excluded: artworks not in the DB (we don't know about them).
+
+### Output 2: `triage-per-artist_<ISO-timestamp>.csv`
+
+One row per distinct artist. Sorted by `total_artworks` descending. Columns:
+
+| Column | Notes |
+|---|---|
+| `artist` | name (or `Unknown`) |
+| `total_artworks` | overall count in DB |
+| `mc_apr_2_count` | how many of their works appear in MC APR 2 |
+| `1stdibs_count` | how many appear in the 1stdibs picks |
+| `both_count` | intersection |
+| `mc_apr_2_only_count` | the triage cohort per artist (the "do we want to keep showing all these?" number) |
+| `mediums` | distinct medium values, comma-joined, lowercased |
+| `date_range` | `<earliest>–<latest>` four-digit-year span if parseable; empty otherwise |
+| `null_image_count` | how many of theirs have null `image_url` |
+| `top_tags` | top 5 most-frequent values from `artworks.tags` across this artist's works, comma-joined |
+
+### Output 3: `triage-tag-frequency_<ISO-timestamp>.csv`
+
+One row per distinct tag value present anywhere in `artworks.tags`. Sorted by `signal_ratio` descending (highest-signal tags surface first). Columns:
+
+| Column | Notes |
+|---|---|
+| `tag` | the tag string |
+| `total_count` | how many DB artworks have this tag |
+| `mc_apr_2_only_count` | restricted to artworks in the `mc_apr_2_only` bucket |
+| `1stdibs_count` | restricted to artworks whose SKU appears in the 1stdibs picks |
+| `signal_ratio` | `mc_apr_2_only_count / total_count`, rounded to 2 decimal places. Values near 1.0 mean "this tag almost exclusively appears on works NOT in the 1stDibs picks" — a candidate signal for triage (e.g., a tag like `ephemera` is likely to score ~1.0). Values near 0 mean the opposite. |
+
+---
+
+## Inputs and join keys
+
+- **MC APR 2** — read `inventory_2026-04-02.csv`, build `Set<sku>` from column `SKU`.
+- **1stdibs picks** — read `tmp/ADD TAGS TO CREATIVE GROWTH PUBLIC ARCHIVE - 1stdibs_clir_picks_2026-03-17.csv`, build `Map<sku, link1>` from columns `SKU` and `Link 1`.
+- **DB** — page through `artworks` using the existing pagination pattern; select `id, sku, title, medium, date_created, image_url, description_origin, on_website, tags, artist:artists(first_name, last_name)` plus a join through `artwork_categories` to count themes.
+
+`sku` is the join key everywhere (the field is non-unique in the schema by design — duplicates `DMi 662` and `JS 27` exist; the report just emits one row per DB artwork, so duplicates produce duplicate rows, which is correct).
+
+---
+
+## Categorization rules
+
+```
+in_mc_apr2 = mc_apr2_skus.has(artwork.sku)
+in_1stdibs = onestdibs_skus.has(artwork.sku)
+
+bucket =
+  both              if in_mc_apr2 and in_1stdibs
+  mc_apr_2_only     if in_mc_apr2 and not in_1stdibs
+  1stdibs_only      if not in_mc_apr2 and in_1stdibs
+  ?                 if neither — emit as `unknown_source` and log a warning
+                                  (these would be DB rows from some other path,
+                                  e.g., manually inserted or seeded by a script
+                                  outside the two source CSVs)
+```
+
+The `unknown_source` bucket should be empty in practice but the script must handle it without crashing.
+
+---
+
+## Implementation outline
+
+**File:** `scripts/catalog-triage-report.ts`
+
+**npm script:** `triage:report`
+
+**Behavior:**
+1. Parse the two source CSVs (similar pattern to other scripts in `scripts/`).
+2. Page through the DB to fetch all artworks with the columns listed in "Inputs" above. Use a join to fetch theme-category counts (or compute via a separate query that counts `artwork_categories` joined to `categories WHERE kind='theme'`).
+3. For each artwork: compute its bucket and image_state, look up the recovery URL from the 1stdibs map, and emit one row to the per-artwork list.
+4. Group by artist (in memory) to produce the per-artist summary.
+5. Group by tag (in memory) to produce the tag-frequency comparison. Compute `signal_ratio` per tag.
+6. Write the three CSVs to `tmp/` with timestamped filenames.
+7. Print a brief summary to stdout: row counts per output, plus the `unknown_source` count if non-zero.
+
+**Concurrency / runtime:** none needed. The data fits in memory; this is a few queries plus three writes. Should complete in well under a minute.
+
+**Helpers to reuse:**
+- The `csvField` / `writeCsv` helpers from `scripts/import-archive.ts` (extract them to a shared file ONLY if their signatures need to change; otherwise just copy the ~15 lines and let TI-001 track the consolidation).
+- The `formatArtistName` util from `src/lib/utils.ts`.
+
+---
+
+## Edge cases
+
+- **Artist is null** (`artist_id IS NULL` on artwork): use literal string `"Unknown"`. Aggregate all such rows together in the per-artist summary as a single `Unknown` row.
+- **`artworks.tags` is null** for a row: treat as empty array.
+- **Tag values that differ only in casing** (e.g. `"Ephemera"` vs `"ephemera"`): normalize to lowercase + trim before grouping in the tag-frequency report. Display the lowercase form.
+- **Dates that don't parse to a year** (e.g., `"ND"`, `"c. 1990s"`): excluded from `date_range` calculation. If an artist has zero parseable dates, `date_range` is empty.
+- **`signal_ratio` denominator zero**: not possible since `total_count` is by construction the number of artworks where the tag appears, but the script should guard with a defensive check (return 0 if denominator is 0 to avoid NaN).
+
+---
+
+## Out of scope (explicit)
+
+- **Acting on the report.** This produces a description, not a remediation. Follow-up projects will decide what to do with the data: bulk-deactivate certain artworks, backfill images from `recovery_url`, etc.
+- **A web UI for browsing the report.** CSVs only. CG can open in Sheets and filter.
+- **Image fetching for the audit.** We don't HEAD-check or download images here — the report describes `image_url` state, not whether the URL actually resolves to a valid image.
+- **Theme-tag analysis.** Only the free-form `artworks.tags` (from the original Art Cloud import) is analyzed; the constrained 8-term theme taxonomy is just a count column on the per-artwork sheet.
+- **Per-tag artist breakdown.** A tag-frequency row tells you "ephemera appears on 47 artworks, of which 45 are in mc_apr_2_only" but doesn't list which artists. CG can derive that from the per-artwork sheet by filtering on tag.
+
+---
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| `signal_ratio` over-reads small samples (e.g., a tag that appears on 1 artwork in `mc_apr_2_only` shows ratio 1.0 and looks like a strong signal) | Sort by `signal_ratio` descending but include `total_count` so reviewers can see the sample size at a glance. |
+| In-memory aggregation breaks on a much larger catalog | Catalog is ~3,260 artworks; aggregation is trivial in memory. Document the assumption; revisit if catalog crosses ~50k. |
+| Re-running produces noisy timestamped files in `tmp/` | `tmp/` is already gitignored. Old report files stay around for comparison; the user can clean up manually. |
+| Artists with the same name resolved to different `artist_id`s would split into multiple rows | The artist-resolution path during imports uses slug equality, so this shouldn't happen unless slugify changed between imports. The per-artist summary groups by resolved name (not artist_id), which papers over any such split. |
+| `unknown_source` rows surface (artworks in DB but in neither source CSV) | Logged as a warning with count to stdout; the row still appears in per-artwork CSV under a fourth bucket value. CG can investigate origin separately. |

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "generate:descriptions": "tsx scripts/generate-descriptions.ts",
     "import:descriptions": "tsx --env-file=.env.local scripts/import-human-descriptions.ts",
     "import:archive": "tsx --env-file=.env.local scripts/import-archive.ts",
+    "triage:report": "tsx --env-file=.env.local scripts/catalog-triage-report.ts",
     "migrate:all": "tsx --env-file=.env.local scripts/migrate-and-describe.ts",
     "db:migrate": "tsx scripts/run-migration.ts"
   },

--- a/scripts/catalog-triage-report.ts
+++ b/scripts/catalog-triage-report.ts
@@ -372,7 +372,10 @@ async function main() {
   console.log(`Per-artist rows:  ${perArtist.length}`);
   console.log(`Tag-freq rows:    ${tagFreq.length}`);
   if (unknownSourceCount > 0) {
-    console.log(`\nWARNING: ${unknownSourceCount} artworks in DB but in neither source CSV (bucket='unknown_source'). Investigate.`);
+    const unknownSkus = perArtwork
+      .filter((r) => r.bucket === "unknown_source")
+      .map((r) => r.sku || `<empty sku, title="${r.title}">`);
+    console.log(`\nWARNING: ${unknownSourceCount} artworks in DB but in neither source CSV (bucket='unknown_source'): ${unknownSkus.join(", ")}`);
   }
   console.log(`\nPer-artwork: ${PER_ARTWORK_FILE}`);
   console.log(`Per-artist:  ${PER_ARTIST_FILE}`);

--- a/scripts/catalog-triage-report.ts
+++ b/scripts/catalog-triage-report.ts
@@ -1,0 +1,385 @@
+#!/usr/bin/env npx tsx
+/**
+ * catalog-triage-report.ts
+ *
+ * Read-only audit of the artworks catalog. Compares two source
+ * datasets — MC APR 2 (inventory_2026-04-02.csv, the original Art
+ * Cloud export) and 1stdibs_clir_picks_2026-03-17 (the curated
+ * picks) — and produces three CSVs in tmp/:
+ *
+ *   1. triage-per-artwork_<ts>.csv   one row per DB artwork
+ *   2. triage-per-artist_<ts>.csv    one row per artist
+ *   3. triage-tag-frequency_<ts>.csv one row per distinct tag
+ *
+ * Spec: docs/superpowers/specs/2026-04-24-catalog-triage-report-design.md
+ *
+ * Run: npx tsx --env-file=.env.local scripts/catalog-triage-report.ts
+ */
+
+import fs from "fs";
+import path from "path";
+import { parse } from "csv-parse/sync";
+import { createClient } from "@supabase/supabase-js";
+import { extractYear } from "../src/lib/dates";
+
+// ─── Config ───────────────────────────────────────────────────────────────
+const TMP_DIR = path.join(__dirname, "..", "tmp");
+const MC_APR_2_PATH = path.join(__dirname, "..", "inventory_2026-04-02.csv");
+const ONESTDIBS_PATH = path.join(
+  TMP_DIR,
+  "ADD TAGS TO CREATIVE GROWTH PUBLIC ARCHIVE - 1stdibs_clir_picks_2026-03-17.csv"
+);
+
+const TIMESTAMP = new Date().toISOString().replace(/[:.]/g, "-");
+const PER_ARTWORK_FILE = path.join(TMP_DIR, `triage-per-artwork_${TIMESTAMP}.csv`);
+const PER_ARTIST_FILE = path.join(TMP_DIR, `triage-per-artist_${TIMESTAMP}.csv`);
+const TAG_FREQ_FILE = path.join(TMP_DIR, `triage-tag-frequency_${TIMESTAMP}.csv`);
+
+const SUPABASE_URL =
+  process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error("Error: Set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY");
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+const PAGE_SIZE = 1000;
+
+// ─── Types ────────────────────────────────────────────────────────────────
+interface ArtworkRow {
+  id: string;
+  sku: string | null;
+  title: string;
+  medium: string | null;
+  date_created: string | null;
+  image_url: string | null;
+  description_origin: "human" | "ai" | null;
+  on_website: boolean;
+  tags: string[] | null;
+  artist: { first_name: string; last_name: string } | null;
+  categories: { category: { kind: string | null } | null }[] | null;
+}
+
+type Bucket = "both" | "mc_apr_2_only" | "1stdibs_only" | "unknown_source";
+
+interface PerArtworkRow {
+  sku: string;
+  artist: string;
+  title: string;
+  medium: string;
+  date_created: string;
+  bucket: Bucket;
+  image_state: "r2" | "artcld" | "null";
+  recovery_source: string;
+  recovery_url: string;
+  description_origin: string;
+  theme_count: string;
+  tag_count: string;
+  tags: string;
+  on_website: string;
+}
+
+interface PerArtistRow {
+  artist: string;
+  total_artworks: string;
+  mc_apr_2_count: string;
+  "1stdibs_count": string;
+  both_count: string;
+  mc_apr_2_only_count: string;
+  mediums: string;
+  date_range: string;
+  null_image_count: string;
+  top_tags: string;
+}
+
+interface TagFreqRow {
+  tag: string;
+  total_count: string;
+  mc_apr_2_only_count: string;
+  "1stdibs_count": string;
+  signal_ratio: string;
+}
+
+// ─── CSV helpers ──────────────────────────────────────────────────────────
+function csvField(value: string | null | undefined): string {
+  if (value === null || value === undefined) return "";
+  const s = String(value);
+  if (/[",\n\r]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+  return s;
+}
+
+function writeCsv(filePath: string, columns: string[], rows: Record<string, string>[]): void {
+  const header = columns.join(",");
+  const body = rows.map((r) => columns.map((c) => csvField(r[c])).join(",")).join("\n");
+  fs.writeFileSync(filePath, header + "\n" + body + "\n");
+}
+
+// ─── Source-CSV parsing ───────────────────────────────────────────────────
+function loadMcApr2Skus(): Set<string> {
+  if (!fs.existsSync(MC_APR_2_PATH)) {
+    console.error(`MC APR 2 CSV not found: ${MC_APR_2_PATH}`);
+    process.exit(1);
+  }
+  const rows = parse(fs.readFileSync(MC_APR_2_PATH, "utf-8"), {
+    columns: true,
+    skip_empty_lines: true,
+    relax_quotes: true,
+    relax_column_count: true,
+  }) as { SKU?: string }[];
+  const skus = new Set<string>();
+  for (const r of rows) {
+    const sku = (r.SKU || "").trim();
+    if (sku) skus.add(sku);
+  }
+  return skus;
+}
+
+function load1stdibsSkuMap(): Map<string, string> {
+  if (!fs.existsSync(ONESTDIBS_PATH)) {
+    console.error(`1stdibs picks CSV not found: ${ONESTDIBS_PATH}`);
+    process.exit(1);
+  }
+  const rows = parse(fs.readFileSync(ONESTDIBS_PATH, "utf-8"), {
+    columns: true,
+    skip_empty_lines: true,
+    relax_quotes: true,
+    relax_column_count: true,
+  }) as { SKU?: string; "Link 1"?: string }[];
+  const map = new Map<string, string>();
+  for (const r of rows) {
+    const sku = (r.SKU || "").trim();
+    const link = (r["Link 1"] || "").trim();
+    if (sku) map.set(sku, link);
+  }
+  return map;
+}
+
+// ─── Image-state classification ───────────────────────────────────────────
+function classifyImage(url: string | null): "r2" | "artcld" | "null" {
+  if (!url) return "null";
+  if (url.includes("artcld.com")) return "artcld";
+  return "r2"; // any non-null, non-artcld URL is treated as R2 / R2-relative
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────
+async function main() {
+  console.log("Loading source CSVs...");
+  const mcApr2 = loadMcApr2Skus();
+  const onestdibs = load1stdibsSkuMap();
+  console.log(`  MC APR 2: ${mcApr2.size} unique SKUs`);
+  console.log(`  1stdibs:  ${onestdibs.size} unique SKUs`);
+
+  console.log("Fetching artworks from DB...");
+  const artworks: ArtworkRow[] = [];
+  let offset = 0;
+  while (true) {
+    const { data, error } = await supabase
+      .from("artworks")
+      .select(`
+        id, sku, title, medium, date_created, image_url,
+        description_origin, on_website, tags,
+        artist:artists(first_name, last_name),
+        categories:artwork_categories(category:categories(kind))
+      `)
+      .order("sku", { ascending: true, nullsFirst: false })
+      .range(offset, offset + PAGE_SIZE - 1);
+    if (error) {
+      console.error("Error fetching artworks:", error);
+      process.exit(1);
+    }
+    if (!data || data.length === 0) break;
+    artworks.push(...(data as unknown as ArtworkRow[]));
+    if (data.length < PAGE_SIZE) break;
+    offset += PAGE_SIZE;
+  }
+  console.log(`  ${artworks.length} artworks fetched`);
+
+  // ── Per-artwork rows ────────────────────────────────────────────────────
+  let unknownSourceCount = 0;
+  const perArtwork: PerArtworkRow[] = [];
+  for (const a of artworks) {
+    const sku = (a.sku || "").trim();
+    const inMc = sku && mcApr2.has(sku);
+    const inOd = sku && onestdibs.has(sku);
+
+    let bucket: Bucket;
+    if (inMc && inOd) bucket = "both";
+    else if (inMc) bucket = "mc_apr_2_only";
+    else if (inOd) bucket = "1stdibs_only";
+    else { bucket = "unknown_source"; unknownSourceCount++; }
+
+    const imageState = classifyImage(a.image_url);
+    const recovery_source =
+      imageState === "null" && inOd && onestdibs.get(sku) ? "1stdibs_link_1_available" : "";
+    const recovery_url =
+      recovery_source === "1stdibs_link_1_available" ? (onestdibs.get(sku) || "") : "";
+
+    const themeCount = (a.categories || []).filter((c) => c.category?.kind === "theme").length;
+    const tagCount = (a.tags || []).length;
+
+    const artistName = a.artist
+      ? `${a.artist.first_name} ${a.artist.last_name}`.trim() || "Unknown"
+      : "Unknown";
+
+    perArtwork.push({
+      sku,
+      artist: artistName,
+      title: a.title || "",
+      medium: a.medium || "",
+      date_created: a.date_created || "",
+      bucket,
+      image_state: imageState,
+      recovery_source,
+      recovery_url,
+      description_origin: a.description_origin || "",
+      theme_count: String(themeCount),
+      tag_count: String(tagCount),
+      tags: (a.tags || []).join("; "),
+      on_website: a.on_website ? "true" : "false",
+    });
+  }
+
+  // Sort: artist, then sku
+  perArtwork.sort((x, y) => {
+    if (x.artist !== y.artist) return x.artist.localeCompare(y.artist);
+    return x.sku.localeCompare(y.sku);
+  });
+
+  // ── Per-artist aggregation ──────────────────────────────────────────────
+  interface ArtistAgg {
+    artist: string;
+    total: number;
+    inMc: number;
+    inOd: number;
+    inBoth: number;
+    mcOnly: number;
+    mediums: Set<string>;
+    years: number[];
+    nullImages: number;
+    tagCounts: Map<string, number>;
+  }
+  const byArtist = new Map<string, ArtistAgg>();
+  for (const r of perArtwork) {
+    const agg = byArtist.get(r.artist) || {
+      artist: r.artist, total: 0, inMc: 0, inOd: 0, inBoth: 0, mcOnly: 0,
+      mediums: new Set(), years: [], nullImages: 0, tagCounts: new Map(),
+    };
+    agg.total++;
+    if (r.bucket === "both") { agg.inMc++; agg.inOd++; agg.inBoth++; }
+    else if (r.bucket === "mc_apr_2_only") { agg.inMc++; agg.mcOnly++; }
+    else if (r.bucket === "1stdibs_only") { agg.inOd++; }
+    if (r.medium) agg.mediums.add(r.medium.toLowerCase().trim());
+    const y = extractYear(r.date_created);
+    if (y !== null) agg.years.push(y);
+    if (r.image_state === "null") agg.nullImages++;
+    if (r.tags) {
+      for (const t of r.tags.split(";").map((s) => s.trim().toLowerCase()).filter(Boolean)) {
+        agg.tagCounts.set(t, (agg.tagCounts.get(t) || 0) + 1);
+      }
+    }
+    byArtist.set(r.artist, agg);
+  }
+
+  const perArtist: PerArtistRow[] = [...byArtist.values()]
+    .sort((a, b) => b.total - a.total)
+    .map((agg) => {
+      const dateRange = agg.years.length > 0
+        ? `${Math.min(...agg.years)}–${Math.max(...agg.years)}`
+        : "";
+      const topTags = [...agg.tagCounts.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 5)
+        .map(([t]) => t)
+        .join(", ");
+      return {
+        artist: agg.artist,
+        total_artworks: String(agg.total),
+        mc_apr_2_count: String(agg.inMc),
+        "1stdibs_count": String(agg.inOd),
+        both_count: String(agg.inBoth),
+        mc_apr_2_only_count: String(agg.mcOnly),
+        mediums: [...agg.mediums].sort().join(", "),
+        date_range: dateRange,
+        null_image_count: String(agg.nullImages),
+        top_tags: topTags,
+      };
+    });
+
+  // ── Tag frequency ───────────────────────────────────────────────────────
+  interface TagAgg {
+    tag: string;
+    total: number;
+    mcOnly: number;
+    inOd: number;
+  }
+  const byTag = new Map<string, TagAgg>();
+  for (const r of perArtwork) {
+    if (!r.tags) continue;
+    const tags = r.tags.split(";").map((s) => s.trim().toLowerCase()).filter(Boolean);
+    const seen = new Set<string>(); // dedup tags within a single artwork's tag list
+    for (const t of tags) {
+      if (seen.has(t)) continue;
+      seen.add(t);
+      const agg = byTag.get(t) || { tag: t, total: 0, mcOnly: 0, inOd: 0 };
+      agg.total++;
+      if (r.bucket === "mc_apr_2_only") agg.mcOnly++;
+      if (r.bucket === "both" || r.bucket === "1stdibs_only") agg.inOd++;
+      byTag.set(t, agg);
+    }
+  }
+
+  const tagFreq: TagFreqRow[] = [...byTag.values()]
+    .map((agg) => ({
+      tag: agg.tag,
+      total_count: String(agg.total),
+      mc_apr_2_only_count: String(agg.mcOnly),
+      "1stdibs_count": String(agg.inOd),
+      signal_ratio: agg.total > 0 ? (agg.mcOnly / agg.total).toFixed(2) : "0.00",
+    }))
+    .sort((a, b) => parseFloat(b.signal_ratio) - parseFloat(a.signal_ratio));
+
+  // ── Write outputs ───────────────────────────────────────────────────────
+  if (!fs.existsSync(TMP_DIR)) fs.mkdirSync(TMP_DIR, { recursive: true });
+
+  writeCsv(PER_ARTWORK_FILE,
+    ["sku", "artist", "title", "medium", "date_created", "bucket", "image_state",
+     "recovery_source", "recovery_url", "description_origin", "theme_count",
+     "tag_count", "tags", "on_website"],
+    perArtwork
+  );
+  writeCsv(PER_ARTIST_FILE,
+    ["artist", "total_artworks", "mc_apr_2_count", "1stdibs_count", "both_count",
+     "mc_apr_2_only_count", "mediums", "date_range", "null_image_count", "top_tags"],
+    perArtist
+  );
+  writeCsv(TAG_FREQ_FILE,
+    ["tag", "total_count", "mc_apr_2_only_count", "1stdibs_count", "signal_ratio"],
+    tagFreq
+  );
+
+  // ── Summary ─────────────────────────────────────────────────────────────
+  const byBucket = perArtwork.reduce<Record<string, number>>((acc, r) => {
+    acc[r.bucket] = (acc[r.bucket] || 0) + 1;
+    return acc;
+  }, {});
+  console.log("\n=== Summary ===");
+  console.log(`Per-artwork rows: ${perArtwork.length}`);
+  Object.entries(byBucket).forEach(([k, v]) => console.log(`  ${k.padEnd(18)} ${v}`));
+  console.log(`Per-artist rows:  ${perArtist.length}`);
+  console.log(`Tag-freq rows:    ${tagFreq.length}`);
+  if (unknownSourceCount > 0) {
+    console.log(`\nWARNING: ${unknownSourceCount} artworks in DB but in neither source CSV (bucket='unknown_source'). Investigate.`);
+  }
+  console.log(`\nPer-artwork: ${PER_ARTWORK_FILE}`);
+  console.log(`Per-artist:  ${PER_ARTIST_FILE}`);
+  console.log(`Tag-freq:    ${TAG_FREQ_FILE}`);
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/scripts/test-dates.ts
+++ b/scripts/test-dates.ts
@@ -1,0 +1,57 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { extractYear } from "../src/lib/dates";
+
+test("returns null for null input", () => {
+  assert.equal(extractYear(null), null);
+});
+
+test("returns null for empty string", () => {
+  assert.equal(extractYear(""), null);
+  assert.equal(extractYear("   "), null);
+});
+
+test("returns null for 'ND' (no date)", () => {
+  assert.equal(extractYear("ND"), null);
+  assert.equal(extractYear("nd"), null);
+});
+
+test("parses a four-digit year", () => {
+  assert.equal(extractYear("1992"), 1992);
+});
+
+test("parses a four-digit year with surrounding whitespace", () => {
+  assert.equal(extractYear("  2007  "), 2007);
+});
+
+test("parses a year out of a M/D/YYYY date", () => {
+  assert.equal(extractYear("7/20/1987"), 1987);
+});
+
+test("parses a year out of an ISO date", () => {
+  assert.equal(extractYear("1987-07-20"), 1987);
+});
+
+test("parses a year out of a circa string", () => {
+  assert.equal(extractYear("c. 1990"), 1990);
+  assert.equal(extractYear("circa 2003"), 2003);
+});
+
+test("parses a year out of a decade-style string by taking the first valid year", () => {
+  assert.equal(extractYear("1990s"), 1990);
+});
+
+test("returns null when no four-digit year is present", () => {
+  assert.equal(extractYear("nineteen ninety"), null);
+  assert.equal(extractYear("?"), null);
+});
+
+test("rejects implausibly small or large years (< 1900 or > current year + 1)", () => {
+  assert.equal(extractYear("0042"), null);
+  assert.equal(extractYear("1850"), null);
+  assert.equal(extractYear("9999"), null);
+});
+
+test("takes the first 4-digit year if multiple are present", () => {
+  assert.equal(extractYear("1985-1990"), 1985);
+});

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -1,0 +1,36 @@
+/**
+ * Date parsing utilities for the artworks catalog.
+ *
+ * Source dates come from the Art Cloud CSVs as free-form strings:
+ * "1992", "ND", "c. 1990", "7/20/1987", "1985-1990", etc. We need
+ * to derive a year for the decade dropdown (Project B) and the
+ * triage report's date_range aggregation (this PR).
+ */
+
+const MIN_PLAUSIBLE_YEAR = 1900;
+const MAX_PLAUSIBLE_YEAR = new Date().getFullYear() + 1;
+
+/**
+ * Extract a four-digit year from a free-form date string.
+ *
+ * Rules:
+ * - Returns null for null, empty, "ND" (case-insensitive), or any
+ *   string with no four-digit substring.
+ * - Returns the FIRST four-digit year found in the string.
+ * - Years outside [MIN_PLAUSIBLE_YEAR, MAX_PLAUSIBLE_YEAR] are
+ *   rejected as null (filters out things like "0042" or accidental
+ *   inventory numbers that look like years).
+ */
+export function extractYear(raw: string | null): number | null {
+  if (raw === null) return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  if (trimmed.toLowerCase() === "nd") return null;
+
+  const match = trimmed.match(/\d{4}/);
+  if (!match) return null;
+
+  const year = parseInt(match[0], 10);
+  if (year < MIN_PLAUSIBLE_YEAR || year > MAX_PLAUSIBLE_YEAR) return null;
+  return year;
+}


### PR DESCRIPTION
## Summary

A read-only audit script that helps Creative Growth triage the artworks catalog. Compares two source datasets — **MC APR 2** (`inventory_2026-04-02.csv`, the original Art Cloud export) and **1stdibs_clir_picks_2026-03-17** (the curated picks) — against the DB and produces three timestamped CSVs in `tmp/`:

- **triage-per-artwork:** one row per DB artwork. Includes a `bucket` column (`both` / `mc_apr_2_only` / `1stdibs_only` / `unknown_source`), `image_state` (`r2` / `artcld` / `null`), and a `recovery_url` for null-image rows whose SKU is in the 1stdibs picks (so we know which broken images we can auto-fix from a known source).
- **triage-per-artist:** one row per artist with aggregates — counts per source dataset, mediums seen, date range, null_image_count, top-5 tags. Sorted by total artworks descending.
- **triage-tag-frequency:** one row per distinct tag, with `signal_ratio = mc_apr_2_only_count / total_count`. Sorted by signal_ratio descending so triage-signal tags surface first.

A small pure helper at `src/lib/dates.ts` extracts a four-digit year from messy date strings (`"ND"`, `"c. 1990"`, `"7/20/1987"`, etc.) with out-of-range filtering. `node:test` covers it. Project B's decade dropdown will reuse it.

## Real findings from running this against production

- **`ephemera` tag → smoking gun.** All 208 artworks tagged `ephemera` are in `mc_apr_2_only` (signal_ratio 1.00). Strong candidate cohort for bulk deactivation.
- **`ogl: american visionary art museum` → loaned works.** 16 artworks, all `mc_apr_2_only`. Probably on loan to that museum, not the gallery's call to publish.
- **Camille Holvoet** has the largest triage cohort: 221 mc_apr_2_only out of 284 total.
- **Dan Miller** has 99 mc_apr_2_only artworks, **95 with null images** — biggest image-recovery debt for a single artist.
- **Ron Veasey** (the user-mentioned case) has 80 works split 50/30 across the two source CSVs with **0 overlap**, and 49 of his MC APR 2 works are missing images with no 1stdibs recovery URL — needs CG to provide images directly.
- **1 `unknown_source` row** surfaced: \`DMi 662\` by Donald Mitchell — DB row has empty SKU value (the SKU is in the title column instead). Edge case worth follow-up but not blocking.

## Out of scope (deferred)

- Acting on the report (no DB writes; no \`on_website = false\` flips, no image backfills)
- HEAD-checking image URLs to verify they actually resolve (only image_url field state is reported)
- Per-tag artist breakdown
- Web UI — CSVs only

## Follow-ups

- **TI-001** (existing): consolidate the duplicated csvField/writeCsv helpers across import-archive.ts and catalog-triage-report.ts
- **Reviewer-flagged polish** (not blocking, can be future PRs):
  - Per-artist aggregation could derive source membership from the source sets directly (current code derives from bucket label — equivalent today, but a single-source-of-truth issue)
  - Tag-frequency column naming asymmetry (\`mc_apr_2_only_count\` has \`_count\`, \`1stdibs_count\` doesn't — could rename for symmetry)

## Test plan

- [ ] Run \`npm run triage:report\` and confirm three CSVs appear in tmp/ with reasonable bucket counts (~909 both, ~1,200 mc_apr_2_only, ~1,150 1stdibs_only, 1 unknown_source)
- [ ] Open the tag-frequency CSV in Sheets, sort by signal_ratio, verify \`ephemera\` is at or near the top with total_count of 208
- [ ] Open the per-artist CSV, verify it's sorted by total_artworks descending (Camille Holvoet, Unknown, Gerone Spruill, etc. at the top)
- [ ] Run \`npx tsx --test scripts/test-dates.ts\` — 12 tests should pass
- [ ] Spot-check one specific artwork's row in the per-artwork CSV (e.g., \`grep "^CLIR2024.233," tmp/triage-per-artwork_*.csv\`) — should show \`mc_apr_2_only\`, \`null\` image, no recovery_url