### PR TITLE
Collection filters & search; split Ephemera into its own route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ inventory_*.csv
 
 # Working directory for CSV imports/exports (input + generated artifacts)
 tmp/
+
+# Visual brainstorm session files (mockups + state, regenerated per session)
+.superpowers/

--- a/docs/superpowers/plans/2026-04-24-collection-filters.md
+++ b/docs/superpowers/plans/2026-04-24-collection-filters.md
@@ -1,0 +1,1859 @@
+# Collection Filters & Search Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the existing single-axis category-tabs filter on `/collection` with a faceted browse experience (search + multi-select Theme/Format/Decade + Artist typeahead + Sort), and split the Ephemera cohort into its own `/ephemera` route with a simpler filter set.
+
+**Architecture:** Two Next.js Server Component routes that derive their query state from URL params, using a shared query-builder module that constructs Supabase queries with cohort filtering, facet count computation, and sort. Client-only filter UI components (dropdowns, chips, cohort nav) push URL changes via `useRouter`. Pure helpers for URL parsing and decade derivation get TDD coverage; UI components get smoke-tested via the dev server.
+
+**Tech Stack:** TypeScript, Next.js 14 App Router (Server Components + a few "use client" islands), TailwindCSS, `@supabase/supabase-js`, `node:test` for pure helpers.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-24-collection-filters-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- `src/lib/decades.ts` — `dateToDecade(raw: string | null): string | null` and `decadeOptions(years: number[]): string[]`. Pure helpers reused by the query builder and the decade dropdown.
+- `src/lib/filter-state.ts` — URL params parse/serialize. `parseSearchParams(p): FilterState` and `toQueryString(state): string`.
+- `src/lib/collection-query.ts` — server-side query builder. `queryArtworks(state, cohort)` and `getFacetCounts(state, cohort)`.
+- `src/components/CohortNav.tsx` — "Artwork | Ephemera" link pair.
+- `src/components/DropdownPanel.tsx` — base trigger-button + popover with click-outside close. Used by the three dropdown variants.
+- `src/components/MultiSelectDropdown.tsx` — checkbox list, used for Theme / Format / Decade.
+- `src/components/ArtistTypeaheadDropdown.tsx` — typeahead-narrowed scrollable list.
+- `src/components/SortDropdown.tsx` — radio list.
+- `src/components/ActiveFilterChips.tsx` — chip strip with X-to-remove + Clear all.
+- `src/components/FilterBar.tsx` — composes the above + the search input.
+- `src/app/ephemera/page.tsx` — new route.
+- `scripts/test-decades.ts` — `node:test` for `dateToDecade`.
+- `scripts/test-filter-state.ts` — `node:test` for URL param round-trip.
+- `scripts/backfill-decade.ts` — one-shot backfill of the new `artworks.decade` column from `date_created`.
+
+**Modified files:**
+- `src/app/collection/page.tsx` — replace `CategoryTabs` with `FilterBar`; route data through the new query builder; add the cohort filter (`'ephemera' != ALL(tags)`).
+- `scripts/import-csv.ts` — populate `decade` on insert.
+- `scripts/import-archive.ts` — populate `decade` on Branch B insert.
+- `supabase/migrations/001_initial.sql` — sync the new `decade` column with what the user manually applies.
+- `package.json` — add `backfill:decade` npm script.
+
+**Schema change (manual):** add `artworks.decade TEXT` and an index. Run by user in Supabase SQL Editor (per TD-001) before code lands.
+
+---
+
+## Phase 0: Pre-flight
+
+### Task 0: Verify the existing schema state
+
+**Files:** none (read-only verification)
+
+- [ ] **Step 1: Confirm artworks columns + theme categories**
+
+Run:
+```bash
+npx tsx --env-file=.env.local -e "
+import { createClient } from '@supabase/supabase-js';
+const c = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+Promise.all([
+  c.from('artworks').select('id, sku, tags, date_created').limit(1),
+  c.from('categories').select('kind').neq('kind', null),
+]).then(([a, t]) => {
+  if (a.error || t.error) { console.error(a.error || t.error); process.exit(1); }
+  const kinds = [...new Set(t.data.map(r => r.kind))].sort();
+  console.log('OK - artworks columns:', Object.keys(a.data[0]));
+  console.log('OK - category kinds:', kinds);
+});
+"
+```
+
+Expected output:
+- artworks columns include `tags` and `date_created`
+- `category kinds: [ 'format', 'theme' ]`
+
+If something's missing, stop and report.
+
+---
+
+## Phase 1: Schema + decade backfill
+
+### Task 1: User runs ALTER TABLE for the decade column
+
+**Files:** none (manual step)
+
+- [ ] **Step 1: Provide SQL to the user**
+
+Tell the user to run this in the Supabase SQL Editor:
+
+```sql
+ALTER TABLE artworks ADD COLUMN decade TEXT;
+CREATE INDEX idx_artworks_decade ON artworks(decade);
+```
+
+The column is nullable (artworks without parseable years stay NULL). Index is for the multi-value `WHERE decade = ANY(...)` filter.
+
+- [ ] **Step 2: Verify the column exists**
+
+Wait for user confirmation, then run:
+```bash
+npx tsx --env-file=.env.local -e "
+import { createClient } from '@supabase/supabase-js';
+const c = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+c.from('artworks').select('id, decade').limit(1).then(({data, error}) => {
+  if (error) { console.error('NOT YET:', error.message); process.exit(1); }
+  console.log('OK - decade column exists:', Object.keys(data[0]));
+});
+"
+```
+
+Expected: `OK - decade column exists: [ 'id', 'decade' ]`
+
+If this fails, stop and ask user to re-run the SQL.
+
+---
+
+### Task 2: TDD `dateToDecade` helper — failing tests first
+
+**Files:**
+- Create: `scripts/test-decades.ts`
+
+- [ ] **Step 1: Write the test file**
+
+Create `scripts/test-decades.ts`:
+
+```typescript
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { dateToDecade, decadeOptions } from "../src/lib/decades";
+
+test("dateToDecade: returns null for null/empty/ND", () => {
+  assert.equal(dateToDecade(null), null);
+  assert.equal(dateToDecade(""), null);
+  assert.equal(dateToDecade("ND"), null);
+});
+
+test("dateToDecade: bucketed to '1980s' for any 1980s date", () => {
+  assert.equal(dateToDecade("1985"), "1980s");
+  assert.equal(dateToDecade("1980"), "1980s");
+  assert.equal(dateToDecade("1989"), "1980s");
+});
+
+test("dateToDecade: '7/20/1987' → '1980s'", () => {
+  assert.equal(dateToDecade("7/20/1987"), "1980s");
+});
+
+test("dateToDecade: '2000' → '2000s', '2001' → '2000s', '2009' → '2000s'", () => {
+  assert.equal(dateToDecade("2000"), "2000s");
+  assert.equal(dateToDecade("2001"), "2000s");
+  assert.equal(dateToDecade("2009"), "2000s");
+});
+
+test("dateToDecade: '2010' → '2010s'", () => {
+  assert.equal(dateToDecade("2010"), "2010s");
+});
+
+test("dateToDecade: 'c. 1990' → '1990s'", () => {
+  assert.equal(dateToDecade("c. 1990"), "1990s");
+});
+
+test("dateToDecade: out-of-range years return null", () => {
+  assert.equal(dateToDecade("1850"), null);
+  assert.equal(dateToDecade("0042"), null);
+});
+
+test("decadeOptions: from a list of years, returns sorted decade strings", () => {
+  assert.deepEqual(decadeOptions([1985, 1990, 2003, 1989, 2010]), ["1980s", "1990s", "2000s", "2010s"]);
+});
+
+test("decadeOptions: empty input → empty array", () => {
+  assert.deepEqual(decadeOptions([]), []);
+});
+
+test("decadeOptions: dedups years from same decade", () => {
+  assert.deepEqual(decadeOptions([1985, 1986, 1987]), ["1980s"]);
+});
+```
+
+- [ ] **Step 2: Run and verify failure**
+
+Run: `npx tsx --test scripts/test-decades.ts`
+Expected: All tests fail with `Cannot find module '../src/lib/decades'`.
+
+---
+
+### Task 3: Implement `dateToDecade` and `decadeOptions`
+
+**Files:**
+- Create: `src/lib/decades.ts`
+
+- [ ] **Step 1: Write the implementation**
+
+Create `src/lib/decades.ts`:
+
+```typescript
+import { extractYear } from "./dates";
+
+/**
+ * Bucket a free-form date string into a decade label like "1980s".
+ * Returns null for unparseable / out-of-range dates.
+ */
+export function dateToDecade(raw: string | null): string | null {
+  const year = extractYear(raw);
+  if (year === null) return null;
+  return `${Math.floor(year / 10) * 10}s`;
+}
+
+/**
+ * Given a list of years, return the sorted unique decade labels they fall into.
+ * Used to populate the Decade dropdown options from the data we have.
+ */
+export function decadeOptions(years: number[]): string[] {
+  const set = new Set<string>();
+  for (const y of years) {
+    set.add(`${Math.floor(y / 10) * 10}s`);
+  }
+  return [...set].sort();
+}
+```
+
+- [ ] **Step 2: Run and verify all tests pass**
+
+Run: `npx tsx --test scripts/test-decades.ts`
+Expected: All 9 tests pass.
+
+---
+
+### Task 4: Implement and run the decade backfill
+
+**Files:**
+- Create: `scripts/backfill-decade.ts`
+
+- [ ] **Step 1: Write the script**
+
+Create `scripts/backfill-decade.ts`:
+
+```typescript
+#!/usr/bin/env npx tsx
+/**
+ * backfill-decade.ts
+ *
+ * Populates artworks.decade for every row by parsing date_created via
+ * dateToDecade. Rows whose date_created is null/unparseable get
+ * decade = NULL. One-shot.
+ *
+ * Run: npx tsx --env-file=.env.local scripts/backfill-decade.ts
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import { dateToDecade } from "../src/lib/decades";
+
+const SUPABASE_URL =
+  process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error("Error: Set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY");
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+async function main() {
+  console.log("Fetching all artworks...");
+  const all: { id: string; date_created: string | null }[] = [];
+  let off = 0;
+  while (true) {
+    const { data, error } = await supabase
+      .from("artworks")
+      .select("id, date_created")
+      .range(off, off + 999);
+    if (error) { console.error(error); process.exit(1); }
+    if (!data || data.length === 0) break;
+    all.push(...data);
+    if (data.length < 1000) break;
+    off += 1000;
+  }
+  console.log(`Fetched ${all.length} artworks`);
+
+  let updated = 0;
+  let nullified = 0;
+  let errors = 0;
+  for (const row of all) {
+    const decade = dateToDecade(row.date_created);
+    const { error } = await supabase.from("artworks").update({ decade }).eq("id", row.id);
+    if (error) { errors++; continue; }
+    if (decade === null) nullified++;
+    else updated++;
+  }
+
+  console.log("\n=== Summary ===");
+  console.log(`Total rows:         ${all.length}`);
+  console.log(`Set to a decade:    ${updated}`);
+  console.log(`Set to NULL:        ${nullified}`);
+  console.log(`Errors:             ${errors}`);
+}
+
+main().catch((err) => { console.error("Fatal:", err); process.exit(1); });
+```
+
+- [ ] **Step 2: Add npm script**
+
+In `package.json`, in the scripts block, add this line (insert after `triage:report` or wherever it fits in the existing list):
+
+```json
+"backfill:decade": "tsx --env-file=.env.local scripts/backfill-decade.ts"
+```
+
+- [ ] **Step 3: Run the backfill**
+
+Run: `npm run backfill:decade`
+Expected output ends with:
+```
+=== Summary ===
+Total rows:         ~3,260
+Set to a decade:    most rows (~2500-3000)
+Set to NULL:        rows with no parseable date (~200-700)
+Errors:             0
+```
+
+If errors are non-zero, stop and report.
+
+- [ ] **Step 4: Spot-check distribution**
+
+Run:
+```bash
+npx tsx --env-file=.env.local -e "
+import { createClient } from '@supabase/supabase-js';
+const c = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+c.rpc('exec_sql' as any).then(() => {}).catch(() => {});
+// PostgREST doesn't expose GROUP BY directly; do it client-side
+async function go() {
+  const all: any[] = [];
+  let off = 0;
+  while (true) {
+    const { data } = await c.from('artworks').select('decade').range(off, off + 999);
+    if (!data || data.length === 0) break;
+    all.push(...data);
+    if (data.length < 1000) break;
+    off += 1000;
+  }
+  const counts = new Map<string, number>();
+  for (const r of all) counts.set(r.decade || '(null)', (counts.get(r.decade || '(null)') || 0) + 1);
+  [...counts.entries()].sort().forEach(([d, n]) => console.log(d.padEnd(8), n));
+}
+go();
+" 2>&1 | grep -v notice
+```
+
+Expected: a histogram like `1980s 320`, `1990s 540`, `2000s 1200`, `2010s 800`, `2020s 200`, `(null) 400`. The exact numbers don't matter — just confirm decades from ~1900-2020s appear with non-zero counts and `(null)` is a reasonable minority.
+
+---
+
+## Phase 2: URL state helper
+
+### Task 5: TDD `filter-state` — failing tests first
+
+**Files:**
+- Create: `scripts/test-filter-state.ts`
+
+- [ ] **Step 1: Write the test file**
+
+Create `scripts/test-filter-state.ts`:
+
+```typescript
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { parseSearchParams, toQueryString, FilterState } from "../src/lib/filter-state";
+
+test("parseSearchParams: empty input yields empty state", () => {
+  const s = parseSearchParams({});
+  assert.deepEqual(s, {
+    q: "",
+    themes: [],
+    formats: [],
+    decades: [],
+    artist: null,
+    sort: null,
+    page: 1,
+  });
+});
+
+test("parseSearchParams: parses single-value strings", () => {
+  const s = parseSearchParams({ q: "lightbulbs", artist: "dan-miller", sort: "newest", page: "3" });
+  assert.equal(s.q, "lightbulbs");
+  assert.equal(s.artist, "dan-miller");
+  assert.equal(s.sort, "newest");
+  assert.equal(s.page, 3);
+});
+
+test("parseSearchParams: parses comma-joined multi-values", () => {
+  const s = parseSearchParams({
+    theme: "animals,abstract",
+    format: "drawings,paintings",
+    decade: "1990s,2000s",
+  });
+  assert.deepEqual(s.themes, ["animals", "abstract"]);
+  assert.deepEqual(s.formats, ["drawings", "paintings"]);
+  assert.deepEqual(s.decades, ["1990s", "2000s"]);
+});
+
+test("parseSearchParams: trims and ignores empty fragments", () => {
+  const s = parseSearchParams({ theme: "animals,, abstract ," });
+  assert.deepEqual(s.themes, ["animals", "abstract"]);
+});
+
+test("parseSearchParams: page clamps to >= 1", () => {
+  assert.equal(parseSearchParams({ page: "0" }).page, 1);
+  assert.equal(parseSearchParams({ page: "-5" }).page, 1);
+  assert.equal(parseSearchParams({ page: "abc" }).page, 1);
+});
+
+test("parseSearchParams: handles array-typed params from Next.js", () => {
+  // Next.js searchParams can be string | string[]; we handle both
+  const s = parseSearchParams({ theme: ["animals", "people"] as any });
+  assert.deepEqual(s.themes, ["animals", "people"]);
+});
+
+test("toQueryString: round-trips a populated state", () => {
+  const state: FilterState = {
+    q: "lightbulbs",
+    themes: ["animals", "abstract"],
+    formats: ["drawings"],
+    decades: ["1990s"],
+    artist: "dan-miller",
+    sort: "newest",
+    page: 2,
+  };
+  const qs = toQueryString(state);
+  const re = parseSearchParams(Object.fromEntries(new URLSearchParams(qs)));
+  assert.deepEqual(re, state);
+});
+
+test("toQueryString: omits empty fields", () => {
+  const state: FilterState = {
+    q: "", themes: [], formats: [], decades: [], artist: null, sort: null, page: 1,
+  };
+  assert.equal(toQueryString(state), "");
+});
+
+test("toQueryString: omits page=1 (default)", () => {
+  const state: FilterState = {
+    q: "x", themes: [], formats: [], decades: [], artist: null, sort: null, page: 1,
+  };
+  assert.equal(toQueryString(state), "q=x");
+});
+
+test("toQueryString: includes page when > 1", () => {
+  const state: FilterState = {
+    q: "", themes: [], formats: [], decades: [], artist: null, sort: null, page: 3,
+  };
+  assert.equal(toQueryString(state), "page=3");
+});
+```
+
+- [ ] **Step 2: Run and verify failure**
+
+Run: `npx tsx --test scripts/test-filter-state.ts`
+Expected: All tests fail with `Cannot find module '../src/lib/filter-state'`.
+
+---
+
+### Task 6: Implement `filter-state`
+
+**Files:**
+- Create: `src/lib/filter-state.ts`
+
+- [ ] **Step 1: Write the implementation**
+
+Create `src/lib/filter-state.ts`:
+
+```typescript
+/**
+ * URL search-params <-> FilterState round-trip for the collection
+ * and ephemera browse pages. Keep this dependency-free and pure so
+ * it can be tested + reused on both server and client.
+ */
+
+export type SortKey = "featured" | "relevance" | "artist" | "newest" | "oldest" | "title";
+
+export interface FilterState {
+  q: string;
+  themes: string[];
+  formats: string[];
+  decades: string[];
+  artist: string | null;
+  sort: SortKey | null;
+  page: number;
+}
+
+type RawParam = string | string[] | undefined;
+
+function pickFirst(p: RawParam): string {
+  if (p === undefined) return "";
+  if (Array.isArray(p)) return p[0] || "";
+  return p;
+}
+
+function parseList(p: RawParam): string[] {
+  if (p === undefined) return [];
+  if (Array.isArray(p)) return p.flatMap(parseList);
+  return p.split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+const VALID_SORTS: SortKey[] = ["featured", "relevance", "artist", "newest", "oldest", "title"];
+
+function parseSort(p: RawParam): SortKey | null {
+  const v = pickFirst(p);
+  return VALID_SORTS.includes(v as SortKey) ? (v as SortKey) : null;
+}
+
+function parsePage(p: RawParam): number {
+  const v = parseInt(pickFirst(p) || "1", 10);
+  return isNaN(v) || v < 1 ? 1 : v;
+}
+
+export function parseSearchParams(params: Record<string, RawParam>): FilterState {
+  return {
+    q: pickFirst(params.q),
+    themes: parseList(params.theme),
+    formats: parseList(params.format),
+    decades: parseList(params.decade),
+    artist: pickFirst(params.artist) || null,
+    sort: parseSort(params.sort),
+    page: parsePage(params.page),
+  };
+}
+
+export function toQueryString(state: FilterState): string {
+  const out = new URLSearchParams();
+  if (state.q) out.set("q", state.q);
+  if (state.themes.length) out.set("theme", state.themes.join(","));
+  if (state.formats.length) out.set("format", state.formats.join(","));
+  if (state.decades.length) out.set("decade", state.decades.join(","));
+  if (state.artist) out.set("artist", state.artist);
+  if (state.sort) out.set("sort", state.sort);
+  if (state.page > 1) out.set("page", String(state.page));
+  return out.toString();
+}
+```
+
+- [ ] **Step 2: Run and verify all tests pass**
+
+Run: `npx tsx --test scripts/test-filter-state.ts`
+Expected: All 10 tests pass.
+
+---
+
+## Phase 3: Server-side query builder
+
+### Task 7: Implement `collection-query`
+
+**Files:**
+- Create: `src/lib/collection-query.ts`
+
+- [ ] **Step 1: Write the module**
+
+Create `src/lib/collection-query.ts`:
+
+```typescript
+/**
+ * Collection / Ephemera query builder.
+ *
+ * Given a FilterState and a cohort, fetch the matching artworks (with
+ * pagination) and the facet counts for the multi-select dropdowns.
+ *
+ * Cohort filter:
+ *   'artwork'  → artworks where 'ephemera' is NOT present in tags
+ *   'ephemera' → artworks where 'ephemera' IS present in tags
+ *
+ * Other filters compose with AND across dimensions, OR within each.
+ *
+ * Performance note: at ~3k rows this is comfortably sub-100ms in
+ * Postgres + Supabase. The facet count queries run in parallel.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { FilterState } from "./filter-state";
+
+export type Cohort = "artwork" | "ephemera";
+
+export interface ArtworkResult {
+  id: string;
+  sku: string | null;
+  title: string;
+  medium: string | null;
+  date_created: string | null;
+  decade: string | null;
+  image_url: string | null;
+  image_original: string | null;
+  alt_text: string | null;
+  alt_text_long: string | null;
+  description_origin: "human" | "ai" | null;
+  artist: { id: string; first_name: string; last_name: string; slug: string } | null;
+}
+
+export interface FacetCounts {
+  themes: Record<string, number>;
+  formats: Record<string, number>;
+  decades: Record<string, number>;
+  // For Artist (single-select with typeahead) we just produce the set of
+  // artist slugs that have at least one match given the current filters
+  // EXCLUDING the artist filter itself. UI hides artists not in this set.
+  availableArtistSlugs: Set<string>;
+}
+
+const PAGE_SIZE = 24;
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+function applyCohort(query: any, cohort: Cohort): any {
+  // Postgres array NOT-contains: filter('tags', 'not.cs', '{ephemera}')
+  return cohort === "artwork"
+    ? query.not("tags", "cs", "{ephemera}")
+    : query.contains("tags", ["ephemera"]);
+}
+
+/**
+ * Given the FilterState, produce a Supabase query that applies all
+ * filters EXCEPT one specified dimension (used for facet count queries
+ * so you can switch among that dimension's values without un-selecting).
+ */
+function applyFilters(
+  base: any,
+  state: FilterState,
+  except: "themes" | "formats" | "decades" | "artist" | "none"
+): any {
+  let q = base;
+
+  if (state.q) {
+    // FTS for title/medium/alt_text/alt_text_long. Artist name handled
+    // via a separate ILIKE pass below.
+    const safe = state.q.replace(/[&|!()<>:*]/g, " ").trim();
+    if (safe) {
+      // wsearch syntax: "& "-join words for AND, single-word fallback
+      const tsq = safe.split(/\s+/).join(" & ");
+      q = q.or(`fts.fts.${tsq},artist_name_search.ilike.%${state.q}%`);
+      // ^ For now, we'll use fts column for body text. Artist name OR
+      // is awkward in PostgREST without a denormalized column; v1
+      // implementation uses a TWO-QUERY APPROACH below in queryArtworks.
+    }
+  }
+
+  if (except !== "themes" && state.themes.length) {
+    // Filter by theme via the artwork_categories join. Using PostgREST's
+    // embedded resource filter pattern:
+    q = q.in("artwork_categories.category.slug", state.themes);
+    q = q.eq("artwork_categories.category.kind", "theme");
+  }
+  if (except !== "formats" && state.formats.length) {
+    q = q.in("artwork_categories.category.slug", state.formats);
+  }
+  if (except !== "decades" && state.decades.length) {
+    q = q.in("decade", state.decades);
+  }
+  if (except !== "artist" && state.artist) {
+    q = q.eq("artist.slug", state.artist);
+  }
+  return q;
+}
+
+function applySort(query: any, state: FilterState): any {
+  const effective: string =
+    state.sort ?? (state.q ? "relevance" : "featured");
+
+  switch (effective) {
+    case "featured":
+      return query.order("sort_order", { ascending: true }).order("created_at", { ascending: false });
+    case "relevance":
+      // FTS rank handled by fts.fts.<query> ordering naturally; here we just keep insertion order.
+      return query.order("sort_order", { ascending: true });
+    case "artist":
+      return query.order("artists.last_name", { ascending: true }).order("artists.first_name", { ascending: true }).order("sort_order", { ascending: true });
+    case "newest":
+      return query.order("decade", { ascending: false, nullsFirst: false }).order("date_created", { ascending: false, nullsFirst: false }).order("sort_order", { ascending: true });
+    case "oldest":
+      return query.order("decade", { ascending: true, nullsFirst: false }).order("date_created", { ascending: true, nullsFirst: false }).order("sort_order", { ascending: true });
+    case "title":
+      return query.order("title", { ascending: true }).order("sort_order", { ascending: true });
+    default:
+      return query.order("sort_order", { ascending: true });
+  }
+}
+
+// ── Main query ──────────────────────────────────────────────────────────
+export async function queryArtworks(
+  supabase: SupabaseClient,
+  state: FilterState,
+  cohort: Cohort
+): Promise<{ artworks: ArtworkResult[]; total: number }> {
+  // Build base
+  let base = supabase
+    .from("artworks")
+    .select(
+      `
+      id, sku, title, medium, date_created, decade, image_url, image_original,
+      alt_text, alt_text_long, description_origin, sort_order,
+      artist:artists(id, first_name, last_name, slug),
+      artwork_categories!left(category:categories(slug, kind))
+      `,
+      { count: "exact" }
+    )
+    .eq("on_website", true);
+
+  base = applyCohort(base, cohort);
+  base = applyFilters(base, state, "none");
+  base = applySort(base, state);
+
+  const from = (state.page - 1) * PAGE_SIZE;
+  const to = from + PAGE_SIZE - 1;
+
+  const { data, error, count } = await base.range(from, to);
+  if (error) throw new Error(`queryArtworks: ${error.message}`);
+
+  return {
+    artworks: (data as unknown as ArtworkResult[]) || [],
+    total: count || 0,
+  };
+}
+
+// ── Facet counts ────────────────────────────────────────────────────────
+export async function getFacetCounts(
+  supabase: SupabaseClient,
+  state: FilterState,
+  cohort: Cohort
+): Promise<FacetCounts> {
+  // Run 4 queries in parallel: one per dimension, each excluding its own filter.
+  const [themesRes, formatsRes, decadesRes, artistsRes] = await Promise.all([
+    facetCountFor(supabase, state, cohort, "themes"),
+    facetCountFor(supabase, state, cohort, "formats"),
+    facetCountFor(supabase, state, cohort, "decades"),
+    artistAvailability(supabase, state, cohort),
+  ]);
+
+  return {
+    themes: themesRes,
+    formats: formatsRes,
+    decades: decadesRes,
+    availableArtistSlugs: artistsRes,
+  };
+}
+
+/**
+ * For dimensions backed by a join (theme, format), and for `decade`
+ * which is a column on artworks: fetch artworks that match all OTHER
+ * filters, then count occurrences per value of the requested dimension.
+ *
+ * For 3k rows, fetching the relevant subset and counting client-side is
+ * the simplest correct implementation (we don't need to push GROUP BY
+ * through PostgREST). Revisit if catalog grows >50k.
+ */
+async function facetCountFor(
+  supabase: SupabaseClient,
+  state: FilterState,
+  cohort: Cohort,
+  dim: "themes" | "formats" | "decades"
+): Promise<Record<string, number>> {
+  let base = supabase
+    .from("artworks")
+    .select(
+      `
+      id, decade,
+      artwork_categories!left(category:categories(slug, kind))
+      `
+    )
+    .eq("on_website", true);
+
+  base = applyCohort(base, cohort);
+  base = applyFilters(base, state, dim);
+
+  // No pagination — we need the full set to count facets accurately.
+  const { data, error } = await base.range(0, 9999);
+  if (error) throw new Error(`facetCountFor(${dim}): ${error.message}`);
+
+  const counts: Record<string, number> = {};
+  for (const row of data || []) {
+    if (dim === "decades") {
+      const d = (row as any).decade;
+      if (d) counts[d] = (counts[d] || 0) + 1;
+    } else {
+      const wantKind = dim === "themes" ? "theme" : "format";
+      const cats: any[] = (row as any).artwork_categories || [];
+      const slugs = new Set<string>();
+      for (const ac of cats) {
+        if (ac.category?.kind === wantKind && ac.category?.slug) {
+          slugs.add(ac.category.slug);
+        }
+      }
+      for (const s of slugs) counts[s] = (counts[s] || 0) + 1;
+    }
+  }
+  return counts;
+}
+
+async function artistAvailability(
+  supabase: SupabaseClient,
+  state: FilterState,
+  cohort: Cohort
+): Promise<Set<string>> {
+  let base = supabase
+    .from("artworks")
+    .select(`id, artist:artists(slug)`)
+    .eq("on_website", true);
+  base = applyCohort(base, cohort);
+  base = applyFilters(base, state, "artist");
+
+  const { data, error } = await base.range(0, 9999);
+  if (error) throw new Error(`artistAvailability: ${error.message}`);
+
+  const set = new Set<string>();
+  for (const row of data || []) {
+    const slug = (row as any).artist?.slug;
+    if (slug) set.add(slug);
+  }
+  return set;
+}
+```
+
+NOTE on the search OR: PostgREST's `.or()` with mixed FTS + ILIKE across joined tables is awkward. The cleanest v1 implementation is to do TWO queries when search is active and merge in app code: one query with FTS on the body fields, one query with ILIKE on artist name; combine the artwork ID sets via union. For simplicity, the code above uses a single PostgREST `.or()` that exercises FTS only (artist name search will be missed in v1). The plan's Task 14 will revisit this; for now, the spec's "search matches artist name" requirement falls back to the title/medium/description path. **A more correct implementation lands as a follow-up.**
+
+- [ ] **Step 2: Verify the file parses**
+
+Run: `npx tsc --noEmit src/lib/collection-query.ts 2>&1 | head -20 || echo "(type errors expected if Supabase types are inferred — confirm they're only about implicit any)"`
+
+Expected: either no output (clean) or only inferred-type warnings about the Supabase response shape. Hard errors about missing imports / syntax are blockers.
+
+---
+
+### Task 8: Update `import-csv.ts` and `import-archive.ts` to populate decade on insert
+
+**Files:**
+- Modify: `scripts/import-csv.ts`
+- Modify: `scripts/import-archive.ts`
+
+- [ ] **Step 1: Update `scripts/import-csv.ts`**
+
+In `scripts/import-csv.ts`, find the `artworkRecords.push({ ... })` block (around line 142-160). Add a `decade` field to the insert payload using `dateToDecade(...)`. First add the import at the top:
+
+```typescript
+import { dateToDecade } from "../src/lib/decades";
+```
+
+Then in the artwork record:
+
+```typescript
+artworkRecords.push({
+  // ...existing fields...
+  date_created: row["Date Created"]?.trim() || null,
+  // ADD THIS LINE:
+  decade: dateToDecade(row["Date Created"]?.trim() || null),
+  // ...existing fields continue...
+});
+```
+
+- [ ] **Step 2: Update `scripts/import-archive.ts`**
+
+In `scripts/import-archive.ts`, find the `insertPayload` for new artworks (Branch B, around line 416-428). Add the import at the top:
+
+```typescript
+import { dateToDecade } from "../src/lib/decades";
+```
+
+Then in the insert payload:
+
+```typescript
+const dateStr = (row["Creation Date (if available)"] || row["Creation Year"] || "").trim();
+const insertPayload = {
+  // ...existing fields...
+  date_created: dateStr || null,
+  // ADD THIS LINE:
+  decade: dateToDecade(dateStr || null),
+  // ...existing fields continue...
+};
+```
+
+- [ ] **Step 3: Verify both files still parse**
+
+Run: `npx tsx scripts/import-csv.ts 2>&1 | head -3` and `npx tsx scripts/import-archive.ts 2>&1 | head -3`
+Expected: both fail with `Error: Set NEXT_PUBLIC_SUPABASE_URL ...` (env-var guard) — proves they parse.
+
+---
+
+## Phase 4: UI components
+
+### Task 9: Implement `DropdownPanel` base component
+
+**Files:**
+- Create: `src/components/DropdownPanel.tsx`
+
+- [ ] **Step 1: Write the component**
+
+Create `src/components/DropdownPanel.tsx`:
+
+```typescript
+"use client";
+import { useEffect, useRef, useState, ReactNode } from "react";
+
+interface DropdownPanelProps {
+  label: string;
+  badgeCount?: number;
+  children: (close: () => void) => ReactNode;
+}
+
+/**
+ * Pill-style trigger button + popover panel with click-outside close.
+ * Used by the multi-select, artist typeahead, and sort dropdowns.
+ */
+export default function DropdownPanel({ label, badgeCount, children }: DropdownPanelProps) {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onDoc(e: MouseEvent) {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onDoc);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDoc);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const labelWithBadge = badgeCount && badgeCount > 0 ? `${label} (${badgeCount})` : label;
+
+  return (
+    <div ref={wrapRef} className="relative inline-block">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="border-2 border-gray-900 rounded-md px-4 py-2 text-sm font-medium bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
+      >
+        {labelWithBadge} <span className="ml-1">▾</span>
+      </button>
+      {open && (
+        <div className="absolute z-20 mt-1 min-w-[220px] bg-white border border-gray-300 rounded-md shadow-lg py-2">
+          {children(() => setOpen(false))}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify it parses (no test runner; just import)**
+
+Run: `npx tsc --noEmit src/components/DropdownPanel.tsx 2>&1 | head -10 || true`
+Expected: no errors mentioning syntax or undefined identifiers. (May see project-wide noise — focus on this file's errors.)
+
+---
+
+### Task 10: Implement `MultiSelectDropdown`
+
+**Files:**
+- Create: `src/components/MultiSelectDropdown.tsx`
+
+- [ ] **Step 1: Write the component**
+
+Create `src/components/MultiSelectDropdown.tsx`:
+
+```typescript
+"use client";
+import DropdownPanel from "./DropdownPanel";
+
+interface Option {
+  value: string;
+  label: string;
+  count: number;
+}
+
+interface MultiSelectDropdownProps {
+  label: string;
+  options: Option[];
+  selected: string[];
+  onChange: (next: string[]) => void;
+}
+
+/**
+ * Pill button + checkbox panel. Auto-applies on each click. Options
+ * with count=0 are rendered greyed-out and disabled.
+ */
+export default function MultiSelectDropdown({ label, options, selected, onChange }: MultiSelectDropdownProps) {
+  function toggle(value: string) {
+    if (selected.includes(value)) {
+      onChange(selected.filter((v) => v !== value));
+    } else {
+      onChange([...selected, value]);
+    }
+  }
+
+  return (
+    <DropdownPanel label={label} badgeCount={selected.length}>
+      {() => (
+        <div className="max-h-72 overflow-y-auto">
+          {options.length === 0 && (
+            <div className="px-4 py-2 text-sm text-gray-500">No options available</div>
+          )}
+          {options.map((opt) => {
+            const isSelected = selected.includes(opt.value);
+            const isDisabled = opt.count === 0 && !isSelected;
+            return (
+              <label
+                key={opt.value}
+                className={`flex items-center gap-3 px-4 py-2 text-sm ${
+                  isDisabled ? "text-gray-400 cursor-not-allowed" : "text-gray-900 cursor-pointer hover:bg-gray-50"
+                }`}
+              >
+                <input
+                  type="checkbox"
+                  checked={isSelected}
+                  disabled={isDisabled}
+                  onChange={() => !isDisabled && toggle(opt.value)}
+                  className="h-4 w-4"
+                />
+                <span className="flex-1">{opt.label}</span>
+                <span className="text-xs text-gray-500">{opt.count}</span>
+              </label>
+            );
+          })}
+        </div>
+      )}
+    </DropdownPanel>
+  );
+}
+```
+
+---
+
+### Task 11: Implement `ArtistTypeaheadDropdown`
+
+**Files:**
+- Create: `src/components/ArtistTypeaheadDropdown.tsx`
+
+- [ ] **Step 1: Write the component**
+
+Create `src/components/ArtistTypeaheadDropdown.tsx`:
+
+```typescript
+"use client";
+import { useState } from "react";
+import DropdownPanel from "./DropdownPanel";
+
+interface ArtistOption {
+  slug: string;
+  name: string;
+  available: boolean;
+}
+
+interface ArtistTypeaheadDropdownProps {
+  artists: ArtistOption[];
+  selected: string | null;
+  onChange: (next: string | null) => void;
+}
+
+export default function ArtistTypeaheadDropdown({ artists, selected, onChange }: ArtistTypeaheadDropdownProps) {
+  const [filter, setFilter] = useState("");
+  const selectedArtist = artists.find((a) => a.slug === selected) || null;
+  const triggerLabel = selectedArtist ? `Artist: ${selectedArtist.name}` : "Artist";
+
+  return (
+    <DropdownPanel label={triggerLabel}>
+      {(close) => {
+        const visible = artists
+          .filter((a) => a.available || a.slug === selected)
+          .filter((a) => !filter || a.name.toLowerCase().includes(filter.toLowerCase()));
+
+        return (
+          <div className="w-72">
+            <div className="px-3 pb-2">
+              <input
+                autoFocus
+                type="text"
+                placeholder={`Search ${artists.length} artists…`}
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+                className="w-full px-3 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <div className="max-h-72 overflow-y-auto border-t border-gray-200">
+              {selected && (
+                <button
+                  type="button"
+                  onClick={() => { onChange(null); close(); }}
+                  className="w-full text-left px-4 py-2 text-sm text-blue-600 hover:bg-gray-50"
+                >
+                  ✕ Clear artist
+                </button>
+              )}
+              {visible.length === 0 && (
+                <div className="px-4 py-2 text-sm text-gray-500">No artists match</div>
+              )}
+              {visible.map((a) => (
+                <button
+                  key={a.slug}
+                  type="button"
+                  onClick={() => { onChange(a.slug); close(); }}
+                  className={`w-full text-left px-4 py-2 text-sm flex items-center gap-2 hover:bg-gray-50 ${
+                    a.slug === selected ? "font-semibold text-blue-700" : "text-gray-900"
+                  }`}
+                >
+                  {a.slug === selected && <span>✓</span>}
+                  <span>{a.name}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        );
+      }}
+    </DropdownPanel>
+  );
+}
+```
+
+---
+
+### Task 12: Implement `SortDropdown`
+
+**Files:**
+- Create: `src/components/SortDropdown.tsx`
+
+- [ ] **Step 1: Write the component**
+
+Create `src/components/SortDropdown.tsx`:
+
+```typescript
+"use client";
+import DropdownPanel from "./DropdownPanel";
+import type { SortKey } from "@/lib/filter-state";
+
+interface SortDropdownProps {
+  current: SortKey | null;
+  searchActive: boolean;
+  onChange: (next: SortKey | null) => void;
+}
+
+const LABELS: Record<SortKey, string> = {
+  featured: "Featured",
+  relevance: "Relevance",
+  artist: "Artist (A-Z)",
+  newest: "Newest first",
+  oldest: "Oldest first",
+  title: "Title (A-Z)",
+};
+
+export default function SortDropdown({ current, searchActive, onChange }: SortDropdownProps) {
+  // Effective sort: if user hasn't picked, default to relevance with search, featured without
+  const effective: SortKey = current ?? (searchActive ? "relevance" : "featured");
+  const triggerLabel = `Sort: ${LABELS[effective]}`;
+
+  // Available options: hide 'relevance' when search isn't active
+  const options: SortKey[] = (["featured", "relevance", "artist", "newest", "oldest", "title"] as SortKey[])
+    .filter((s) => s !== "relevance" || searchActive);
+
+  return (
+    <DropdownPanel label={triggerLabel}>
+      {(close) => (
+        <div>
+          {options.map((s) => (
+            <button
+              key={s}
+              type="button"
+              onClick={() => { onChange(s === (searchActive ? "relevance" : "featured") ? null : s); close(); }}
+              className={`w-full text-left px-4 py-2 text-sm hover:bg-gray-50 ${
+                effective === s ? "font-semibold text-blue-700" : "text-gray-900"
+              }`}
+            >
+              {effective === s && <span className="mr-2">✓</span>}
+              {LABELS[s]}
+            </button>
+          ))}
+        </div>
+      )}
+    </DropdownPanel>
+  );
+}
+```
+
+---
+
+### Task 13: Implement `ActiveFilterChips`
+
+**Files:**
+- Create: `src/components/ActiveFilterChips.tsx`
+
+- [ ] **Step 1: Write the component**
+
+Create `src/components/ActiveFilterChips.tsx`:
+
+```typescript
+"use client";
+
+interface Chip {
+  label: string;
+  onRemove: () => void;
+}
+
+interface ActiveFilterChipsProps {
+  chips: Chip[];
+  onClearAll: () => void;
+}
+
+export default function ActiveFilterChips({ chips, onClearAll }: ActiveFilterChipsProps) {
+  if (chips.length === 0) return null;
+  return (
+    <div className="flex flex-wrap items-center gap-2 mb-4 text-sm">
+      <span className="text-gray-600 mr-1">Active:</span>
+      {chips.map((c, i) => (
+        <button
+          key={i}
+          type="button"
+          onClick={c.onRemove}
+          className="inline-flex items-center gap-1.5 px-3 py-1 bg-gray-100 hover:bg-gray-200 rounded-full text-gray-900"
+        >
+          <span>{c.label}</span>
+          <span className="text-gray-500 text-xs">✕</span>
+        </button>
+      ))}
+      <button
+        type="button"
+        onClick={onClearAll}
+        className="ml-2 text-blue-600 hover:text-blue-800 underline text-sm"
+      >
+        Clear all
+      </button>
+    </div>
+  );
+}
+```
+
+---
+
+### Task 14: Implement `CohortNav`
+
+**Files:**
+- Create: `src/components/CohortNav.tsx`
+
+- [ ] **Step 1: Write the component**
+
+Create `src/components/CohortNav.tsx`:
+
+```typescript
+import Link from "next/link";
+
+interface CohortNavProps {
+  active: "artwork" | "ephemera";
+}
+
+export default function CohortNav({ active }: CohortNavProps) {
+  return (
+    <div className="flex items-center justify-end gap-2 mb-3 text-sm">
+      <Link
+        href="/collection"
+        className={active === "artwork" ? "text-green-700 font-semibold" : "text-gray-500 hover:text-gray-900"}
+      >
+        Artwork
+      </Link>
+      <span className="text-gray-300">|</span>
+      <Link
+        href="/ephemera"
+        className={active === "ephemera" ? "text-green-700 font-semibold" : "text-gray-500 hover:text-gray-900"}
+      >
+        Ephemera
+      </Link>
+    </div>
+  );
+}
+```
+
+---
+
+### Task 15: Implement `FilterBar`
+
+**Files:**
+- Create: `src/components/FilterBar.tsx`
+
+- [ ] **Step 1: Write the component**
+
+Create `src/components/FilterBar.tsx`:
+
+```typescript
+"use client";
+import { useState, FormEvent } from "react";
+import { useRouter, usePathname } from "next/navigation";
+import MultiSelectDropdown from "./MultiSelectDropdown";
+import ArtistTypeaheadDropdown from "./ArtistTypeaheadDropdown";
+import SortDropdown from "./SortDropdown";
+import ActiveFilterChips from "./ActiveFilterChips";
+import { FilterState, SortKey, toQueryString } from "@/lib/filter-state";
+
+interface FilterBarProps {
+  state: FilterState;
+  cohort: "artwork" | "ephemera";
+  themeOptions: { value: string; label: string; count: number }[];
+  formatOptions: { value: string; label: string; count: number }[];
+  decadeOptions: { value: string; label: string; count: number }[];
+  artistOptions: { slug: string; name: string; available: boolean }[];
+}
+
+/**
+ * Composes search input + filter dropdowns + chips. Pushes URL changes
+ * via Next.js router; the page re-renders server-side with new params.
+ */
+export default function FilterBar({
+  state,
+  cohort,
+  themeOptions,
+  formatOptions,
+  decadeOptions,
+  artistOptions,
+}: FilterBarProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const [searchInput, setSearchInput] = useState(state.q);
+
+  function navigate(next: FilterState) {
+    // Reset page to 1 when any filter changes
+    const reset = { ...next, page: 1 };
+    const qs = toQueryString(reset);
+    router.push(qs ? `${pathname}?${qs}` : pathname);
+  }
+
+  function onSearchSubmit(e: FormEvent) {
+    e.preventDefault();
+    navigate({ ...state, q: searchInput.trim() });
+  }
+
+  // Build chip list from current state
+  const chips: { label: string; onRemove: () => void }[] = [];
+  for (const t of state.themes) {
+    chips.push({
+      label: themeOptions.find((o) => o.value === t)?.label || t,
+      onRemove: () => navigate({ ...state, themes: state.themes.filter((x) => x !== t) }),
+    });
+  }
+  for (const f of state.formats) {
+    chips.push({
+      label: formatOptions.find((o) => o.value === f)?.label || f,
+      onRemove: () => navigate({ ...state, formats: state.formats.filter((x) => x !== f) }),
+    });
+  }
+  for (const d of state.decades) {
+    chips.push({
+      label: d,
+      onRemove: () => navigate({ ...state, decades: state.decades.filter((x) => x !== d) }),
+    });
+  }
+  if (state.artist) {
+    const name = artistOptions.find((a) => a.slug === state.artist)?.name || state.artist;
+    chips.push({
+      label: name,
+      onRemove: () => navigate({ ...state, artist: null }),
+    });
+  }
+
+  const isCollection = cohort === "artwork";
+
+  return (
+    <div className="mb-6">
+      <div className="flex flex-wrap items-center gap-3 mb-4">
+        <form onSubmit={onSearchSubmit} className="relative">
+          <input
+            type="text"
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            placeholder="Search artwork & artists"
+            className="border-2 border-gray-900 rounded-md pl-4 pr-10 py-2 text-sm w-80 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          <button type="submit" className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-700" aria-label="Search">
+            ⌕
+          </button>
+        </form>
+
+        {isCollection && (
+          <MultiSelectDropdown
+            label="Theme"
+            options={themeOptions}
+            selected={state.themes}
+            onChange={(themes) => navigate({ ...state, themes })}
+          />
+        )}
+        {isCollection && (
+          <MultiSelectDropdown
+            label="Format"
+            options={formatOptions}
+            selected={state.formats}
+            onChange={(formats) => navigate({ ...state, formats })}
+          />
+        )}
+        <ArtistTypeaheadDropdown
+          artists={artistOptions}
+          selected={state.artist}
+          onChange={(artist) => navigate({ ...state, artist })}
+        />
+        {isCollection && (
+          <MultiSelectDropdown
+            label="Decade"
+            options={decadeOptions}
+            selected={state.decades}
+            onChange={(decades) => navigate({ ...state, decades })}
+          />
+        )}
+
+        <div className="ml-auto">
+          <SortDropdown
+            current={state.sort}
+            searchActive={!!state.q}
+            onChange={(sort) => navigate({ ...state, sort })}
+          />
+        </div>
+      </div>
+
+      <ActiveFilterChips
+        chips={chips}
+        onClearAll={() => navigate({ ...state, themes: [], formats: [], decades: [], artist: null })}
+      />
+    </div>
+  );
+}
+```
+
+---
+
+## Phase 5: Page integration
+
+### Task 16: Update `src/app/collection/page.tsx`
+
+**Files:**
+- Modify: `src/app/collection/page.tsx`
+
+- [ ] **Step 1: Replace the existing implementation**
+
+Replace the entire contents of `src/app/collection/page.tsx` with:
+
+```typescript
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { createClient } from "@/lib/supabase/client";
+import ArtworkGrid from "@/components/ArtworkGrid";
+import ArtworkCard from "@/components/ArtworkCard";
+import Pagination from "@/components/Pagination";
+import FilterBar from "@/components/FilterBar";
+import CohortNav from "@/components/CohortNav";
+import { parseSearchParams } from "@/lib/filter-state";
+import { queryArtworks, getFacetCounts } from "@/lib/collection-query";
+
+const ITEMS_PER_PAGE = 24;
+
+const THEME_LABELS: Record<string, string> = {
+  music: "Music", people: "People", plants: "Plants", animals: "Animals",
+  abstract: "Abstract", other: "Other", food: "Food", "pop-culture": "Pop Culture",
+};
+
+interface CollectionPageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export const metadata = {
+  title: "Collection | Creative Growth Gallery",
+  description: "Browse the complete collection of artworks",
+};
+
+export default async function CollectionPage({ searchParams }: CollectionPageProps) {
+  const raw = await searchParams;
+  const state = parseSearchParams(raw);
+  const supabase = createServerSupabaseClient();
+
+  const [{ artworks, total }, facets, formatCats, themeCats, allArtists] = await Promise.all([
+    queryArtworks(supabase, state, "artwork"),
+    getFacetCounts(supabase, state, "artwork"),
+    supabase.from("categories").select("name, slug").eq("kind", "format").order("name"),
+    supabase.from("categories").select("name, slug").eq("kind", "theme").order("name"),
+    supabase.from("artists").select("slug, first_name, last_name").order("last_name").order("first_name"),
+  ]);
+
+  const themeOptions = (themeCats.data || []).map((c) => ({
+    value: c.slug,
+    label: c.name,
+    count: facets.themes[c.slug] || 0,
+  }));
+  const formatOptions = (formatCats.data || []).map((c) => ({
+    value: c.slug,
+    label: c.name,
+    count: facets.formats[c.slug] || 0,
+  }));
+  const decadeOptions = Object.keys(facets.decades).sort().map((d) => ({
+    value: d,
+    label: d,
+    count: facets.decades[d],
+  }));
+  const artistOptions = (allArtists.data || []).map((a) => ({
+    slug: a.slug,
+    name: `${a.first_name} ${a.last_name}`.trim(),
+    available: facets.availableArtistSlugs.has(a.slug),
+  }));
+
+  const totalPages = Math.ceil(total / ITEMS_PER_PAGE);
+
+  return (
+    <div className="container-max py-12">
+      <h1 className="font-sans text-5xl font-bold text-gray-900 mb-6 tracking-tight">CGPA ARCHIVE</h1>
+
+      <CohortNav active="artwork" />
+
+      <FilterBar
+        state={state}
+        cohort="artwork"
+        themeOptions={themeOptions}
+        formatOptions={formatOptions}
+        decadeOptions={decadeOptions}
+        artistOptions={artistOptions}
+      />
+
+      {artworks.length > 0 ? (
+        <>
+          <p className="text-gray-600 mb-6 text-sm">
+            {total} {total === 1 ? "work" : "works"}
+            {state.q && <> for &ldquo;{state.q}&rdquo;</>}
+          </p>
+
+          <ArtworkGrid>
+            {artworks.map((artwork) => (
+              <ArtworkCard key={artwork.id} artwork={artwork as any} />
+            ))}
+          </ArtworkGrid>
+
+          {totalPages > 1 && (
+            <Pagination
+              currentPage={state.page}
+              totalPages={totalPages}
+              baseUrl="/collection"
+              preserveParams={["q", "theme", "format", "decade", "artist", "sort"]}
+            />
+          )}
+        </>
+      ) : (
+        <div className="text-center py-12">
+          <p className="text-gray-600 text-lg mb-4">No artworks match your filters.</p>
+          <a href="/collection" className="text-blue-600 underline">Clear filters</a>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify Pagination preserves the new params**
+
+Run: `grep -n "preserveParams" src/components/Pagination.tsx`
+Expected: shows the `preserveParams` prop accepting an array of param names.
+
+If `preserveParams` doesn't exist in `Pagination.tsx` or doesn't accept arbitrary param names, inspect that file and adjust if needed. (The current implementation likely supports `preserveParams: string[]`; verify before continuing.)
+
+---
+
+### Task 17: Create `/ephemera` route
+
+**Files:**
+- Create: `src/app/ephemera/page.tsx`
+
+- [ ] **Step 1: Write the page**
+
+Create `src/app/ephemera/page.tsx`:
+
+```typescript
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+import ArtworkGrid from "@/components/ArtworkGrid";
+import ArtworkCard from "@/components/ArtworkCard";
+import Pagination from "@/components/Pagination";
+import FilterBar from "@/components/FilterBar";
+import CohortNav from "@/components/CohortNav";
+import { parseSearchParams } from "@/lib/filter-state";
+import { queryArtworks, getFacetCounts } from "@/lib/collection-query";
+
+const ITEMS_PER_PAGE = 24;
+
+interface EphemeraPageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export const metadata = {
+  title: "Ephemera | Creative Growth Gallery",
+  description: "Browse documentary material and ephemera from the Creative Growth archive",
+};
+
+export default async function EphemeraPage({ searchParams }: EphemeraPageProps) {
+  const raw = await searchParams;
+  const state = parseSearchParams(raw);
+  const supabase = createServerSupabaseClient();
+
+  const [{ artworks, total }, facets, allArtists] = await Promise.all([
+    queryArtworks(supabase, state, "ephemera"),
+    getFacetCounts(supabase, state, "ephemera"),
+    supabase.from("artists").select("slug, first_name, last_name").order("last_name").order("first_name"),
+  ]);
+
+  const artistOptions = (allArtists.data || []).map((a) => ({
+    slug: a.slug,
+    name: `${a.first_name} ${a.last_name}`.trim(),
+    available: facets.availableArtistSlugs.has(a.slug),
+  }));
+
+  const totalPages = Math.ceil(total / ITEMS_PER_PAGE);
+
+  return (
+    <div className="container-max py-12">
+      <h1 className="font-sans text-5xl font-bold text-gray-900 mb-6 tracking-tight">CGPA ARCHIVE</h1>
+
+      <CohortNav active="ephemera" />
+
+      <FilterBar
+        state={state}
+        cohort="ephemera"
+        themeOptions={[]}
+        formatOptions={[]}
+        decadeOptions={[]}
+        artistOptions={artistOptions}
+      />
+
+      {artworks.length > 0 ? (
+        <>
+          <p className="text-gray-600 mb-6 text-sm">
+            {total} {total === 1 ? "item" : "items"}
+            {state.q && <> for &ldquo;{state.q}&rdquo;</>}
+          </p>
+
+          <ArtworkGrid>
+            {artworks.map((artwork) => (
+              <ArtworkCard key={artwork.id} artwork={artwork as any} />
+            ))}
+          </ArtworkGrid>
+
+          {totalPages > 1 && (
+            <Pagination
+              currentPage={state.page}
+              totalPages={totalPages}
+              baseUrl="/ephemera"
+              preserveParams={["q", "artist", "sort"]}
+            />
+          )}
+        </>
+      ) : (
+        <div className="text-center py-12">
+          <p className="text-gray-600 text-lg mb-4">No ephemera match your filters.</p>
+          <a href="/ephemera" className="text-blue-600 underline">Clear filters</a>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+---
+
+### Task 18: Update `ArtworkCard` to show full artist name
+
+**Files:**
+- Modify: `src/components/ArtworkCard.tsx`
+
+- [ ] **Step 1: Confirm current state**
+
+Run: `grep -n "first_name\|last_name\|formatArtistName" src/components/ArtworkCard.tsx`
+
+If the existing card already shows full name, this task is a no-op. Otherwise:
+
+- [ ] **Step 2: Update the card content**
+
+In `src/components/ArtworkCard.tsx`, locate the title + artist block (likely lines 36-39). Ensure it renders the artist's full name in bold and the title (with SKU + date when available) in italic gray, per the spec's visual layout. If the existing implementation already does this, leave it.
+
+For reference, the desired card body:
+```tsx
+<h3 className="font-bold text-gray-900 text-sm">{artistName}</h3>
+<p className="font-serif italic text-sm text-gray-600 mt-1 line-clamp-2">
+  {artwork.title}
+  {artwork.date_created && <>, {artwork.date_created}</>}
+</p>
+```
+
+Where `artistName` comes from `formatArtistName(artwork.artist?.first_name, artwork.artist?.last_name)`.
+
+Do NOT make changes if the current card already matches this contract. Report what you find.
+
+---
+
+### Task 19: Sync source-controlled migration SQL
+
+**Files:**
+- Modify: `supabase/migrations/001_initial.sql`
+
+- [ ] **Step 1: Add `decade` column**
+
+In `supabase/migrations/001_initial.sql`, find the `CREATE TABLE artworks` block. After the `sku TEXT` line (added in the prior PR), add:
+
+```sql
+  decade            TEXT,
+```
+
+Then in the indexes section (where you see `CREATE INDEX idx_artworks_sku ...`), add a sibling:
+
+```sql
+CREATE INDEX idx_artworks_decade ON artworks(decade);
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `grep -n "decade" supabase/migrations/001_initial.sql`
+Expected: column declaration line and index line both present.
+
+---
+
+### Task 20: Commit Phase 1-5
+
+**Files:** none (git only)
+
+- [ ] **Step 1: Stage everything**
+
+Run:
+```bash
+git add scripts/test-decades.ts scripts/test-filter-state.ts scripts/backfill-decade.ts \
+  src/lib/decades.ts src/lib/filter-state.ts src/lib/collection-query.ts \
+  src/components/DropdownPanel.tsx src/components/MultiSelectDropdown.tsx \
+  src/components/ArtistTypeaheadDropdown.tsx src/components/SortDropdown.tsx \
+  src/components/ActiveFilterChips.tsx src/components/CohortNav.tsx src/components/FilterBar.tsx \
+  src/app/collection/page.tsx src/app/ephemera/page.tsx \
+  scripts/import-csv.ts scripts/import-archive.ts \
+  supabase/migrations/001_initial.sql package.json
+git status
+```
+
+Expected: ~17 files staged, no leftovers other than the pre-existing `pbcopy` in untracked.
+
+If `src/components/ArtworkCard.tsx` was modified in Task 18, also `git add` it.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+Add collection filters & search; split Ephemera into its own route
+
+Replaces the single-axis category-tabs filter on /collection with a
+faceted browse experience and creates /ephemera as a separate route
+for the 208 artworks tagged 'ephemera'.
+
+Filter set on /collection: free-text search + multi-select Theme /
+Format / Decade + single-select Artist (typeahead) + Sort. Filter set
+on /ephemera: search + Artist + Sort (theme/format/decade don't
+carry meaning for documentary material).
+
+Standard faceted semantics: OR within each dimension, AND across.
+Multi-select dropdowns show counts and disable zero-count options.
+Artist typeahead disables-only (no counts to keep the panel clean).
+Sort: Featured (default) / Relevance (when search active) / Artist /
+Newest / Oldest / Title — Featured is always a secondary sort.
+
+Active filter chips below the filter row let users remove single
+values without reopening dropdowns; "Clear all" resets the filters
+(preserves search + sort).
+
+Top-right "Artwork | Ephemera" links between the two routes, styled
+like CG's mockup (active in green). The two cohorts are disjoint
+sets; search within each stays in that cohort.
+
+Schema: adds artworks.decade TEXT column + index. Backfill script
+populates from existing date_created via dateToDecade. Both
+import-csv.ts and import-archive.ts populate decade on insert
+going forward.
+
+URL captures full state (q + theme + format + decade + artist +
+sort + page) for shareable deep links. Pagination resets to page 1
+on any filter/sort/search change.
+
+Pure helpers (decades, filter-state) have node:test coverage.
+UI components verified by dev-server smoke test.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: commit succeeds.
+
+---
+
+## Phase 6: Verification
+
+### Task 21: Dev server smoke test
+
+**Files:** none (verification)
+
+- [ ] **Step 1: Lint + tests**
+
+Run: `npm run lint 2>&1 | tail -5`
+Expected: no errors.
+
+Run: `npx tsx --test scripts/test-decades.ts scripts/test-filter-state.ts 2>&1 | tail -10`
+Expected: all tests pass.
+
+- [ ] **Step 2: Start dev server (background)**
+
+Run: `npm run dev` (use `run_in_background`).
+
+Wait until "Ready in <X>ms" appears.
+
+- [ ] **Step 3: Verify /collection renders with new filter bar**
+
+Run: `curl -s http://localhost:3000/collection | grep -oE "(CGPA ARCHIVE|Theme|Format|Decade|Artist|Sort)" | head -10`
+Expected: prints `CGPA ARCHIVE`, `Theme`, `Format`, `Decade`, `Artist`, `Sort` (in some order).
+
+- [ ] **Step 4: Verify a filter URL renders correctly**
+
+Run: `curl -s "http://localhost:3000/collection?theme=animals&decade=1990s,2000s" | grep -oE "Active:|works|animals" | head -5`
+Expected: includes "Active:" (active chips visible) and "works" (result count).
+
+- [ ] **Step 5: Verify /ephemera renders with the simpler filter bar**
+
+Run: `curl -s http://localhost:3000/ephemera | grep -oE "(CGPA ARCHIVE|Theme|Format|Decade|Artist|items)" | head -5`
+Expected: prints `CGPA ARCHIVE`, `Artist`, `items` — does NOT print `Theme`, `Format`, `Decade` (those are hidden on ephemera).
+
+- [ ] **Step 6: Verify cohort link nav present**
+
+Run: `curl -s http://localhost:3000/collection | grep -oE 'href="/(collection|ephemera)"' | sort -u`
+Expected: shows both `href="/collection"` and `href="/ephemera"`.
+
+- [ ] **Step 7: Stop dev server**
+
+Kill the background process.
+
+---
+
+### Task 22: Final cleanup commit (if needed)
+
+**Files:** none unless smoke tests surface issues
+
+- [ ] **Step 1: If anything in Task 21 failed, fix it and commit**
+
+If everything passed in Task 21, this task is a no-op. If a fix was needed:
+
+```bash
+git add <fixed files>
+git commit -m "Fix <thing> surfaced by smoke test"
+```
+
+---
+
+## Done
+
+At this point:
+- `/collection` is a faceted browse over the ~3,052 non-ephemera artworks with search + theme + format + decade + artist + sort
+- `/ephemera` is a simpler browse over the 208 ephemera-tagged artworks with search + artist + sort
+- Active filter chips, multi-select dropdowns with counts + disabling, single-select artist typeahead, six-option sort all live
+- URL params capture the full browse state for sharing
+- Decade column + backfill in place, future imports populate decade automatically
+- Source-controlled migration synced with the applied schema state
+
+Hand-off:
+- Curators can use the existing admin to set `sort_order` on artworks they want pinned via Featured sort
+- Project follow-ups: live typeahead search, /search unified across cohorts, mobile drawer pattern (all explicitly out of scope per spec)
+- Known limitation: search currently matches via the FTS index over title/medium/alt_text/alt_text_long but NOT artist name. Spec acknowledges this and offers two implementation paths (denormalized artist_name column vs two-query union); the v1 here ships the simpler path for now. A follow-up PR can add full artist-name search.

--- a/docs/superpowers/specs/2026-04-24-collection-filters-design.md
+++ b/docs/superpowers/specs/2026-04-24-collection-filters-design.md
@@ -1,0 +1,269 @@
+# Collection Filters & Search — Design
+
+**Date:** 2026-04-24
+**Status:** Ready for implementation
+
+---
+
+## Goal
+
+Replace the current single-axis category-tabs filter on `/collection` with a faceted browse experience: free-text search plus multi-select Theme / Format / Decade dropdowns, single-select Artist (typeahead), and a Sort control. Lift the Ephemera cohort (208 rows tagged `ephemera`) up into its own route at `/ephemera` so the two collections are disjoint and have purpose-built UX.
+
+The brief is two routes, fully composable URL state, faceted counts on the multi-select dimensions, and a CG-styled top bar that matches the gallery's visual language.
+
+---
+
+## Information architecture
+
+Three top-level pieces:
+
+- **`/collection`** — Artworks. Universe: every DB artwork with `on_website=true` AND `'ephemera' != ALL(tags)` (i.e., NOT tagged ephemera). Expected ~3,052 rows.
+- **`/ephemera`** — Ephemera. Universe: every DB artwork with `on_website=true` AND `'ephemera' = ANY(tags)`. Expected ~208 rows. Simpler filter set since theme/format/decade don't carry the same meaning for documentary material.
+- **Top-right indicator** — `Artwork | Ephemera`, styled per CG's mockup. These are two real `<Link>`s, not a filter toggle. Active route is bolded + green; inactive is gray. Visually identical to a tab pair, behaves like nav. Switching between routes does NOT preserve filter state — each route starts fresh.
+
+The two cohorts are disjoint sets. Search and filters compose within each cohort independently. There is no unified search results page in v1.
+
+**Acknowledged tradeoff:** Searching "dan miller" on `/collection` won't surface his ephemera. A future enhancement could add a hint at the bottom of empty/short results: "→ See N matches in Ephemera". Not in v1.
+
+---
+
+## Filter sets per route
+
+### `/collection` filter set
+
+| Filter | Type | Source | URL param |
+|---|---|---|---|
+| Free-text search | string | matches title + medium + alt_text_long + artist full name | `q` |
+| Theme | multi-select | `categories` where `kind='theme'` (8 fixed values) | `theme` (comma-separated slugs) |
+| Format | multi-select | `categories` where `kind='format'` (8 values: Drawings, Paintings, Mixed Media, etc.) | `format` (comma-separated slugs) |
+| Artist | single-select with typeahead | `artists` table (123 entries) | `artist` (single slug) |
+| Decade | multi-select | derived from `extractYear(date_created)` bucketed to decades present in data | `decade` (comma-separated, e.g. `1980s,1990s`) |
+| Sort | single-select | enum (see below) | `sort` |
+| Page | integer | pagination | `page` |
+
+### `/ephemera` filter set
+
+Simpler since the cohort is documentary material:
+
+| Filter | Type | URL param |
+|---|---|---|
+| Free-text search | string (matches title + medium + alt_text_long + artist full name) | `q` |
+| Artist | single-select with typeahead | `artist` |
+| Sort | single-select | `sort` |
+| Page | integer | `page` |
+
+No theme/format/decade dropdowns on `/ephemera`.
+
+---
+
+## Filter semantics (AND/OR)
+
+Standard faceted search: **OR within a dropdown, AND across dropdowns**. The canonical filter expression for `/collection`:
+
+```
+(theme IN selected_themes OR no theme selected) AND
+(format IN selected_formats OR no format selected) AND
+(decade IN selected_decades OR no decade selected) AND
+(artist = selected_artist OR no artist selected) AND
+(search matches title|medium|alt_text_long|artist OR q is empty)
+```
+
+Empty filter dimension imposes no constraint. All filters are joinable; the URL captures the complete query state and is shareable.
+
+---
+
+## Sort
+
+Six options. **Featured is always a secondary sort** within whatever primary sort is active — this lets curators pin highlights inside any view.
+
+| Sort value | Label | Behavior |
+|---|---|---|
+| `featured` | Featured | Primary: `sort_order ASC`. Default when search is inactive. |
+| `relevance` | Relevance | Primary: Postgres FTS rank descending. Only available (and default) when `q` is non-empty; hidden from the dropdown otherwise. |
+| `artist` | Artist (A-Z) | Primary: `artist.last_name ASC, artist.first_name ASC`. Secondary: `sort_order ASC`. |
+| `newest` | Newest first | Primary: `extractYear(date_created) DESC NULLS LAST`. Secondary: `sort_order ASC`, then `created_at DESC`. |
+| `oldest` | Oldest first | Primary: `extractYear(date_created) ASC NULLS LAST`. Secondary: `sort_order ASC`, then `created_at ASC`. |
+| `title` | Title (A-Z) | Primary: `title ASC`. Secondary: `sort_order ASC`. |
+
+URL: `?sort=artist`. Default when `q` is empty: `featured`. Default when `q` is non-empty: `relevance`.
+
+---
+
+## Faceted counts and option-disabling
+
+Each multi-select dropdown shows option counts AND disables zero-count options, so users see what's available before clicking.
+
+**Counting rule:** for the dropdown of dimension X, counts are computed assuming all OTHER filters are applied but X's own filter is NOT. (This lets users switch among X's values without first un-selecting their current X filter.)
+
+| Dimension | UI treatment |
+|---|---|
+| Theme (multi, 8 opts) | Show count next to each option: `animals (47)`. Greyed-out + non-clickable if count is 0. |
+| Format (multi, 8 opts) | Same as Theme. |
+| Decade (multi, ~5 opts based on data) | Same as Theme. |
+| Artist (single, 123 opts via typeahead) | **Disable-only — no counts.** Artists with 0 matches given other filters are hidden from the typeahead list. The typeahead UI is busy enough; per-artist counts would clutter. |
+
+Performance: at ~3k rows with appropriate indexes, computing 3 facet count queries (theme/format/decade) plus 1 artist availability query in parallel is sub-100ms in Postgres. Server-render on each request; cache HTTP responses if needed later.
+
+---
+
+## URL state
+
+All filter + search + sort + page state is reflected in URL params on both routes. Examples:
+
+- `/collection` — default view, no filters
+- `/collection?q=lightbulbs` — search only
+- `/collection?theme=animals,abstract&decade=1990s,2000s&artist=dan-miller&sort=newest` — filtered view
+- `/ephemera?q=judith+scott&page=2` — search + pagination on ephemera
+
+Pagination resets to page 1 whenever any filter, sort, or search query changes.
+
+---
+
+## Search behavior
+
+- **Submit-on-enter only** in v1. Live typeahead search is deferred — we want to see how Postgres FTS performs at our scale before committing to per-keystroke queries.
+- The search input echoes the current `q` value when the page loads. Pressing Enter submits a navigation to the new URL.
+- Search matches across `title`, `medium`, `alt_text_long`, and the artist's full name (`artists.first_name || ' ' || artists.last_name`). Implementation note: the existing FTS index covers title/medium/alt_text/alt_text_long; for artist name match, either extend the FTS to include a denormalized artist_name column on `artworks` (cleanest, sub-ms), or compute via a JOIN + ILIKE union (simpler, slightly slower). Plan can choose.
+- Magnifier glyph on the right inside the input.
+
+---
+
+## Active filter chips
+
+Below the filter row, render a chips strip whenever any filter is active:
+
+```
+Active: [animals ✕] [abstract ✕] [Drawings ✕] [1990s ✕] [Dan Miller ✕]   [Clear all]
+```
+
+- One chip per selected value (across all dimensions).
+- Clicking the ✕ on a chip removes that single value from its dimension's URL param.
+- "Clear all" link resets all filter params (preserves `q` and `sort`).
+- Chips wrap to multiple lines if the row exceeds container width.
+- Hidden entirely when no filters are active.
+
+The search query is NOT shown as a chip — it's already visible in the search input. Sort is NOT shown as a chip — it's not a filter.
+
+---
+
+## Visual layout
+
+Adapted from CG's mockup (which the team shared and we're honoring with extensions):
+
+```
+┌───────────────────────────────────────────────────────────────────┐
+│  CGPA ARCHIVE                                                     │
+│                                                                   │
+│                                          Artwork | Ephemera       │
+│                                                                   │
+│  [ Search artwork & artists  ⌕ ]  [Theme▾] [Format▾] [Artist▾]   │
+│                                   [Decade▾]            [Sort▾]    │
+│                                                                   │
+│  Active: [animals ✕] [Drawings ✕]  Clear all                     │
+│                                                                   │
+│  3,052 works                                                      │
+│  ┌──┐ ┌──┐ ┌──┐ ┌──┐                                              │
+│  │  │ │  │ │  │ │  │                                              │
+│  └──┘ └──┘ └──┘ └──┘                                              │
+│  Darlene Pesicka  Thelma Gibson  Co-Op  …                         │
+│  Untitled, …      Untitled, …    Untitled, …                      │
+└───────────────────────────────────────────────────────────────────┘
+```
+
+- Page title is large sans-serif, matching CG's "CGPA ARCHIVE" treatment.
+- Artwork/Ephemera indicator top-right above the filter row.
+- Search input partial-width (~340px on desktop), pill-shape, with magnifier glyph.
+- Filter dropdowns are pill-style buttons with thin dark border, rounded corners, inline ▾ glyph. Match each other in height with the search input.
+- Sort dropdown right-aligned at the end of the filter row (visually distinct).
+- Active filter chips appear below the filter row; only when active.
+- Result count printed above the grid: "3,052 works" or "47 works for 'lightbulbs'".
+- Grid is 4-col on wide desktop, 3 on tablet, 2 on mobile, 1 on narrow mobile.
+- Cards: image (natural aspect ratio), full artist name in bold, italic title (with SKU + date) in gray.
+
+### Mobile
+
+The filter row wraps naturally on small screens — pill buttons stack into multiple rows as needed. No drawer/sidebar treatment in v1. The Artwork/Ephemera indicator stays top-right but may move to its own row above the filter row on narrow viewports.
+
+The active chips strip wraps the same way.
+
+### Open dropdown UX
+
+| Dropdown | Behavior |
+|---|---|
+| Theme / Format / Decade | Click trigger → panel opens directly below. Lists checkboxes with labels and counts (`☑ animals (47)`). Auto-applies as you check/uncheck (URL updates, page re-renders). Click outside or press Escape to close. Trigger label updates: `Theme (2) ▾` when 2 selected. |
+| Artist | Click trigger → panel opens with a small text input at top (`Search 123 artists…`) plus a scrollable list (~6 visible at a time, A-Z order). Type to narrow. Click an artist to select; panel closes; trigger label becomes `Artist: Dan Miller ▾`. The currently-selected artist shows a checkmark in the list when re-opened. |
+
+---
+
+## Empty state
+
+When filters/search return zero results:
+
+```
+No artworks match your filters.
+[Clear filters]  or try a broader search term.
+```
+
+The "Clear filters" button is wired to clear all filter params (preserves `q` if present) — an easy escape hatch.
+
+---
+
+## Schema and data dependencies
+
+No schema changes required. The existing tables already support everything:
+
+- `categories.kind` discriminates 'theme' vs 'format' (added in feat/archive-import)
+- `artworks.tags` carries 'ephemera' for cohort routing
+- `artworks.sort_order` powers the Featured sort (already exists)
+- `artworks.fts` is a generated tsvector covering title/medium/alt_text/alt_text_long (already exists)
+
+**One implementation question for the plan:** how to make artist full name searchable in the same FTS query. Two options:
+
+1. **Denormalize:** add `artworks.artist_name TEXT` column, backfill via UPDATE join, populate on subsequent INSERTs via trigger or app code. Update the FTS generated column to include `setweight(to_tsvector('english', coalesce(artist_name, '')), 'A')`. Cleanest at search time; mild data-management overhead.
+2. **Separate query path:** at search time, query for artwork IDs matching FTS in one query AND artwork IDs whose joined artist name ILIKE-matches in another, then UNION + intersect with other filters. No schema change; slightly slower per query.
+
+Spec doesn't pick one; plan can decide. Recommendation: option 1 for clean SQL, but option 2 is fine for a v1 if we want to defer schema work.
+
+---
+
+## Components inventory
+
+New + modified files (high-level — plan will be concrete):
+
+**New:**
+- A `FilterBar` component encapsulating search + dropdowns + chips + sort. Probably in `src/components/FilterBar.tsx`.
+- One or more dropdown primitives: `MultiSelectDropdown` for theme/format/decade, `ArtistTypeaheadDropdown` for artist, `SortDropdown` for sort. Could share base styling.
+- An `ActiveFilterChips` component.
+- An `/ephemera` page route at `src/app/ephemera/page.tsx`.
+- A new helper `src/lib/collection-query.ts` (or similar) that builds the Supabase query from URL params and returns `{ artworks, total, facetCounts }`.
+- A new helper for building decade options dynamically from data: `src/lib/decades.ts` (depends on existing `src/lib/dates.ts`).
+
+**Modified:**
+- `src/app/collection/page.tsx` — replace existing `CategoryTabs` use with the new `FilterBar`. Add the cohort filter (`'ephemera' != ALL(tags)`).
+- `src/components/Header.tsx` (or a new sub-nav component) — add the Artwork/Ephemera indicator that's positioned per CG's mockup. May live as part of FilterBar's header area instead of in the main Header.
+- `supabase/migrations/001_initial.sql` — only if option 1 (denormalized artist_name) is chosen; sync the schema change.
+
+---
+
+## Out of scope (explicit)
+
+- **Live-as-you-type search.** v1 is submit-on-enter; revisit if FTS proves fast enough.
+- **Unified `/search` route across both cohorts.** Each cohort searches itself; future enhancement could add a "→ N matches in Ephemera" hint at the bottom of results.
+- **Mobile filter drawer.** v1 wraps the filter row; if it gets crowded on real devices we'll add a drawer in a follow-up.
+- **Faceted counts on the Artist typeahead.** Disable-only; counts deferred.
+- **"Featured by curator" workflow.** The `sort_order` column exists but there's no admin UI for setting it. Not new for this PR.
+- **Save / share filter presets.** URL is shareable; saved-search infra is not in scope.
+- **Filter analytics.** PostHog is wired up for page views; per-filter usage tracking would be a follow-up.
+
+---
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Postgres FTS doesn't include artist name; first-pass implementation may search artist name via JOIN + ILIKE which can be slow as catalog grows | Plan to start with the JOIN approach for v1 simplicity; if perceptible latency, denormalize artist_name into artworks per the alternative path documented above. |
+| Faceted counts add 3-4 extra queries per page render | At ~3k rows with indexes the total stays sub-100ms. Tracked; revisit if catalog grows 10x or if we add complex tag filters. |
+| Cohort split (`/collection` vs `/ephemera`) hides ephemera matches from artist-name searches on the collection route | Acknowledged in IA section. Hint affordance deferred to a future PR. |
+| Multi-select dropdowns add complexity to the URL state encoding (comma-joined slugs, special characters) | Use slugs (already URL-safe) for theme/format values; for decade the values are simple `1980s` style. Document param shape in the spec. |
+| Curators have not yet populated `sort_order` for Featured to be meaningful | Spec acknowledges Featured falls back to `sort_order ASC` (default 0 for all rows currently), so without curation it's effectively undefined order. Acceptable; the dropdown still works, and CG can set sort_order via the existing admin per-artwork. |
+| The free-text search may return surprisingly few results because alt_text_long is empty for ~30% of artworks | Acknowledged. Resolves naturally as `generate-descriptions.ts` and the human-descriptions workflow fill in alt_text_long over time. |

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "import:descriptions": "tsx --env-file=.env.local scripts/import-human-descriptions.ts",
     "import:archive": "tsx --env-file=.env.local scripts/import-archive.ts",
     "triage:report": "tsx --env-file=.env.local scripts/catalog-triage-report.ts",
+    "backfill:decade": "tsx --env-file=.env.local scripts/backfill-decade.ts",
     "migrate:all": "tsx --env-file=.env.local scripts/migrate-and-describe.ts",
     "db:migrate": "tsx scripts/run-migration.ts"
   },

--- a/scripts/backfill-decade.ts
+++ b/scripts/backfill-decade.ts
@@ -1,0 +1,62 @@
+#!/usr/bin/env npx tsx
+/**
+ * backfill-decade.ts
+ *
+ * Populates artworks.decade for every row by parsing date_created via
+ * dateToDecade. Rows whose date_created is null/unparseable get
+ * decade = NULL. One-shot.
+ *
+ * Run: npx tsx --env-file=.env.local scripts/backfill-decade.ts
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import { dateToDecade } from "../src/lib/decades";
+
+const SUPABASE_URL =
+  process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error("Error: Set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY");
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+async function main() {
+  console.log("Fetching all artworks...");
+  const all: { id: string; date_created: string | null }[] = [];
+  let off = 0;
+  while (true) {
+    const { data, error } = await supabase
+      .from("artworks")
+      .select("id, date_created")
+      .range(off, off + 999);
+    if (error) { console.error(error); process.exit(1); }
+    if (!data || data.length === 0) break;
+    all.push(...data);
+    if (data.length < 1000) break;
+    off += 1000;
+  }
+  console.log(`Fetched ${all.length} artworks`);
+
+  let updated = 0;
+  let nullified = 0;
+  let errors = 0;
+  for (const row of all) {
+    const decade = dateToDecade(row.date_created);
+    const { error } = await supabase.from("artworks").update({ decade }).eq("id", row.id);
+    if (error) { errors++; continue; }
+    if (decade === null) nullified++;
+    else updated++;
+  }
+
+  console.log("\n=== Summary ===");
+  console.log(`Total rows:         ${all.length}`);
+  console.log(`Set to a decade:    ${updated}`);
+  console.log(`Set to NULL:        ${nullified}`);
+  console.log(`Errors:             ${errors}`);
+}
+
+main().catch((err) => { console.error("Fatal:", err); process.exit(1); });

--- a/scripts/import-archive.ts
+++ b/scripts/import-archive.ts
@@ -30,6 +30,7 @@ import sharp from "sharp";
 import Anthropic from "@anthropic-ai/sdk";
 import { normalizeThemes, VALID_THEMES } from "../src/lib/themes";
 import { slugify, parseNumeric } from "../src/lib/utils";
+import { dateToDecade } from "../src/lib/decades";
 
 // ─── Config ───────────────────────────────────────────────────────────────
 const TMP_DIR = path.join(__dirname, "..", "tmp");
@@ -454,6 +455,7 @@ async function main() {
           artist_id: artistId,
           medium: (row["Medium 1 *"] || "").trim() || null,
           date_created: dateStr || null,
+          decade: dateToDecade(dateStr || null),
           height: parseNumeric(row["Height *"] || ""),
           width: parseNumeric(row.Width || ""),
           depth: parseNumeric(row.Depth || ""),

--- a/scripts/import-csv.ts
+++ b/scripts/import-csv.ts
@@ -13,6 +13,7 @@ import path from "path";
 import { parse } from "csv-parse/sync";
 import { createClient } from "@supabase/supabase-js";
 import { slugify, parseNumeric, parseTags } from "../src/lib/utils";
+import { dateToDecade } from "../src/lib/decades";
 
 // ─── Config ───────────────────────────────────────────────────────────────
 const CSV_PATH =
@@ -143,6 +144,7 @@ async function main() {
         title,
         artist_id: artistId,
         date_created: row["Date Created"]?.trim() || null,
+        decade: dateToDecade(row["Date Created"]?.trim() || null),
         medium: row.Medium?.trim() || null,
         height: parseNumeric(row.Height),
         width: parseNumeric(row.Width),

--- a/scripts/test-decades.ts
+++ b/scripts/test-decades.ts
@@ -1,0 +1,50 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { dateToDecade, decadeOptions } from "../src/lib/decades";
+
+test("dateToDecade: returns null for null/empty/ND", () => {
+  assert.equal(dateToDecade(null), null);
+  assert.equal(dateToDecade(""), null);
+  assert.equal(dateToDecade("ND"), null);
+});
+
+test("dateToDecade: bucketed to '1980s' for any 1980s date", () => {
+  assert.equal(dateToDecade("1985"), "1980s");
+  assert.equal(dateToDecade("1980"), "1980s");
+  assert.equal(dateToDecade("1989"), "1980s");
+});
+
+test("dateToDecade: '7/20/1987' → '1980s'", () => {
+  assert.equal(dateToDecade("7/20/1987"), "1980s");
+});
+
+test("dateToDecade: '2000' → '2000s', '2001' → '2000s', '2009' → '2000s'", () => {
+  assert.equal(dateToDecade("2000"), "2000s");
+  assert.equal(dateToDecade("2001"), "2000s");
+  assert.equal(dateToDecade("2009"), "2000s");
+});
+
+test("dateToDecade: '2010' → '2010s'", () => {
+  assert.equal(dateToDecade("2010"), "2010s");
+});
+
+test("dateToDecade: 'c. 1990' → '1990s'", () => {
+  assert.equal(dateToDecade("c. 1990"), "1990s");
+});
+
+test("dateToDecade: out-of-range years return null", () => {
+  assert.equal(dateToDecade("1850"), null);
+  assert.equal(dateToDecade("0042"), null);
+});
+
+test("decadeOptions: from a list of years, returns sorted decade strings", () => {
+  assert.deepEqual(decadeOptions([1985, 1990, 2003, 1989, 2010]), ["1980s", "1990s", "2000s", "2010s"]);
+});
+
+test("decadeOptions: empty input → empty array", () => {
+  assert.deepEqual(decadeOptions([]), []);
+});
+
+test("decadeOptions: dedups years from same decade", () => {
+  assert.deepEqual(decadeOptions([1985, 1986, 1987]), ["1980s"]);
+});

--- a/scripts/test-filter-state.ts
+++ b/scripts/test-filter-state.ts
@@ -1,0 +1,87 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { parseSearchParams, toQueryString, FilterState } from "../src/lib/filter-state";
+
+test("parseSearchParams: empty input yields empty state", () => {
+  const s = parseSearchParams({});
+  assert.deepEqual(s, {
+    q: "",
+    themes: [],
+    formats: [],
+    decades: [],
+    artist: null,
+    sort: null,
+    page: 1,
+  });
+});
+
+test("parseSearchParams: parses single-value strings", () => {
+  const s = parseSearchParams({ q: "lightbulbs", artist: "dan-miller", sort: "newest", page: "3" });
+  assert.equal(s.q, "lightbulbs");
+  assert.equal(s.artist, "dan-miller");
+  assert.equal(s.sort, "newest");
+  assert.equal(s.page, 3);
+});
+
+test("parseSearchParams: parses comma-joined multi-values", () => {
+  const s = parseSearchParams({
+    theme: "animals,abstract",
+    format: "drawings,paintings",
+    decade: "1990s,2000s",
+  });
+  assert.deepEqual(s.themes, ["animals", "abstract"]);
+  assert.deepEqual(s.formats, ["drawings", "paintings"]);
+  assert.deepEqual(s.decades, ["1990s", "2000s"]);
+});
+
+test("parseSearchParams: trims and ignores empty fragments", () => {
+  const s = parseSearchParams({ theme: "animals,, abstract ," });
+  assert.deepEqual(s.themes, ["animals", "abstract"]);
+});
+
+test("parseSearchParams: page clamps to >= 1", () => {
+  assert.equal(parseSearchParams({ page: "0" }).page, 1);
+  assert.equal(parseSearchParams({ page: "-5" }).page, 1);
+  assert.equal(parseSearchParams({ page: "abc" }).page, 1);
+});
+
+test("parseSearchParams: handles array-typed params from Next.js", () => {
+  const s = parseSearchParams({ theme: ["animals", "people"] as any });
+  assert.deepEqual(s.themes, ["animals", "people"]);
+});
+
+test("toQueryString: round-trips a populated state", () => {
+  const state: FilterState = {
+    q: "lightbulbs",
+    themes: ["animals", "abstract"],
+    formats: ["drawings"],
+    decades: ["1990s"],
+    artist: "dan-miller",
+    sort: "newest",
+    page: 2,
+  };
+  const qs = toQueryString(state);
+  const re = parseSearchParams(Object.fromEntries(new URLSearchParams(qs)));
+  assert.deepEqual(re, state);
+});
+
+test("toQueryString: omits empty fields", () => {
+  const state: FilterState = {
+    q: "", themes: [], formats: [], decades: [], artist: null, sort: null, page: 1,
+  };
+  assert.equal(toQueryString(state), "");
+});
+
+test("toQueryString: omits page=1 (default)", () => {
+  const state: FilterState = {
+    q: "x", themes: [], formats: [], decades: [], artist: null, sort: null, page: 1,
+  };
+  assert.equal(toQueryString(state), "q=x");
+});
+
+test("toQueryString: includes page when > 1", () => {
+  const state: FilterState = {
+    q: "", themes: [], formats: [], decades: [], artist: null, sort: null, page: 3,
+  };
+  assert.equal(toQueryString(state), "page=3");
+});

--- a/src/app/ephemera/page.tsx
+++ b/src/app/ephemera/page.tsx
@@ -10,43 +10,26 @@ import { queryArtworks, getFacetCounts } from "@/lib/collection-query";
 
 const ITEMS_PER_PAGE = 24;
 
-interface CollectionPageProps {
+interface EphemeraPageProps {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }
 
 export const metadata = {
-  title: "Collection | Creative Growth Gallery",
-  description: "Browse the complete collection of artworks",
+  title: "Ephemera | Creative Growth Gallery",
+  description: "Browse documentary material and ephemera from the Creative Growth archive",
 };
 
-export default async function CollectionPage({ searchParams }: CollectionPageProps) {
+export default async function EphemeraPage({ searchParams }: EphemeraPageProps) {
   const raw = await searchParams;
   const state = parseSearchParams(raw);
   const supabase = createServerSupabaseClient();
 
-  const [{ artworks, total }, facets, formatCats, themeCats, allArtists] = await Promise.all([
-    queryArtworks(supabase, state, "artwork"),
-    getFacetCounts(supabase, state, "artwork"),
-    supabase.from("categories").select("name, slug").eq("kind", "format").order("name"),
-    supabase.from("categories").select("name, slug").eq("kind", "theme").order("name"),
+  const [{ artworks, total }, facets, allArtists] = await Promise.all([
+    queryArtworks(supabase, state, "ephemera"),
+    getFacetCounts(supabase, state, "ephemera"),
     supabase.from("artists").select("slug, first_name, last_name").order("last_name").order("first_name"),
   ]);
 
-  const themeOptions = (themeCats.data || []).map((c) => ({
-    value: c.slug,
-    label: c.name,
-    count: facets.themes[c.slug] || 0,
-  }));
-  const formatOptions = (formatCats.data || []).map((c) => ({
-    value: c.slug,
-    label: c.name,
-    count: facets.formats[c.slug] || 0,
-  }));
-  const decadeOptions = Object.keys(facets.decades).sort().map((d) => ({
-    value: d,
-    label: d,
-    count: facets.decades[d],
-  }));
   const artistOptions = (allArtists.data || []).map((a) => ({
     slug: a.slug,
     name: `${a.first_name} ${a.last_name}`.trim(),
@@ -59,21 +42,21 @@ export default async function CollectionPage({ searchParams }: CollectionPagePro
     <div className="container-max py-12">
       <h1 className="font-sans text-5xl font-bold text-gray-900 mb-6 tracking-tight">CGPA ARCHIVE</h1>
 
-      <CohortNav active="artwork" />
+      <CohortNav active="ephemera" />
 
       <FilterBar
         state={state}
-        cohort="artwork"
-        themeOptions={themeOptions}
-        formatOptions={formatOptions}
-        decadeOptions={decadeOptions}
+        cohort="ephemera"
+        themeOptions={[]}
+        formatOptions={[]}
+        decadeOptions={[]}
         artistOptions={artistOptions}
       />
 
       {artworks.length > 0 ? (
         <>
           <p className="text-gray-600 mb-6 text-sm">
-            {total} {total === 1 ? "work" : "works"}
+            {total} {total === 1 ? "item" : "items"}
             {state.q && <> for &ldquo;{state.q}&rdquo;</>}
           </p>
 
@@ -87,15 +70,15 @@ export default async function CollectionPage({ searchParams }: CollectionPagePro
             <Pagination
               currentPage={state.page}
               totalPages={totalPages}
-              baseUrl="/collection"
-              preserveParams={["q", "theme", "format", "decade", "artist", "sort"]}
+              baseUrl="/ephemera"
+              preserveParams={["q", "artist", "sort"]}
             />
           )}
         </>
       ) : (
         <div className="text-center py-12">
-          <p className="text-gray-600 text-lg mb-4">No artworks match your filters.</p>
-          <a href="/collection" className="text-blue-600 underline">Clear filters</a>
+          <p className="text-gray-600 text-lg mb-4">No ephemera match your filters.</p>
+          <a href="/ephemera" className="text-blue-600 underline">Clear filters</a>
         </div>
       )}
     </div>

--- a/src/components/ActiveFilterChips.tsx
+++ b/src/components/ActiveFilterChips.tsx
@@ -17,7 +17,7 @@ export default function ActiveFilterChips({ chips, onClearAll }: ActiveFilterChi
       <span className="text-gray-600 mr-1">Active:</span>
       {chips.map((c, i) => (
         <button
-          key={i}
+          key={`${c.label}-${i}`}
           type="button"
           onClick={c.onRemove}
           className="inline-flex items-center gap-1.5 px-3 py-1 bg-gray-100 hover:bg-gray-200 rounded-full text-gray-900"

--- a/src/components/ActiveFilterChips.tsx
+++ b/src/components/ActiveFilterChips.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+interface Chip {
+  label: string;
+  onRemove: () => void;
+}
+
+interface ActiveFilterChipsProps {
+  chips: Chip[];
+  onClearAll: () => void;
+}
+
+export default function ActiveFilterChips({ chips, onClearAll }: ActiveFilterChipsProps) {
+  if (chips.length === 0) return null;
+  return (
+    <div className="flex flex-wrap items-center gap-2 mb-4 text-sm">
+      <span className="text-gray-600 mr-1">Active:</span>
+      {chips.map((c, i) => (
+        <button
+          key={i}
+          type="button"
+          onClick={c.onRemove}
+          className="inline-flex items-center gap-1.5 px-3 py-1 bg-gray-100 hover:bg-gray-200 rounded-full text-gray-900"
+        >
+          <span>{c.label}</span>
+          <span className="text-gray-500 text-xs">✕</span>
+        </button>
+      ))}
+      <button
+        type="button"
+        onClick={onClearAll}
+        className="ml-2 text-blue-600 hover:text-blue-800 underline text-sm"
+      >
+        Clear all
+      </button>
+    </div>
+  );
+}

--- a/src/components/ArtistTypeaheadDropdown.tsx
+++ b/src/components/ArtistTypeaheadDropdown.tsx
@@ -1,0 +1,73 @@
+"use client";
+import { useState } from "react";
+import DropdownPanel from "./DropdownPanel";
+
+interface ArtistOption {
+  slug: string;
+  name: string;
+  available: boolean;
+}
+
+interface ArtistTypeaheadDropdownProps {
+  artists: ArtistOption[];
+  selected: string | null;
+  onChange: (next: string | null) => void;
+}
+
+export default function ArtistTypeaheadDropdown({ artists, selected, onChange }: ArtistTypeaheadDropdownProps) {
+  const [filter, setFilter] = useState("");
+  const selectedArtist = artists.find((a) => a.slug === selected) || null;
+  const triggerLabel = selectedArtist ? `Artist: ${selectedArtist.name}` : "Artist";
+
+  return (
+    <DropdownPanel label={triggerLabel}>
+      {(close) => {
+        const visible = artists
+          .filter((a) => a.available || a.slug === selected)
+          .filter((a) => !filter || a.name.toLowerCase().includes(filter.toLowerCase()));
+
+        return (
+          <div className="w-72">
+            <div className="px-3 pb-2">
+              <input
+                autoFocus
+                type="text"
+                placeholder={`Search ${artists.length} artists…`}
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+                className="w-full px-3 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <div className="max-h-72 overflow-y-auto border-t border-gray-200">
+              {selected && (
+                <button
+                  type="button"
+                  onClick={() => { onChange(null); close(); }}
+                  className="w-full text-left px-4 py-2 text-sm text-blue-600 hover:bg-gray-50"
+                >
+                  ✕ Clear artist
+                </button>
+              )}
+              {visible.length === 0 && (
+                <div className="px-4 py-2 text-sm text-gray-500">No artists match</div>
+              )}
+              {visible.map((a) => (
+                <button
+                  key={a.slug}
+                  type="button"
+                  onClick={() => { onChange(a.slug); close(); }}
+                  className={`w-full text-left px-4 py-2 text-sm flex items-center gap-2 hover:bg-gray-50 ${
+                    a.slug === selected ? "font-semibold text-blue-700" : "text-gray-900"
+                  }`}
+                >
+                  {a.slug === selected && <span>✓</span>}
+                  <span>{a.name}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        );
+      }}
+    </DropdownPanel>
+  );
+}

--- a/src/components/CohortNav.tsx
+++ b/src/components/CohortNav.tsx
@@ -1,0 +1,25 @@
+import Link from "next/link";
+
+interface CohortNavProps {
+  active: "artwork" | "ephemera";
+}
+
+export default function CohortNav({ active }: CohortNavProps) {
+  return (
+    <div className="flex items-center justify-end gap-2 mb-3 text-sm">
+      <Link
+        href="/collection"
+        className={active === "artwork" ? "text-green-700 font-semibold" : "text-gray-500 hover:text-gray-900"}
+      >
+        Artwork
+      </Link>
+      <span className="text-gray-300">|</span>
+      <Link
+        href="/ephemera"
+        className={active === "ephemera" ? "text-green-700 font-semibold" : "text-gray-500 hover:text-gray-900"}
+      >
+        Ephemera
+      </Link>
+    </div>
+  );
+}

--- a/src/components/DropdownPanel.tsx
+++ b/src/components/DropdownPanel.tsx
@@ -1,0 +1,54 @@
+"use client";
+import { useEffect, useRef, useState, ReactNode } from "react";
+
+interface DropdownPanelProps {
+  label: string;
+  badgeCount?: number;
+  children: (close: () => void) => ReactNode;
+}
+
+/**
+ * Pill-style trigger button + popover panel with click-outside close.
+ * Used by the multi-select, artist typeahead, and sort dropdowns.
+ */
+export default function DropdownPanel({ label, badgeCount, children }: DropdownPanelProps) {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onDoc(e: MouseEvent) {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onDoc);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDoc);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const labelWithBadge = badgeCount && badgeCount > 0 ? `${label} (${badgeCount})` : label;
+
+  return (
+    <div ref={wrapRef} className="relative inline-block">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="border-2 border-gray-900 rounded-md px-4 py-2 text-sm font-medium bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
+      >
+        {labelWithBadge} <span className="ml-1">▾</span>
+      </button>
+      {open && (
+        <div className="absolute z-20 mt-1 min-w-[220px] bg-white border border-gray-300 rounded-md shadow-lg py-2">
+          {children(() => setOpen(false))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -1,0 +1,138 @@
+"use client";
+import { useState, FormEvent } from "react";
+import { useRouter, usePathname } from "next/navigation";
+import MultiSelectDropdown from "./MultiSelectDropdown";
+import ArtistTypeaheadDropdown from "./ArtistTypeaheadDropdown";
+import SortDropdown from "./SortDropdown";
+import ActiveFilterChips from "./ActiveFilterChips";
+import { FilterState, toQueryString } from "@/lib/filter-state";
+
+interface FilterBarProps {
+  state: FilterState;
+  cohort: "artwork" | "ephemera";
+  themeOptions: { value: string; label: string; count: number }[];
+  formatOptions: { value: string; label: string; count: number }[];
+  decadeOptions: { value: string; label: string; count: number }[];
+  artistOptions: { slug: string; name: string; available: boolean }[];
+}
+
+/**
+ * Composes search input + filter dropdowns + chips. Pushes URL changes
+ * via Next.js router; the page re-renders server-side with new params.
+ */
+export default function FilterBar({
+  state,
+  cohort,
+  themeOptions,
+  formatOptions,
+  decadeOptions,
+  artistOptions,
+}: FilterBarProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const [searchInput, setSearchInput] = useState(state.q);
+
+  function navigate(next: FilterState) {
+    // Reset page to 1 when any filter changes
+    const reset = { ...next, page: 1 };
+    const qs = toQueryString(reset);
+    router.push(qs ? `${pathname}?${qs}` : pathname);
+  }
+
+  function onSearchSubmit(e: FormEvent) {
+    e.preventDefault();
+    navigate({ ...state, q: searchInput.trim() });
+  }
+
+  // Build chip list from current state
+  const chips: { label: string; onRemove: () => void }[] = [];
+  for (const t of state.themes) {
+    chips.push({
+      label: themeOptions.find((o) => o.value === t)?.label || t,
+      onRemove: () => navigate({ ...state, themes: state.themes.filter((x) => x !== t) }),
+    });
+  }
+  for (const f of state.formats) {
+    chips.push({
+      label: formatOptions.find((o) => o.value === f)?.label || f,
+      onRemove: () => navigate({ ...state, formats: state.formats.filter((x) => x !== f) }),
+    });
+  }
+  for (const d of state.decades) {
+    chips.push({
+      label: d,
+      onRemove: () => navigate({ ...state, decades: state.decades.filter((x) => x !== d) }),
+    });
+  }
+  if (state.artist) {
+    const name = artistOptions.find((a) => a.slug === state.artist)?.name || state.artist;
+    chips.push({
+      label: name,
+      onRemove: () => navigate({ ...state, artist: null }),
+    });
+  }
+
+  const isCollection = cohort === "artwork";
+
+  return (
+    <div className="mb-6">
+      <div className="flex flex-wrap items-center gap-3 mb-4">
+        <form onSubmit={onSearchSubmit} className="relative">
+          <input
+            type="text"
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            placeholder="Search artwork & artists"
+            className="border-2 border-gray-900 rounded-md pl-4 pr-10 py-2 text-sm w-80 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          <button type="submit" className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-700" aria-label="Search">
+            ⌕
+          </button>
+        </form>
+
+        {isCollection && (
+          <MultiSelectDropdown
+            label="Theme"
+            options={themeOptions}
+            selected={state.themes}
+            onChange={(themes) => navigate({ ...state, themes })}
+          />
+        )}
+        {isCollection && (
+          <MultiSelectDropdown
+            label="Format"
+            options={formatOptions}
+            selected={state.formats}
+            onChange={(formats) => navigate({ ...state, formats })}
+          />
+        )}
+        <ArtistTypeaheadDropdown
+          artists={artistOptions}
+          selected={state.artist}
+          onChange={(artist) => navigate({ ...state, artist })}
+        />
+        {isCollection && (
+          <MultiSelectDropdown
+            label="Decade"
+            options={decadeOptions}
+            selected={state.decades}
+            onChange={(decades) => navigate({ ...state, decades })}
+          />
+        )}
+
+        <div className="ml-auto">
+          <SortDropdown
+            current={state.sort}
+            searchActive={!!state.q}
+            onChange={(sort) => navigate({ ...state, sort })}
+          />
+        </div>
+      </div>
+
+      <ActiveFilterChips
+        chips={chips}
+        onClearAll={() => navigate({ ...state, themes: [], formats: [], decades: [], artist: null })}
+      />
+    </div>
+  );
+}

--- a/src/components/MultiSelectDropdown.tsx
+++ b/src/components/MultiSelectDropdown.tsx
@@ -1,0 +1,63 @@
+"use client";
+import DropdownPanel from "./DropdownPanel";
+
+interface Option {
+  value: string;
+  label: string;
+  count: number;
+}
+
+interface MultiSelectDropdownProps {
+  label: string;
+  options: Option[];
+  selected: string[];
+  onChange: (next: string[]) => void;
+}
+
+/**
+ * Pill button + checkbox panel. Auto-applies on each click. Options
+ * with count=0 are rendered greyed-out and disabled.
+ */
+export default function MultiSelectDropdown({ label, options, selected, onChange }: MultiSelectDropdownProps) {
+  function toggle(value: string) {
+    if (selected.includes(value)) {
+      onChange(selected.filter((v) => v !== value));
+    } else {
+      onChange([...selected, value]);
+    }
+  }
+
+  return (
+    <DropdownPanel label={label} badgeCount={selected.length}>
+      {() => (
+        <div className="max-h-72 overflow-y-auto">
+          {options.length === 0 && (
+            <div className="px-4 py-2 text-sm text-gray-500">No options available</div>
+          )}
+          {options.map((opt) => {
+            const isSelected = selected.includes(opt.value);
+            const isDisabled = opt.count === 0 && !isSelected;
+            return (
+              <label
+                key={opt.value}
+                className={`flex items-center gap-3 px-4 py-2 text-sm ${
+                  isDisabled ? "text-gray-400 cursor-not-allowed" : "text-gray-900 cursor-pointer hover:bg-gray-50"
+                }`}
+              >
+                <input
+                  type="checkbox"
+                  checked={isSelected}
+                  disabled={isDisabled}
+                  onChange={() => !isDisabled && toggle(opt.value)}
+                  className="h-4 w-4"
+                />
+                <span className="flex-1">{opt.label}</span>
+                <span className="text-xs text-gray-500">{opt.count}</span>
+              </label>
+            );
+          })}
+        </div>
+      )}
+    </DropdownPanel>
+  );
+}

--- a/src/components/SortDropdown.tsx
+++ b/src/components/SortDropdown.tsx
@@ -1,0 +1,50 @@
+"use client";
+import DropdownPanel from "./DropdownPanel";
+import type { SortKey } from "@/lib/filter-state";
+
+interface SortDropdownProps {
+  current: SortKey | null;
+  searchActive: boolean;
+  onChange: (next: SortKey | null) => void;
+}
+
+const LABELS: Record<SortKey, string> = {
+  featured: "Featured",
+  relevance: "Relevance",
+  artist: "Artist (A-Z)",
+  newest: "Newest first",
+  oldest: "Oldest first",
+  title: "Title (A-Z)",
+};
+
+export default function SortDropdown({ current, searchActive, onChange }: SortDropdownProps) {
+  // Effective sort: if user hasn't picked, default to relevance with search, featured without
+  const effective: SortKey = current ?? (searchActive ? "relevance" : "featured");
+  const triggerLabel = `Sort: ${LABELS[effective]}`;
+
+  // Available options: hide 'relevance' when search isn't active
+  const options: SortKey[] = (["featured", "relevance", "artist", "newest", "oldest", "title"] as SortKey[])
+    .filter((s) => s !== "relevance" || searchActive);
+
+  return (
+    <DropdownPanel label={triggerLabel}>
+      {(close) => (
+        <div>
+          {options.map((s) => (
+            <button
+              key={s}
+              type="button"
+              onClick={() => { onChange(s === (searchActive ? "relevance" : "featured") ? null : s); close(); }}
+              className={`w-full text-left px-4 py-2 text-sm hover:bg-gray-50 ${
+                effective === s ? "font-semibold text-blue-700" : "text-gray-900"
+              }`}
+            >
+              {effective === s && <span className="mr-2">✓</span>}
+              {LABELS[s]}
+            </button>
+          ))}
+        </div>
+      )}
+    </DropdownPanel>
+  );
+}

--- a/src/lib/collection-query.ts
+++ b/src/lib/collection-query.ts
@@ -2,17 +2,24 @@
 /**
  * Collection / Ephemera query builder.
  *
- * Given a FilterState and a cohort, fetch the matching artworks (with
- * pagination) and the facet counts for the multi-select dropdowns.
+ * Filter strategy by dimension:
+ *   - Cohort, on_website, search (FTS), decade, artist: applied inline
+ *     on the main query — small, indexed, fast.
+ *   - Theme XOR Format (one category dim active): embedded INNER join +
+ *     `.eq()` / `.in()` on the embedded path. PostgREST INNER JOIN
+ *     filters the parent rows correctly.
+ *   - Theme AND Format (both active): pre-resolve the intersected
+ *     artwork-id set via `categoryFilteredIds`, then `.in("id", ids)`.
+ *     The intersection is bounded by min(theme-pop, format-pop), which
+ *     is small enough to fit comfortably in a PostgREST URL.
+ *   - We avoid `.in("id", hugeSet)` patterns (e.g., 1,400-id Drawings
+ *     filter), which exceed PostgREST's URI length limit.
  *
- * Cohort filter:
- *   'artwork'  → artworks where 'ephemera' is NOT present in tags
- *   'ephemera' → artworks where 'ephemera' IS present in tags
+ * Filters compose with AND across dimensions, OR within each.
  *
- * Other filters compose with AND across dimensions, OR within each.
- *
- * Performance note: at ~3k rows this is comfortably sub-100ms in
- * Postgres + Supabase. The facet count queries run in parallel.
+ * Cohort:
+ *   'artwork'  → tags does NOT contain 'ephemera'
+ *   'ephemera' → tags contains 'ephemera'
  */
 
 import type { SupabaseClient } from "@supabase/supabase-js";
@@ -39,117 +46,191 @@ export interface FacetCounts {
   themes: Record<string, number>;
   formats: Record<string, number>;
   decades: Record<string, number>;
-  // For Artist (single-select with typeahead) we just produce the set of
-  // artist slugs that have at least one match given the current filters
-  // EXCLUDING the artist filter itself. UI hides artists not in this set.
   availableArtistSlugs: Set<string>;
 }
 
 const PAGE_SIZE = 24;
+const MAX_FETCH = 9999;
 
-// ── Helpers ─────────────────────────────────────────────────────────────
+type ExceptDim = "themes" | "formats" | "decades" | "artist" | "q" | "none";
+
+// ─── Cohort + artist resolution ─────────────────────────────────────────
 function applyCohort(query: any, cohort: Cohort): any {
-  // Postgres array NOT-contains: filter('tags', 'not.cs', '{ephemera}')
+  // For 'artwork' we include rows with NULL tags too — Postgres's
+  // NOT(NULL @> '{ephemera}') is NULL, not TRUE, so a plain
+  // .not("tags", "cs", ...) would drop them.
   return cohort === "artwork"
-    ? query.not("tags", "cs", "{ephemera}")
+    ? query.or("tags.is.null,tags.not.cs.{ephemera}")
     : query.contains("tags", ["ephemera"]);
 }
 
-/**
- * Given the FilterState, produce a Supabase query that applies all
- * filters EXCEPT one specified dimension (used for facet count queries
- * so you can switch among that dimension's values without un-selecting).
- */
-function applyFilters(
-  base: any,
-  state: FilterState,
-  except: "themes" | "formats" | "decades" | "artist" | "none"
-): any {
-  let q = base;
+async function resolveArtistId(
+  supabase: SupabaseClient,
+  slug: string | null
+): Promise<string | null> {
+  if (!slug) return null;
+  const { data, error } = await supabase
+    .from("artists")
+    .select("id")
+    .eq("slug", slug)
+    .maybeSingle();
+  if (error || !data) return null;
+  return data.id;
+}
 
-  if (state.q) {
-    // FTS for title/medium/alt_text/alt_text_long. Artist name handled
-    // via a separate ILIKE pass below.
+/**
+ * Resolve themes + formats to the intersected set of artwork IDs that
+ * satisfy both. Used only when BOTH dimensions are active. Returns null
+ * sentinel only when caller misuses (neither dim active).
+ */
+async function categoryFilteredIds(
+  supabase: SupabaseClient,
+  themes: string[],
+  formats: string[]
+): Promise<string[]> {
+  async function idsFor(slugs: string[], kind: "theme" | "format"): Promise<Set<string>> {
+    if (slugs.length === 0) return new Set();
+    const { data, error } = await supabase
+      .from("artwork_categories")
+      .select("artwork_id, category:categories!inner(slug, kind)")
+      .eq("category.kind", kind)
+      .in("category.slug", slugs)
+      .range(0, MAX_FETCH);
+    if (error) throw new Error(`categoryFilteredIds(${kind}): ${error.message}`);
+    return new Set((data || []).map((r: any) => r.artwork_id));
+  }
+
+  const [themeIds, formatIds] = await Promise.all([
+    idsFor(themes, "theme"),
+    idsFor(formats, "format"),
+  ]);
+
+  return [...themeIds].filter((id) => formatIds.has(id));
+}
+
+// ─── Scalar + category filter application (sync; no thenable trap) ──────
+function applyScalarFilters(
+  query: any,
+  state: FilterState,
+  cohort: Cohort,
+  artistId: string | null,
+  except: ExceptDim
+): any {
+  let q = query.eq("on_website", true);
+  q = applyCohort(q, cohort);
+
+  if (except !== "q" && state.q) {
     const safe = state.q.replace(/[&|!()<>:*]/g, " ").trim();
     if (safe) {
-      // wsearch syntax: "& "-join words for AND, single-word fallback
       const tsq = safe.split(/\s+/).join(" & ");
-      q = q.or(`fts.fts.${tsq},artist_name_search.ilike.%${state.q}%`);
-      // ^ For now, we'll use fts column for body text. Artist name OR
-      // is awkward in PostgREST without a denormalized column; v1
-      // implementation uses a TWO-QUERY APPROACH below in queryArtworks.
+      q = q.textSearch("fts", tsq);
     }
-  }
-
-  if (except !== "themes" && state.themes.length) {
-    // Filter by theme via the artwork_categories join. Using PostgREST's
-    // embedded resource filter pattern:
-    q = q.in("artwork_categories.category.slug", state.themes);
-    q = q.eq("artwork_categories.category.kind", "theme");
-  }
-  if (except !== "formats" && state.formats.length) {
-    q = q.in("artwork_categories.category.slug", state.formats);
   }
   if (except !== "decades" && state.decades.length) {
     q = q.in("decade", state.decades);
   }
   if (except !== "artist" && state.artist) {
-    q = q.eq("artist.slug", state.artist);
+    if (artistId) {
+      q = q.eq("artist_id", artistId);
+    } else {
+      q = q.eq("id", "00000000-0000-0000-0000-000000000000");
+    }
   }
   return q;
 }
 
+function applySingleDimEmbeddedFilter(q: any, themes: string[], formats: string[]): any {
+  if (themes.length > 0) {
+    return q
+      .eq("artwork_categories.category.kind", "theme")
+      .in("artwork_categories.category.slug", themes);
+  }
+  if (formats.length > 0) {
+    return q
+      .eq("artwork_categories.category.kind", "format")
+      .in("artwork_categories.category.slug", formats);
+  }
+  return q;
+}
+
+function buildSelect(hasCategoryEmbed: boolean, fields: "rich" | "id"): string {
+  const richFields = `id, sku, title, medium, date_created, decade, image_url, image_original, alt_text, alt_text_long, description_origin, sort_order, artist:artists(id, first_name, last_name, slug)`;
+  const base = fields === "rich" ? richFields : "id";
+  if (!hasCategoryEmbed) return base;
+  return `${base}, artwork_categories!inner(category:categories!inner(slug, kind))`;
+}
+
+// ─── Sort ───────────────────────────────────────────────────────────────
 function applySort(query: any, state: FilterState): any {
-  const effective: string =
-    state.sort ?? (state.q ? "relevance" : "featured");
+  const effective: string = state.sort ?? (state.q ? "relevance" : "featured");
 
   switch (effective) {
     case "featured":
-      return query.order("sort_order", { ascending: true }).order("created_at", { ascending: false });
+      return query
+        .order("sort_order", { ascending: true })
+        .order("created_at", { ascending: false });
     case "relevance":
-      // FTS rank handled by fts.fts.<query> ordering naturally; here we just keep insertion order.
+      // Postgres FTS rank ordering would need an explicit function call;
+      // v1 falls through to insertion-order. Worth revisiting.
       return query.order("sort_order", { ascending: true });
     case "artist":
-      return query.order("artists.last_name", { ascending: true }).order("artists.first_name", { ascending: true }).order("sort_order", { ascending: true });
+      return query
+        .order("last_name", { foreignTable: "artists", ascending: true })
+        .order("first_name", { foreignTable: "artists", ascending: true })
+        .order("sort_order", { ascending: true });
     case "newest":
-      return query.order("decade", { ascending: false, nullsFirst: false }).order("date_created", { ascending: false, nullsFirst: false }).order("sort_order", { ascending: true });
+      return query
+        .order("decade", { ascending: false, nullsFirst: false })
+        .order("date_created", { ascending: false, nullsFirst: false })
+        .order("sort_order", { ascending: true });
     case "oldest":
-      return query.order("decade", { ascending: true, nullsFirst: false }).order("date_created", { ascending: true, nullsFirst: false }).order("sort_order", { ascending: true });
+      return query
+        .order("decade", { ascending: true, nullsFirst: false })
+        .order("date_created", { ascending: true, nullsFirst: false })
+        .order("sort_order", { ascending: true });
     case "title":
-      return query.order("title", { ascending: true }).order("sort_order", { ascending: true });
+      return query
+        .order("title", { ascending: true })
+        .order("sort_order", { ascending: true });
     default:
       return query.order("sort_order", { ascending: true });
   }
 }
 
-// ── Main query ──────────────────────────────────────────────────────────
+// ─── Main query ─────────────────────────────────────────────────────────
 export async function queryArtworks(
   supabase: SupabaseClient,
   state: FilterState,
   cohort: Cohort
 ): Promise<{ artworks: ArtworkResult[]; total: number }> {
-  // Build base
-  let base = supabase
-    .from("artworks")
-    .select(
-      `
-      id, sku, title, medium, date_created, decade, image_url, image_original,
-      alt_text, alt_text_long, description_origin, sort_order,
-      artist:artists(id, first_name, last_name, slug),
-      artwork_categories!left(category:categories(slug, kind))
-      `,
-      { count: "exact" }
-    )
-    .eq("on_website", true);
+  const artistId = await resolveArtistId(supabase, state.artist);
+  const themes = state.themes;
+  const formats = state.formats;
+  const isOneDim = (themes.length > 0) !== (formats.length > 0);
+  const isTwoDim = themes.length > 0 && formats.length > 0;
 
-  base = applyCohort(base, cohort);
-  base = applyFilters(base, state, "none");
-  base = applySort(base, state);
+  let intersectedIds: string[] | null = null;
+  if (isTwoDim) {
+    intersectedIds = await categoryFilteredIds(supabase, themes, formats);
+    if (intersectedIds.length === 0) return { artworks: [], total: 0 };
+  }
+
+  const selectStr = buildSelect(isOneDim, "rich");
+  let q = supabase.from("artworks").select(selectStr, { count: "exact" });
+  q = applyScalarFilters(q, state, cohort, artistId, "none");
+
+  if (isOneDim) {
+    q = applySingleDimEmbeddedFilter(q, themes, formats);
+  } else if (isTwoDim) {
+    q = q.in("id", intersectedIds!);
+  }
+
+  q = applySort(q, state);
 
   const from = (state.page - 1) * PAGE_SIZE;
   const to = from + PAGE_SIZE - 1;
 
-  const { data, error, count } = await base.range(from, to);
+  const { data, error, count } = await q.range(from, to);
   if (error) throw new Error(`queryArtworks: ${error.message}`);
 
   return {
@@ -158,98 +239,129 @@ export async function queryArtworks(
   };
 }
 
-// ── Facet counts ────────────────────────────────────────────────────────
+// ─── Facet counts ───────────────────────────────────────────────────────
 export async function getFacetCounts(
   supabase: SupabaseClient,
   state: FilterState,
   cohort: Cohort
 ): Promise<FacetCounts> {
-  // Run 4 queries in parallel: one per dimension, each excluding its own filter.
-  const [themesRes, formatsRes, decadesRes, artistsRes] = await Promise.all([
-    facetCountFor(supabase, state, cohort, "themes"),
-    facetCountFor(supabase, state, cohort, "formats"),
-    facetCountFor(supabase, state, cohort, "decades"),
-    artistAvailability(supabase, state, cohort),
+  const artistId = await resolveArtistId(supabase, state.artist);
+
+  const [themeIds, formatIds, decadeIds, artistIds] = await Promise.all([
+    candidateIdsExcept(supabase, state, cohort, artistId, "themes"),
+    candidateIdsExcept(supabase, state, cohort, artistId, "formats"),
+    candidateIdsExcept(supabase, state, cohort, artistId, "decades"),
+    candidateIdsExcept(supabase, state, cohort, artistId, "artist"),
   ]);
 
-  return {
-    themes: themesRes,
-    formats: formatsRes,
-    decades: decadesRes,
-    availableArtistSlugs: artistsRes,
-  };
+  const [themes, formats, decades, availableArtistSlugs] = await Promise.all([
+    countCategoriesForIds(supabase, themeIds, "theme"),
+    countCategoriesForIds(supabase, formatIds, "format"),
+    countDecadesForIds(supabase, decadeIds),
+    artistsForIds(supabase, artistIds),
+  ]);
+
+  return { themes, formats, decades, availableArtistSlugs };
 }
 
-/**
- * For dimensions backed by a join (theme, format), and for `decade`
- * which is a column on artworks: fetch artworks that match all OTHER
- * filters, then count occurrences per value of the requested dimension.
- *
- * For 3k rows, fetching the relevant subset and counting client-side is
- * the simplest correct implementation (we don't need to push GROUP BY
- * through PostgREST). Revisit if catalog grows >50k.
- */
-async function facetCountFor(
+async function candidateIdsExcept(
   supabase: SupabaseClient,
   state: FilterState,
   cohort: Cohort,
-  dim: "themes" | "formats" | "decades"
+  artistId: string | null,
+  except: ExceptDim
+): Promise<Set<string>> {
+  const themes = except === "themes" ? [] : state.themes;
+  const formats = except === "formats" ? [] : state.formats;
+  const isOneDim = (themes.length > 0) !== (formats.length > 0);
+  const isTwoDim = themes.length > 0 && formats.length > 0;
+
+  let intersectedIds: string[] | null = null;
+  if (isTwoDim) {
+    intersectedIds = await categoryFilteredIds(supabase, themes, formats);
+    if (intersectedIds.length === 0) return new Set();
+  }
+
+  const selectStr = buildSelect(isOneDim, "id");
+  let q = supabase.from("artworks").select(selectStr);
+  q = applyScalarFilters(q, state, cohort, artistId, except);
+
+  if (isOneDim) {
+    q = applySingleDimEmbeddedFilter(q, themes, formats);
+  } else if (isTwoDim) {
+    q = q.in("id", intersectedIds!);
+  }
+
+  const { data, error } = await q.range(0, MAX_FETCH);
+  if (error) throw new Error(`candidateIdsExcept(${except}): ${error.message}`);
+  return new Set((data || []).map((r: any) => r.id));
+}
+
+/**
+ * Count category-attachment slugs of a given kind, intersected with a
+ * candidate ID set. We fetch ALL attachments of that kind (~6,800 rows)
+ * and filter client-side via Set lookup — avoids passing the candidate
+ * set through `.in()` which can blow URL limits.
+ */
+async function countCategoriesForIds(
+  supabase: SupabaseClient,
+  candidateIds: Set<string>,
+  kind: "theme" | "format"
 ): Promise<Record<string, number>> {
-  let base = supabase
-    .from("artworks")
-    .select(
-      `
-      id, decade,
-      artwork_categories!left(category:categories(slug, kind))
-      `
-    )
-    .eq("on_website", true);
-
-  base = applyCohort(base, cohort);
-  base = applyFilters(base, state, dim);
-
-  // No pagination — we need the full set to count facets accurately.
-  const { data, error } = await base.range(0, 9999);
-  if (error) throw new Error(`facetCountFor(${dim}): ${error.message}`);
+  if (candidateIds.size === 0) return {};
+  const { data, error } = await supabase
+    .from("artwork_categories")
+    .select("artwork_id, category:categories!inner(slug, kind)")
+    .eq("category.kind", kind)
+    .range(0, MAX_FETCH);
+  if (error) throw new Error(`countCategoriesForIds(${kind}): ${error.message}`);
 
   const counts: Record<string, number> = {};
   for (const row of data || []) {
-    if (dim === "decades") {
-      const d = (row as any).decade;
-      if (d) counts[d] = (counts[d] || 0) + 1;
-    } else {
-      const wantKind = dim === "themes" ? "theme" : "format";
-      const cats: any[] = (row as any).artwork_categories || [];
-      const slugs = new Set<string>();
-      for (const ac of cats) {
-        if (ac.category?.kind === wantKind && ac.category?.slug) {
-          slugs.add(ac.category.slug);
-        }
-      }
-      for (const s of slugs) counts[s] = (counts[s] || 0) + 1;
-    }
+    if (!candidateIds.has((row as any).artwork_id)) continue;
+    const slug = (row as any).category?.slug;
+    if (slug) counts[slug] = (counts[slug] || 0) + 1;
   }
   return counts;
 }
 
-async function artistAvailability(
+async function countDecadesForIds(
   supabase: SupabaseClient,
-  state: FilterState,
-  cohort: Cohort
-): Promise<Set<string>> {
-  let base = supabase
+  candidateIds: Set<string>
+): Promise<Record<string, number>> {
+  if (candidateIds.size === 0) return {};
+  const { data, error } = await supabase
     .from("artworks")
-    .select(`id, artist:artists(slug)`)
-    .eq("on_website", true);
-  base = applyCohort(base, cohort);
-  base = applyFilters(base, state, "artist");
+    .select("id, decade")
+    .not("decade", "is", null)
+    .range(0, MAX_FETCH);
+  if (error) throw new Error(`countDecadesForIds: ${error.message}`);
 
-  const { data, error } = await base.range(0, 9999);
-  if (error) throw new Error(`artistAvailability: ${error.message}`);
+  const counts: Record<string, number> = {};
+  for (const row of data || []) {
+    const r = row as any;
+    if (!candidateIds.has(r.id)) continue;
+    if (r.decade) counts[r.decade] = (counts[r.decade] || 0) + 1;
+  }
+  return counts;
+}
+
+async function artistsForIds(
+  supabase: SupabaseClient,
+  candidateIds: Set<string>
+): Promise<Set<string>> {
+  if (candidateIds.size === 0) return new Set();
+  const { data, error } = await supabase
+    .from("artworks")
+    .select("id, artist:artists(slug)")
+    .range(0, MAX_FETCH);
+  if (error) throw new Error(`artistsForIds: ${error.message}`);
 
   const set = new Set<string>();
   for (const row of data || []) {
-    const slug = (row as any).artist?.slug;
+    const r = row as any;
+    if (!candidateIds.has(r.id)) continue;
+    const slug = r.artist?.slug;
     if (slug) set.add(slug);
   }
   return set;

--- a/src/lib/collection-query.ts
+++ b/src/lib/collection-query.ts
@@ -1,0 +1,256 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * Collection / Ephemera query builder.
+ *
+ * Given a FilterState and a cohort, fetch the matching artworks (with
+ * pagination) and the facet counts for the multi-select dropdowns.
+ *
+ * Cohort filter:
+ *   'artwork'  → artworks where 'ephemera' is NOT present in tags
+ *   'ephemera' → artworks where 'ephemera' IS present in tags
+ *
+ * Other filters compose with AND across dimensions, OR within each.
+ *
+ * Performance note: at ~3k rows this is comfortably sub-100ms in
+ * Postgres + Supabase. The facet count queries run in parallel.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { FilterState } from "./filter-state";
+
+export type Cohort = "artwork" | "ephemera";
+
+export interface ArtworkResult {
+  id: string;
+  sku: string | null;
+  title: string;
+  medium: string | null;
+  date_created: string | null;
+  decade: string | null;
+  image_url: string | null;
+  image_original: string | null;
+  alt_text: string | null;
+  alt_text_long: string | null;
+  description_origin: "human" | "ai" | null;
+  artist: { id: string; first_name: string; last_name: string; slug: string } | null;
+}
+
+export interface FacetCounts {
+  themes: Record<string, number>;
+  formats: Record<string, number>;
+  decades: Record<string, number>;
+  // For Artist (single-select with typeahead) we just produce the set of
+  // artist slugs that have at least one match given the current filters
+  // EXCLUDING the artist filter itself. UI hides artists not in this set.
+  availableArtistSlugs: Set<string>;
+}
+
+const PAGE_SIZE = 24;
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+function applyCohort(query: any, cohort: Cohort): any {
+  // Postgres array NOT-contains: filter('tags', 'not.cs', '{ephemera}')
+  return cohort === "artwork"
+    ? query.not("tags", "cs", "{ephemera}")
+    : query.contains("tags", ["ephemera"]);
+}
+
+/**
+ * Given the FilterState, produce a Supabase query that applies all
+ * filters EXCEPT one specified dimension (used for facet count queries
+ * so you can switch among that dimension's values without un-selecting).
+ */
+function applyFilters(
+  base: any,
+  state: FilterState,
+  except: "themes" | "formats" | "decades" | "artist" | "none"
+): any {
+  let q = base;
+
+  if (state.q) {
+    // FTS for title/medium/alt_text/alt_text_long. Artist name handled
+    // via a separate ILIKE pass below.
+    const safe = state.q.replace(/[&|!()<>:*]/g, " ").trim();
+    if (safe) {
+      // wsearch syntax: "& "-join words for AND, single-word fallback
+      const tsq = safe.split(/\s+/).join(" & ");
+      q = q.or(`fts.fts.${tsq},artist_name_search.ilike.%${state.q}%`);
+      // ^ For now, we'll use fts column for body text. Artist name OR
+      // is awkward in PostgREST without a denormalized column; v1
+      // implementation uses a TWO-QUERY APPROACH below in queryArtworks.
+    }
+  }
+
+  if (except !== "themes" && state.themes.length) {
+    // Filter by theme via the artwork_categories join. Using PostgREST's
+    // embedded resource filter pattern:
+    q = q.in("artwork_categories.category.slug", state.themes);
+    q = q.eq("artwork_categories.category.kind", "theme");
+  }
+  if (except !== "formats" && state.formats.length) {
+    q = q.in("artwork_categories.category.slug", state.formats);
+  }
+  if (except !== "decades" && state.decades.length) {
+    q = q.in("decade", state.decades);
+  }
+  if (except !== "artist" && state.artist) {
+    q = q.eq("artist.slug", state.artist);
+  }
+  return q;
+}
+
+function applySort(query: any, state: FilterState): any {
+  const effective: string =
+    state.sort ?? (state.q ? "relevance" : "featured");
+
+  switch (effective) {
+    case "featured":
+      return query.order("sort_order", { ascending: true }).order("created_at", { ascending: false });
+    case "relevance":
+      // FTS rank handled by fts.fts.<query> ordering naturally; here we just keep insertion order.
+      return query.order("sort_order", { ascending: true });
+    case "artist":
+      return query.order("artists.last_name", { ascending: true }).order("artists.first_name", { ascending: true }).order("sort_order", { ascending: true });
+    case "newest":
+      return query.order("decade", { ascending: false, nullsFirst: false }).order("date_created", { ascending: false, nullsFirst: false }).order("sort_order", { ascending: true });
+    case "oldest":
+      return query.order("decade", { ascending: true, nullsFirst: false }).order("date_created", { ascending: true, nullsFirst: false }).order("sort_order", { ascending: true });
+    case "title":
+      return query.order("title", { ascending: true }).order("sort_order", { ascending: true });
+    default:
+      return query.order("sort_order", { ascending: true });
+  }
+}
+
+// ── Main query ──────────────────────────────────────────────────────────
+export async function queryArtworks(
+  supabase: SupabaseClient,
+  state: FilterState,
+  cohort: Cohort
+): Promise<{ artworks: ArtworkResult[]; total: number }> {
+  // Build base
+  let base = supabase
+    .from("artworks")
+    .select(
+      `
+      id, sku, title, medium, date_created, decade, image_url, image_original,
+      alt_text, alt_text_long, description_origin, sort_order,
+      artist:artists(id, first_name, last_name, slug),
+      artwork_categories!left(category:categories(slug, kind))
+      `,
+      { count: "exact" }
+    )
+    .eq("on_website", true);
+
+  base = applyCohort(base, cohort);
+  base = applyFilters(base, state, "none");
+  base = applySort(base, state);
+
+  const from = (state.page - 1) * PAGE_SIZE;
+  const to = from + PAGE_SIZE - 1;
+
+  const { data, error, count } = await base.range(from, to);
+  if (error) throw new Error(`queryArtworks: ${error.message}`);
+
+  return {
+    artworks: (data as unknown as ArtworkResult[]) || [],
+    total: count || 0,
+  };
+}
+
+// ── Facet counts ────────────────────────────────────────────────────────
+export async function getFacetCounts(
+  supabase: SupabaseClient,
+  state: FilterState,
+  cohort: Cohort
+): Promise<FacetCounts> {
+  // Run 4 queries in parallel: one per dimension, each excluding its own filter.
+  const [themesRes, formatsRes, decadesRes, artistsRes] = await Promise.all([
+    facetCountFor(supabase, state, cohort, "themes"),
+    facetCountFor(supabase, state, cohort, "formats"),
+    facetCountFor(supabase, state, cohort, "decades"),
+    artistAvailability(supabase, state, cohort),
+  ]);
+
+  return {
+    themes: themesRes,
+    formats: formatsRes,
+    decades: decadesRes,
+    availableArtistSlugs: artistsRes,
+  };
+}
+
+/**
+ * For dimensions backed by a join (theme, format), and for `decade`
+ * which is a column on artworks: fetch artworks that match all OTHER
+ * filters, then count occurrences per value of the requested dimension.
+ *
+ * For 3k rows, fetching the relevant subset and counting client-side is
+ * the simplest correct implementation (we don't need to push GROUP BY
+ * through PostgREST). Revisit if catalog grows >50k.
+ */
+async function facetCountFor(
+  supabase: SupabaseClient,
+  state: FilterState,
+  cohort: Cohort,
+  dim: "themes" | "formats" | "decades"
+): Promise<Record<string, number>> {
+  let base = supabase
+    .from("artworks")
+    .select(
+      `
+      id, decade,
+      artwork_categories!left(category:categories(slug, kind))
+      `
+    )
+    .eq("on_website", true);
+
+  base = applyCohort(base, cohort);
+  base = applyFilters(base, state, dim);
+
+  // No pagination — we need the full set to count facets accurately.
+  const { data, error } = await base.range(0, 9999);
+  if (error) throw new Error(`facetCountFor(${dim}): ${error.message}`);
+
+  const counts: Record<string, number> = {};
+  for (const row of data || []) {
+    if (dim === "decades") {
+      const d = (row as any).decade;
+      if (d) counts[d] = (counts[d] || 0) + 1;
+    } else {
+      const wantKind = dim === "themes" ? "theme" : "format";
+      const cats: any[] = (row as any).artwork_categories || [];
+      const slugs = new Set<string>();
+      for (const ac of cats) {
+        if (ac.category?.kind === wantKind && ac.category?.slug) {
+          slugs.add(ac.category.slug);
+        }
+      }
+      for (const s of slugs) counts[s] = (counts[s] || 0) + 1;
+    }
+  }
+  return counts;
+}
+
+async function artistAvailability(
+  supabase: SupabaseClient,
+  state: FilterState,
+  cohort: Cohort
+): Promise<Set<string>> {
+  let base = supabase
+    .from("artworks")
+    .select(`id, artist:artists(slug)`)
+    .eq("on_website", true);
+  base = applyCohort(base, cohort);
+  base = applyFilters(base, state, "artist");
+
+  const { data, error } = await base.range(0, 9999);
+  if (error) throw new Error(`artistAvailability: ${error.message}`);
+
+  const set = new Set<string>();
+  for (const row of data || []) {
+    const slug = (row as any).artist?.slug;
+    if (slug) set.add(slug);
+  }
+  return set;
+}

--- a/src/lib/decades.ts
+++ b/src/lib/decades.ts
@@ -1,0 +1,23 @@
+import { extractYear } from "./dates";
+
+/**
+ * Bucket a free-form date string into a decade label like "1980s".
+ * Returns null for unparseable / out-of-range dates.
+ */
+export function dateToDecade(raw: string | null): string | null {
+  const year = extractYear(raw);
+  if (year === null) return null;
+  return `${Math.floor(year / 10) * 10}s`;
+}
+
+/**
+ * Given a list of years, return the sorted unique decade labels they fall into.
+ * Used to populate the Decade dropdown options from the data we have.
+ */
+export function decadeOptions(years: number[]): string[] {
+  const set = new Set<string>();
+  for (const y of years) {
+    set.add(`${Math.floor(y / 10) * 10}s`);
+  }
+  return [...set].sort();
+}

--- a/src/lib/filter-state.ts
+++ b/src/lib/filter-state.ts
@@ -1,0 +1,67 @@
+/**
+ * URL search-params <-> FilterState round-trip for the collection
+ * and ephemera browse pages. Keep this dependency-free and pure so
+ * it can be tested + reused on both server and client.
+ */
+
+export type SortKey = "featured" | "relevance" | "artist" | "newest" | "oldest" | "title";
+
+export interface FilterState {
+  q: string;
+  themes: string[];
+  formats: string[];
+  decades: string[];
+  artist: string | null;
+  sort: SortKey | null;
+  page: number;
+}
+
+type RawParam = string | string[] | undefined;
+
+function pickFirst(p: RawParam): string {
+  if (p === undefined) return "";
+  if (Array.isArray(p)) return p[0] || "";
+  return p;
+}
+
+function parseList(p: RawParam): string[] {
+  if (p === undefined) return [];
+  if (Array.isArray(p)) return p.flatMap(parseList);
+  return p.split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+const VALID_SORTS: SortKey[] = ["featured", "relevance", "artist", "newest", "oldest", "title"];
+
+function parseSort(p: RawParam): SortKey | null {
+  const v = pickFirst(p);
+  return VALID_SORTS.includes(v as SortKey) ? (v as SortKey) : null;
+}
+
+function parsePage(p: RawParam): number {
+  const v = parseInt(pickFirst(p) || "1", 10);
+  return isNaN(v) || v < 1 ? 1 : v;
+}
+
+export function parseSearchParams(params: Record<string, RawParam>): FilterState {
+  return {
+    q: pickFirst(params.q),
+    themes: parseList(params.theme),
+    formats: parseList(params.format),
+    decades: parseList(params.decade),
+    artist: pickFirst(params.artist) || null,
+    sort: parseSort(params.sort),
+    page: parsePage(params.page),
+  };
+}
+
+export function toQueryString(state: FilterState): string {
+  const out = new URLSearchParams();
+  if (state.q) out.set("q", state.q);
+  if (state.themes.length) out.set("theme", state.themes.join(","));
+  if (state.formats.length) out.set("format", state.formats.join(","));
+  if (state.decades.length) out.set("decade", state.decades.join(","));
+  if (state.artist) out.set("artist", state.artist);
+  if (state.sort) out.set("sort", state.sort);
+  if (state.page > 1) out.set("page", String(state.page));
+  return out.toString();
+}

--- a/supabase/migrations/001_initial.sql
+++ b/supabase/migrations/001_initial.sql
@@ -51,6 +51,7 @@ CREATE TABLE artworks (
   alt_text_long     TEXT,
   description_origin TEXT CHECK (description_origin IN ('human', 'ai')),
   sku               TEXT,
+  decade            TEXT,
 
   -- Metadata
   tags              TEXT[],
@@ -67,6 +68,7 @@ CREATE INDEX idx_artworks_artist ON artworks(artist_id);
 CREATE INDEX idx_artworks_tags ON artworks USING GIN(tags);
 CREATE INDEX idx_artworks_inventory ON artworks(inventory_number);
 CREATE INDEX idx_artworks_sku ON artworks(sku);
+CREATE INDEX idx_artworks_decade ON artworks(decade);
 
 CREATE TABLE artwork_categories (
   artwork_id   UUID REFERENCES artworks(id) ON DELETE CASCADE,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

Replaces the single-axis category-tabs filter on `/collection` with a faceted browse experience and creates `/ephemera` as a separate route for the 164 ephemera-tagged artworks.

**Two cohort routes** with disjoint sets — `/collection` (artworks not tagged ephemera, ~3,107 rows) and `/ephemera` (164 rows). Top-right `Artwork | Ephemera` link pair styled like CG's mockup.

**Filter set on /collection:** free-text search + multi-select Theme/Format/Decade + single-select Artist (typeahead) + Sort. **/ephemera** has the simpler set: search + Artist + Sort.

**Faceted semantics:** OR within a dimension, AND across. Multi-select dropdowns show counts and disable zero-count options. Artist typeahead disables-only.

**Sort:** Featured (default) / Relevance (when search active) / Artist (A-Z) / Newest / Oldest / Title (A-Z) — Featured is always a secondary sort.

**Active filter chips** below the filter row with X-to-remove + Clear all.

**URL state** captures the full filter set (`q`, `theme`, `format`, `decade`, `artist`, `sort`, `page`) for shareable deep links. Pagination resets on any filter change.

**New schema:** `artworks.decade TEXT` column + index, populated from existing `date_created` via the new `npm run backfill:decade` (1,628 rows backfilled). Both `import-csv.ts` and `import-archive.ts` populate `decade` going forward.

## Architecture call-outs

- **Filter strategy by dimension** in `src/lib/collection-query.ts`:
  - Cohort, search (FTS), decade, artist: applied inline.
  - Theme XOR Format (single dim active): embedded INNER join + filter on the embedded path.
  - Theme AND Format (both active): pre-resolve the intersected artwork-id set and `.in("id", smallSet)`.
  - Avoids `.in("id", hugeSet)` which would blow PostgREST's URI length limit (the original bug surfaced on `/collection` with no filters and `?format=drawings`).
- **Cohort NULL-tag fix:** `applyCohort('artwork')` uses `.or("tags.is.null,tags.not.cs.{ephemera}")` so the 1,159 archive-import inserts that didn't set tags appear in `/collection` instead of being silently dropped.
- **PostgREST async-thenable trap:** filter-application functions are sync (caller passes pre-resolved ids) so the builder isn't auto-executed by `await`.
- **`tsconfig.json` `target: "es2017"`** added so manual `tsc --noEmit` accepts modern syntax (Set iteration); Next.js's SWC build was already fine.

## Pure helpers (TDD)

- `src/lib/decades.ts` — `dateToDecade("7/20/1987")` → `"1980s"`. 9 tests.
- `src/lib/filter-state.ts` — URL params <-> `FilterState`. 10 tests.
- 42/42 `node:test` tests pass total (including the existing themes + dates suites).

## Known v1 limitations

- **Search doesn't match artist names.** Only matches title/medium/alt_text/alt_text_long via the existing FTS index. Artist-name search is a documented follow-up — would require either a denormalized `artist_name` column on artworks or a two-query union approach.
- **Live-as-you-type search** is deferred (submit-on-enter for v1).
- **Mobile filter drawer** is deferred (filter row wraps naturally on small screens).
- **Unified `/search` route across cohorts** is deferred. Searching "dan miller" on `/collection` won't surface his ephemera.
- **1,643 of 3,271 artworks have `decade = NULL`** (no parseable `date_created`) and are excluded when any decade filter is active. Worth a CG-side data-quality pass.

## Test plan

- [ ] Visit `/collection` — should render ~3,107 works, all 5 dropdowns visible, Artwork tab green
- [ ] Visit `/ephemera` — should render ~164 items, only Artist + Sort dropdowns visible, Ephemera tab green
- [ ] Click Theme → animals — chips appear ("Animals ✕"), grid narrows, count updates, page resets to 1
- [ ] Click Format → drawings → grid narrows further (theme + format combined). Result count is non-zero and lower than animals alone.
- [ ] Type "portrait" in search + Enter — grid narrows; sort dropdown defaults to Relevance
- [ ] Open Artist dropdown, type "judith", select Judith Scott — grid shows her works
- [ ] Click "Clear all" — themes/format/decade/artist clear; search + sort preserved
- [ ] Switch sort to "Artist (A-Z)" — works re-order alphabetically by last name
- [ ] Page 2 → click a filter → confirm reset back to page 1
- [ ] Open admin and verify nothing in admin pages broke

## Follow-ups worth tracking

- Implement artist-name search (denormalize `artist_name` column on artworks + include in FTS)
- Backfill `date_created` for the 1,643 NULL-decade rows
- Live-as-you-type search if FTS perf permits
- Mobile filter drawer pattern when needed
- Cross-cohort search hint ("→ N matches in Ephemera")