### PR TITLE
Simplify artwork detail breadcrumb

### DIFF
--- a/src/app/artwork/[id]/page.tsx
+++ b/src/app/artwork/[id]/page.tsx
@@ -138,20 +138,9 @@ export default async function ArtworkPage({ params }: ArtworkPageProps) {
         className="text-sm text-gray-600 mb-8 flex gap-2 flex-wrap"
       >
         <Link href="/" className="hover:text-blue-600">
-          Collection
+          CGPA Archive
         </Link>
         <span>/</span>
-        {artwork.artist && (
-          <>
-            <Link
-              href={`/artists/${artwork.artist.slug}`}
-              className="hover:text-blue-600"
-            >
-              {artistName}
-            </Link>
-            <span>/</span>
-          </>
-        )}
         <span className="text-gray-900 font-semibold">{artwork.title}</span>
       </nav>
 


### PR DESCRIPTION
## Summary

- "Collection" → "CGPA Archive" so the breadcrumb matches the homepage title
- Remove the artist segment — the artist name already appears as a linked element in the metadata column directly below, so listing it twice is redundant

Result: `CGPA Archive / <artwork title>`

## Test plan

- [ ] Visit any artwork detail page
- [ ] Verify the breadcrumb reads `CGPA Archive / <Title>` (no artist link in between)
- [ ] Click `CGPA Archive` — should land on `/`