### PR TITLE
Fix Sort: Artist (A-Z) — was silently a no-op

### DIFF
--- a/src/lib/collection-query.ts
+++ b/src/lib/collection-query.ts
@@ -195,9 +195,14 @@ function applySort(query: any, state: FilterState): any {
       // v1 falls through to insertion-order. Worth revisiting.
       return query.order("sort_order", { ascending: true });
     case "artist":
+      // PostgREST syntax for ordering PARENT rows by an embedded resource
+      // is `?order=artist(last_name).asc`. Supabase JS's `referencedTable`
+      // / `foreignTable` option generates `artist.order=last_name.asc`
+      // instead, which orders the EMBED, not the parent rows. So we
+      // pass the embed-as-column form directly.
       return query
-        .order("last_name", { foreignTable: "artists", ascending: true })
-        .order("first_name", { foreignTable: "artists", ascending: true })
+        .order("artist(last_name)", { ascending: true })
+        .order("artist(first_name)", { ascending: true })
         .order("sort_order", { ascending: true });
     case "newest":
       return query


### PR DESCRIPTION
## Summary

The sort case in `src/lib/collection-query.ts` was passing `foreignTable: "artists"` to `.order()`, which Supabase JS translates to `artist.order=last_name.asc` in the URL. **That URL shape orders the embedded resource, not the parent rows.** Parents kept their natural insertion order, so the "Sort: Artist (A-Z)" dropdown looked random.

PostgREST's actual syntax for ordering parent rows by an embedded column is `?order=artist(last_name).asc`. The workaround: pass `artist(last_name)` directly as the column name to `.order()`, with no `referencedTable` / `foreignTable` option. That generates the right URL.

Verified against production: artworks now sort alphabetically by artist last name then first name, with `sort_order` as the tiebreaker.

## Notes

- Empty / missing last names sort first (a handful of single-name artists like "Co-Op" have `first_name="Co-Op", last_name=""` from the original Art Cloud import). That's a data shape choice, not a sort bug.
- Artworks with `artist_id = NULL` (the ~207 "Unknown" cohort) appear in the sort using PostgREST's default null handling.

## Test plan

- [ ] Visit `/?sort=artist` — first results are artists with names starting with `(`/digits/early letters
- [ ] Page 2, page 3 — confirm continued alphabetical progression by last name
- [ ] Combine with another filter (e.g. `?sort=artist&theme=animals`) — the sort still applies inside the filtered set