### PR TITLE
Title cleanup, category-pill kind, real downloads

### DIFF
--- a/scripts/backfill-titles.ts
+++ b/scripts/backfill-titles.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env npx tsx
+/**
+ * backfill-titles.ts
+ *
+ * Strips the SKU suffix from artwork titles. The original Art Cloud
+ * import gave us titles like "Untitled, CLIR2023.472" — now that SKU
+ * is its own field, the title should just read "Untitled".
+ *
+ * Algorithm: split title by ", ", drop any segment that exactly matches
+ * the row's sku, rejoin. Preserves other segments (e.g. date strings):
+ *   "Untitled, ABai 1, ND"  + sku="ABai 1"  →  "Untitled, ND"
+ *   "Untitled, CLIR2023.472" + sku="CLIR2023.472" → "Untitled"
+ *   "JS 5"                   + sku="JS 5"   →  "JS 5"  (would empty out — left alone)
+ *
+ * Run: npx tsx --env-file=.env.local scripts/backfill-titles.ts
+ */
+
+import { createClient } from "@supabase/supabase-js";
+
+const SUPABASE_URL =
+  process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error("Error: Set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY");
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+function stripSkuFromTitle(title: string, sku: string): string {
+  const segments = title.split(",").map((s) => s.trim());
+  const remaining = segments.filter((s) => s.length > 0 && s !== sku);
+  if (remaining.length === 0) return title; // would fully empty — leave alone
+  return remaining.join(", ");
+}
+
+async function main() {
+  console.log("Fetching artworks with sku set...");
+  const all: { id: string; title: string; sku: string }[] = [];
+  let off = 0;
+  while (true) {
+    const { data, error } = await supabase
+      .from("artworks")
+      .select("id, title, sku")
+      .not("sku", "is", null)
+      .range(off, off + 999);
+    if (error) { console.error(error); process.exit(1); }
+    if (!data || data.length === 0) break;
+    all.push(...(data as any));
+    if (data.length < 1000) break;
+    off += 1000;
+  }
+  console.log(`Fetched ${all.length} artworks with sku`);
+
+  let changed = 0;
+  let unchanged = 0;
+  let errors = 0;
+  for (const row of all) {
+    if (!row.title || !row.sku) { unchanged++; continue; }
+    const newTitle = stripSkuFromTitle(row.title, row.sku);
+    if (newTitle === row.title) { unchanged++; continue; }
+
+    const { error } = await supabase.from("artworks").update({ title: newTitle }).eq("id", row.id);
+    if (error) { errors++; continue; }
+    changed++;
+  }
+
+  console.log("\n=== Summary ===");
+  console.log(`Total scanned: ${all.length}`);
+  console.log(`Title changed: ${changed}`);
+  console.log(`Unchanged:     ${unchanged}`);
+  console.log(`Errors:        ${errors}`);
+}
+
+main().catch((err) => { console.error("Fatal:", err); process.exit(1); });

