### PR TITLE
Lighten dropdown borders + remove unwanted format categories

### DIFF
--- a/src/components/DropdownPanel.tsx
+++ b/src/components/DropdownPanel.tsx
@@ -40,7 +40,7 @@ export default function DropdownPanel({ label, badgeCount, children }: DropdownP
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}
-        className="border-2 border-gray-900 rounded-md px-4 py-2 text-sm font-medium bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        className="border border-gray-400 rounded-md px-4 py-2 text-sm font-medium bg-white hover:border-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
       >
         {labelWithBadge} <span className="ml-1">▾</span>
       </button>

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -83,7 +83,7 @@ export default function FilterBar({
             value={searchInput}
             onChange={(e) => setSearchInput(e.target.value)}
             placeholder="Search artwork & artists"
-            className="border-2 border-gray-900 rounded-md pl-4 pr-10 py-2 text-sm w-80 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="border border-gray-400 rounded-md pl-4 pr-10 py-2 text-sm w-80 focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
           <button type="submit" className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-700" aria-label="Search">
             ⌕


### PR DESCRIPTION
## Summary

Two quick fixes; the third item from the request (medium normalization) is being split into its own spec/plan/PR because it's substantial.

**Borders:** dropdown trigger buttons and the search input switch from `border-2 border-gray-900` (bold black) to `border border-gray-400` (thin gray) with a hover that deepens to `border-gray-700`. Lighter visual weight overall, still affords the input/click target.

**Format categories cleanup:** deleted two rows from the `categories` table:
- `CLIR Collection` — every artwork in the DB is in CLIR, so it never narrowed results
- `Photography & Digital` — had 0 attached artworks per the original seed and current state

`artwork_categories` rows cascade-delete with the parent.

## Test plan

- [ ] Visit `/` — dropdown buttons and the search input have thin gray borders
- [ ] Open the Format dropdown — only 6 options now (Drawings, Fiber Art & Textiles, Mixed Media, Paintings, Prints & Multiples, Sculpture & 3D); CLIR Collection and Photography & Digital are gone