### PR TITLE
Artist summary pages + 'and N more' link on artwork detail

### DIFF
--- a/src/app/artists/[slug]/page.tsx
+++ b/src/app/artists/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { notFound } from "next/navigation";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import ArtworkGrid from "@/components/ArtworkGrid";
@@ -5,48 +6,58 @@ import ArtworkCard from "@/components/ArtworkCard";
 import { Artist, Artwork } from "@/lib/types";
 import { formatArtistName } from "@/lib/utils";
 
+const SAMPLE_LIMIT = 6;
+
+type ArtworkRow = Artwork & {
+  artist?: { id: string; first_name: string; last_name: string };
+};
+
 async function getArtist(slug: string): Promise<Artist | null> {
   const supabase = createServerSupabaseClient();
-
   const { data, error } = await supabase
     .from("artists")
     .select("*")
     .eq("slug", slug)
     .single();
-
   if (error) {
     console.error("Error fetching artist:", error);
     return null;
   }
-
   return data;
 }
 
-async function getArtistArtworks(
-  artistId: string
-): Promise<
-  (Artwork & { artist?: { id: string; first_name: string; last_name: string } })[]
-> {
+async function getArtistSample(
+  artistId: string,
+  cohort: "artwork" | "ephemera"
+): Promise<{ items: ArtworkRow[]; total: number }> {
   const supabase = createServerSupabaseClient();
-
-  const { data, error } = await supabase
+  let q = supabase
     .from("artworks")
     .select(
       `
       *,
       artist:artists(id, first_name, last_name)
-      `
+      `,
+      { count: "exact" }
     )
     .eq("artist_id", artistId)
-    .eq("on_website", true)
-    .order("sort_order", { ascending: true });
+    .eq("on_website", true);
 
+  // Cohort filter — same shape as collection-query so /collection and
+  // /ephemera see identical sets when filtered by this artist.
+  q =
+    cohort === "artwork"
+      ? q.or("tags.is.null,tags.not.cs.{ephemera}")
+      : q.contains("tags", ["ephemera"]);
+
+  q = q.order("sort_order", { ascending: true }).limit(SAMPLE_LIMIT);
+
+  const { data, error, count } = await q;
   if (error) {
-    console.error("Error fetching artworks:", error);
-    return [];
+    console.error(`Error fetching artist ${cohort}:`, error);
+    return { items: [], total: 0 };
   }
-
-  return data || [];
+  return { items: (data as ArtworkRow[]) || [], total: count || 0 };
 }
 
 interface ArtistPageProps {
@@ -56,15 +67,8 @@ interface ArtistPageProps {
 export async function generateMetadata({ params }: ArtistPageProps) {
   const { slug } = await params;
   const artist = await getArtist(slug);
-
-  if (!artist) {
-    return {
-      title: "Artist Not Found",
-    };
-  }
-
+  if (!artist) return { title: "Artist Not Found" };
   const name = formatArtistName(artist.first_name, artist.last_name);
-
   return {
     title: `${name} | Creative Growth Gallery`,
     description: artist.bio || `Artworks by ${name}`,
@@ -74,53 +78,77 @@ export async function generateMetadata({ params }: ArtistPageProps) {
 export default async function ArtistPage({ params }: ArtistPageProps) {
   const { slug } = await params;
   const artist = await getArtist(slug);
+  if (!artist) notFound();
 
-  if (!artist) {
-    notFound();
-  }
+  const [works, ephemera] = await Promise.all([
+    getArtistSample(artist.id, "artwork"),
+    getArtistSample(artist.id, "ephemera"),
+  ]);
 
-  const artworks = await getArtistArtworks(artist.id);
   const artistName = formatArtistName(artist.first_name, artist.last_name);
 
   return (
     <div className="container-max py-12">
-      {/* Artist Info */}
-      <div className="mb-12">
+      {/* Artist info */}
+      <div className="mb-12 max-w-3xl">
         <h1 className="font-serif text-4xl font-bold text-gray-900 mb-4">
           {artistName}
         </h1>
-
         {artist.bio && (
-          <div className="max-w-3xl">
-            <p className="text-lg text-gray-700 leading-relaxed mb-4">
-              {artist.bio}
-            </p>
-          </div>
+          <p className="text-lg text-gray-700 leading-relaxed">{artist.bio}</p>
         )}
-
-        <p className="text-gray-600">
-          {artworks.length} artwork{artworks.length !== 1 ? "s" : ""} in collection
-        </p>
       </div>
 
-      {/* Artworks */}
-      {artworks.length > 0 ? (
-        <div>
+      {/* Artworks sample */}
+      {works.items.length > 0 ? (
+        <section className="mb-16">
           <h2 className="font-serif text-2xl font-bold text-gray-900 mb-8">
-            Works
+            Works ({works.total})
           </h2>
-          <ArtworkGrid>
-            {artworks.map((artwork) => (
-              <ArtworkCard key={artwork.id} artwork={artwork} />
+          <ArtworkGrid columns="3">
+            {works.items.map((art) => (
+              <ArtworkCard key={art.id} artwork={art} />
             ))}
           </ArtworkGrid>
-        </div>
+          {works.total > works.items.length && (
+            <p className="mt-8 text-center">
+              <Link
+                href={`/?artist=${artist.slug}`}
+                className="text-blue-600 hover:text-blue-800 font-medium"
+              >
+                …and {works.total - works.items.length} more works by {artistName} →
+              </Link>
+            </p>
+          )}
+        </section>
       ) : (
-        <div className="text-center py-12">
-          <p className="text-gray-600">
-            No artworks available for this artist yet.
-          </p>
-        </div>
+        <section className="mb-16">
+          <p className="text-gray-600">No artworks in collection yet.</p>
+        </section>
+      )}
+
+      {/* Ephemera sample (only if any) */}
+      {ephemera.items.length > 0 && (
+        <section className="mb-16 pt-12 border-t border-gray-200">
+          <h2 className="font-serif text-2xl font-bold text-gray-900 mb-8">
+            Ephemera ({ephemera.total})
+          </h2>
+          <ArtworkGrid columns="3">
+            {ephemera.items.map((art) => (
+              <ArtworkCard key={art.id} artwork={art} />
+            ))}
+          </ArtworkGrid>
+          {ephemera.total > ephemera.items.length && (
+            <p className="mt-8 text-center">
+              <Link
+                href={`/ephemera?artist=${artist.slug}`}
+                className="text-blue-600 hover:text-blue-800 font-medium"
+              >
+                …and {ephemera.total - ephemera.items.length} more ephemera items →
+              </Link>
+            </p>
+          )}
+        </section>
       )}
     </div>
   );

--- a/src/app/artwork/[id]/page.tsx
+++ b/src/app/artwork/[id]/page.tsx
@@ -44,18 +44,20 @@ async function getArtistArtworks(
   artistId: string,
   excludeId: string,
   limit: number = 6
-): Promise<
-  (Artwork & { artist?: { id: string; first_name: string; last_name: string } })[]
-> {
+): Promise<{
+  items: (Artwork & { artist?: { id: string; first_name: string; last_name: string } })[];
+  total: number;
+}> {
   const supabase = createServerSupabaseClient();
 
-  const { data, error } = await supabase
+  const { data, error, count } = await supabase
     .from("artworks")
     .select(
       `
       *,
       artist:artists(id, first_name, last_name)
-      `
+      `,
+      { count: "exact" }
     )
     .eq("artist_id", artistId)
     .eq("on_website", true)
@@ -65,10 +67,10 @@ async function getArtistArtworks(
 
   if (error) {
     console.error("Error fetching artist artworks:", error);
-    return [];
+    return { items: [], total: 0 };
   }
 
-  return data || [];
+  return { items: data || [], total: count || 0 };
 }
 
 interface ArtworkPageProps {
@@ -115,9 +117,9 @@ export default async function ArtworkPage({ params }: ArtworkPageProps) {
     notFound();
   }
 
-  const moreArtworks =
-    artwork.artist_id &&
-    (await getArtistArtworks(artwork.artist_id, artwork.id));
+  const more = artwork.artist_id
+    ? await getArtistArtworks(artwork.artist_id, artwork.id)
+    : { items: [], total: 0 };
 
   const altText = getAltText(artwork);
   const imageUrl = resolveImageUrl(artwork);
@@ -253,16 +255,26 @@ export default async function ArtworkPage({ params }: ArtworkPageProps) {
       </div>
 
       {/* More by Artist */}
-      {moreArtworks && moreArtworks.length > 0 && (
+      {more.items.length > 0 && (
         <section className="mt-16 pt-16 border-t border-gray-200">
           <h2 className="font-serif text-2xl font-bold text-gray-900 mb-8">
             More by {artistName}
           </h2>
           <ArtworkGrid columns="3">
-            {moreArtworks.slice(0, 6).map((art) => (
+            {more.items.map((art) => (
               <ArtworkCard key={art.id} artwork={art} />
             ))}
           </ArtworkGrid>
+          {more.total > more.items.length && artwork.artist?.slug && (
+            <p className="mt-8 text-center">
+              <Link
+                href={`/?artist=${artwork.artist.slug}`}
+                className="text-blue-600 hover:text-blue-800 font-medium"
+              >
+                …and {more.total - more.items.length} more by {artistName} →
+              </Link>
+            </p>
+          )}
         </section>
       )}
     </div>


### PR DESCRIPTION
## Summary

**Artwork detail page (`/artwork/[id]`):** "More by Artist" 6-grid now followed by `…and N more by <Artist> →` link to `/?artist=<slug>` when there are more than 6 other works. Drills into the canonical filtered set.

**Artist detail page (`/artists/[slug]`):** reframed from a flat archive into a profile-with-samples:

- Bio at the top
- Up to 6 artworks (cohort = artwork) with a `Works (N)` header and a `…and N more works by <Artist> →` link
- (If any) up to 6 ephemera with a `Ephemera (N)` header and a `…and N more ephemera items →` link to `/ephemera?artist=<slug>`
- Both samples use the same cohort filter shape as `collection-query.ts` so the counts match between the artist page and the destination browse page

## Why not paginate the artist page

The homepage already has the full filter + sort + pagination infrastructure. Re-implementing it on the artist page would either duplicate UI or introduce inconsistency. Making the artist page a focused profile and handing off to `/?artist=<slug>` for "show me everything" reuses existing infrastructure and keeps the artist page reading like a curatorial summary.

## Test plan

- [ ] Visit a prolific artist's detail page (e.g. `/artists/judith-scott`) — bio + sample + "see N more" link visible
- [ ] Click the "see N more" link — lands on `/?artist=judith-scott` with the filter active
- [ ] Visit an artist with both works and ephemera — both sections render, both links work
- [ ] Visit an artist with no ephemera — ephemera section is hidden entirely
- [ ] Visit any artwork detail page where the artist has >6 other works — see "…and N more" link below the 6-grid; click drills into filtered set