--- a/src/app/api/download/route.ts
+++ b/src/app/api/download/route.ts
@@ -1,5 +1,7 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { NextRequest, NextResponse } from "next/server";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { resolveImageUrl } from "@/lib/utils";
 import crypto from "crypto";
 
 function hashIP(ip: string): string {
@@ -9,97 +11,109 @@ function hashIP(ip: string): string {
     .digest("hex");
 }
 
-export async function POST(request: NextRequest) {
-  try {
-    const body = await request.json();
-    const { artwork_id } = body;
+function buildFilename(artistName: string | null, title: string): string {
+  const parts = ["Creative Growth Public Archive"];
+  if (artistName && artistName.trim()) parts.push(artistName.trim());
+  parts.push((title || "Untitled").trim());
+  // Sanitize: drop characters that are illegal in common filesystems / HTTP headers.
+  const safe = parts.join(" - ").replace(/[\\/:*?"<>|\r\n]+/g, " ").replace(/\s+/g, " ").trim();
+  return `${safe}.jpg`;
+}
 
+/**
+ * GET /api/download?id=<artwork_id>
+ *
+ * Streams the artwork's image with Content-Disposition: attachment so the
+ * browser triggers a real download regardless of source (R2 or legacy
+ * artcld). Logs a download_event row plus a PostHog event keyed by the
+ * (salted) hashed client IP.
+ *
+ * The browser sees a same-origin response with attachment headers, so
+ * the `download` filename is honored consistently across all sources.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const url = new URL(request.url);
+    const artwork_id = url.searchParams.get("id");
     if (!artwork_id) {
-      return NextResponse.json(
-        { error: "artwork_id is required" },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: "id query param is required" }, { status: 400 });
     }
 
-    // Get artwork
     const supabase = createServerSupabaseClient();
     const { data: artwork, error: artworkError } = await supabase
       .from("artworks")
-      .select("id, image_url, title")
+      .select("id, image_url, image_original, title, artist:artists(first_name, last_name)")
       .eq("id", artwork_id)
       .single();
 
     if (artworkError || !artwork) {
-      return NextResponse.json(
-        { error: "Artwork not found" },
-        { status: 404 }
-      );
+      return NextResponse.json({ error: "Artwork not found" }, { status: 404 });
+    }
+    const sourceUrl = resolveImageUrl(artwork);
+    if (!sourceUrl) {
+      return NextResponse.json({ error: "Artwork has no image" }, { status: 404 });
     }
 
-    // Get client IP
+    // Tracking
     const ip =
       request.headers.get("x-forwarded-for")?.split(",")[0] ||
       request.headers.get("x-real-ip") ||
       request.ip ||
       "unknown";
-
     const ipHash = hashIP(ip);
     const userAgent = request.headers.get("user-agent");
     const referrer = request.headers.get("referer");
 
-    // Log download event
-    const { error: insertError } = await supabase
+    await supabase
       .from("download_events")
-      .insert({
-        artwork_id,
-        ip_hash: ipHash,
-        user_agent: userAgent,
-        referrer: referrer,
+      .insert({ artwork_id, ip_hash: ipHash, user_agent: userAgent, referrer: referrer })
+      .then(({ error }) => {
+        if (error) console.error("Error logging download event:", error);
       });
 
-    if (insertError) {
-      console.error("Error logging download event:", insertError);
-    }
-
-    // Track with PostHog if configured
     if (process.env.NEXT_PUBLIC_POSTHOG_KEY) {
-      try {
-        await fetch(
-          `${process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://us.i.posthog.com"}/track/`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              api_key: process.env.NEXT_PUBLIC_POSTHOG_KEY,
-              event: "artwork_downloaded_server",
-              properties: {
-                artwork_id,
-                title: artwork.title,
-              },
-              distinct_id: ipHash,
-            }),
-          }
-        ).catch(() => {
-          // Silently fail PostHog tracking
-        });
-      } catch (err) {
-        console.error("Error tracking with PostHog:", err);
-      }
+      fetch(
+        `${process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://us.i.posthog.com"}/track/`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            api_key: process.env.NEXT_PUBLIC_POSTHOG_KEY,
+            event: "artwork_downloaded_server",
+            properties: { artwork_id, title: artwork.title },
+            distinct_id: ipHash,
+          }),
+        }
+      ).catch(() => {});
     }
 
-    // Return image URL (will be signed R2 URL in production)
-    return NextResponse.json({
-      url: artwork.image_url,
-      id: artwork.id,
-      title: artwork.title,
+    // Stream the source image back with attachment headers.
+    const sourceResponse = await fetch(sourceUrl);
+    if (!sourceResponse.ok || !sourceResponse.body) {
+      return NextResponse.json(
+        { error: `Source image fetch failed: ${sourceResponse.status}` },
+        { status: 502 }
+      );
+    }
+
+    const artistTuple = (artwork as any).artist;
+    const artistName = artistTuple
+      ? `${artistTuple.first_name || ""} ${artistTuple.last_name || ""}`.trim()
+      : null;
+
+    const filename = buildFilename(artistName || null, artwork.title);
+    const contentType = sourceResponse.headers.get("content-type") || "image/jpeg";
+
+    return new NextResponse(sourceResponse.body, {
+      status: 200,
+      headers: {
+        "Content-Type": contentType,
+        "Content-Disposition": `attachment; filename="${filename.replace(/"/g, "")}"`,
+        "Cache-Control": "no-store",
+      },
     });
   } catch (error) {
     console.error("Download API error:", error);
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }

--- a/src/app/artwork/[id]/page.tsx
+++ b/src/app/artwork/[id]/page.tsx
@@ -26,7 +26,7 @@ async function getArtwork(
       `
       *,
       artist:artists(id, first_name, last_name, slug),
-      categories:artwork_categories(category:categories(id, name, slug))
+      categories:artwork_categories(category:categories(id, name, slug, kind))
       `
     )
     .eq("id", id)

--- a/src/components/DownloadButton.tsx
+++ b/src/components/DownloadButton.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { trackEvent } from "@/lib/posthog";
 
 interface DownloadButtonProps {
@@ -8,71 +7,21 @@ interface DownloadButtonProps {
   title: string;
 }
 
-export default function DownloadButton({
-  artworkId,
-  title,
-}: DownloadButtonProps) {
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const handleDownload = async () => {
-    try {
-      setIsLoading(true);
-      setError(null);
-
-      trackEvent("artwork_download_requested", {
-        artwork_id: artworkId,
-        title,
-      });
-
-      const response = await fetch("/api/download", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ artwork_id: artworkId }),
-      });
-
-      if (!response.ok) {
-        throw new Error("Failed to download image");
-      }
-
-      const { url } = await response.json();
-
-      // Trigger download
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = `${title}.jpg`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-
-      trackEvent("artwork_downloaded", {
-        artwork_id: artworkId,
-        title,
-      });
-    } catch (err) {
-      setError(
-        err instanceof Error
-          ? err.message
-          : "An error occurred while downloading"
-      );
-      console.error("Download error:", err);
-    } finally {
-      setIsLoading(false);
-    }
+export default function DownloadButton({ artworkId, title }: DownloadButtonProps) {
+  const handleDownload = () => {
+    trackEvent("artwork_download_requested", { artwork_id: artworkId, title });
+    // Navigate to the streaming download endpoint. Server responds with
+    // Content-Disposition: attachment so the browser saves the file
+    // instead of navigating to it.
+    window.location.href = `/api/download?id=${encodeURIComponent(artworkId)}`;
   };
 
   return (
-    <div>
-      <button
-        onClick={handleDownload}
-        disabled={isLoading}
-        className="button-primary disabled:opacity-50 disabled:cursor-not-allowed"
-      >
-        {isLoading ? "Downloading..." : "Download Image"}
-      </button>
-      {error && <p className="text-red-600 text-sm mt-2">{error}</p>}
-    </div>
+    <button
+      onClick={handleDownload}
+      className="button-primary"
+    >
+      Download Image
+    </button>
   );
 }


### PR DESCRIPTION
## Summary

Three UI tweaks bundled.

**1. Title cleanup** — backfill script `scripts/backfill-titles.ts` strips the SKU suffix from artwork titles. "Untitled, CLIR2023.472" → "Untitled". Splits on commas, drops segments that exactly match the row's `sku`, preserves other segments like trailing date strings ("Untitled, ABai 1, ND" → "Untitled, ND"). **Run on production already:** 2,936 of 3,270 titles cleaned, 0 errors.

**2. Category pill `kind` fix** — the artwork detail page was always rendering `href="/?format=…"` because the `categories` embed in `getArtwork` was missing the `kind` column, so the kind ternary fell through to the format default. Theme categories now correctly link to `?theme=…`.

**3. Real downloads** — switched `/api/download` from POST + JSON to GET + streaming. The endpoint now fetches the source image (R2 or legacy artcld) and pipes it back with `Content-Disposition: attachment`, so the browser triggers an actual file download regardless of cross-origin source. Filename pattern: `Creative Growth Public Archive - <Artist> - <Title>.jpg` with safe character sanitization. Tracking (download_events insert + PostHog event) preserved. `DownloadButton` simplified to a `window.location.href` navigation.

## Test plan

- [ ] Visit any artwork detail page; verify the title in the breadcrumb / `<h1>` reads cleanly without a trailing SKU
- [ ] Click a category pill; URL goes to `/?theme=…` for themes or `/?format=…` for formats
- [ ] Click "Download Image"; the file should save to the user's downloads folder with name like `Creative Growth Public Archive - Judith Scott - Untitled.jpg`
- [ ] Spot-check `download_events` rows are still being inserted (tracking unchanged)