### PR TITLE
Add Medium filter dropdown backed by normalized material taxonomy

### DIFF
--- a/docs/superpowers/plans/2026-04-25-medium-normalization.md
+++ b/docs/superpowers/plans/2026-04-25-medium-normalization.md
@@ -1,0 +1,1491 @@
+# Medium Normalization & Filter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a faceted "Medium" filter to the public collection, backed by an LLM-derived (and human-reviewed) taxonomy of art materials, with each artwork attached to multiple medium tags via the existing `categories` table; future imports consult a persisted lookup map.
+
+**Architecture:** Two-phase script workflow (LLM proposal → CSV review → apply to DB) writes a `kind='medium'` slice of the existing `categories` table and attaches each artwork to one-or-more medium categories via `artwork_categories`. The persisted `scripts/data/medium-buckets.json` lookup map ships in source control so future importers can attach medium categories on insert without another LLM call. UI integration: a fourth multi-select dropdown in `FilterBar`, plumbed through `collection-query.ts` (the existing two-category-dimension filter logic generalizes to three).
+
+**Tech Stack:** TypeScript, Node 20+, `tsx`, `csv-parse/sync`, `@supabase/supabase-js`, `@anthropic-ai/sdk`, Node's built-in `node:test`. No new dependencies.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-25-medium-normalization-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- `scripts/normalize-mediums-propose.ts` — Phase 1 script. Fetches distinct mediums, calls Claude, writes timestamped CSV.
+- `scripts/normalize-mediums-apply.ts` — Phase 2 script. Reads (possibly-edited) CSV, validates, upserts medium categories, attaches to artworks, persists JSON lookup map.
+- `scripts/data/medium-buckets.json` — produced by Phase 2; consumed by importers. Source-controlled.
+- `scripts/lib/medium-buckets.ts` — small helper exporting `loadBucketMap()` and `mediumToCategoryIds(map, medium)`. Used by both apply script and the importer updates so the lookup logic is DRY.
+- `scripts/test-medium-buckets.ts` — `node:test` for the helper.
+
+**Modified files:**
+- `src/lib/filter-state.ts` — add `mediums: string[]` field + `medium=` URL param.
+- `scripts/test-filter-state.ts` — extend tests for the new field.
+- `src/lib/collection-query.ts` — extend the category-dimension count from 2 to 3 (themes / formats / mediums); `categoryFilteredIds`, `applySingleDimEmbeddedFilter`, `applyAllFilters`, `getFacetCounts` all touch.
+- `src/components/FilterBar.tsx` — add `MultiSelectDropdown` for medium + chip rendering for selected mediums.
+- `src/app/page.tsx` — fetch medium category list + pass to FilterBar.
+- `src/app/ephemera/page.tsx` — does NOT add medium dropdown (cohort-specific filter set per spec — no change needed beyond confirming).
+- `scripts/import-csv.ts` — read bucket map; attach medium categories on insert.
+- `scripts/import-archive.ts` — same.
+- `package.json` — add `medium:propose` and `medium:apply` npm scripts.
+- `supabase/migrations/001_initial.sql` — sync the relaxed `categories.kind` CHECK constraint.
+
+**Schema migration (manual):** extend the `categories.kind` CHECK constraint to allow `'medium'`. User runs the SQL via Supabase SQL Editor (per TD-001) before Phase 2.
+
+---
+
+## Phase 0: Pre-flight
+
+### Task 0: Verify the schema migration is in place
+
+**Files:** none (read-only verification, gated on user-run SQL)
+
+- [ ] **Step 1: Provide SQL to the user**
+
+Tell the user to run this in the Supabase SQL Editor:
+
+```sql
+ALTER TABLE categories DROP CONSTRAINT IF EXISTS categories_kind_check;
+ALTER TABLE categories ADD CONSTRAINT categories_kind_check
+  CHECK (kind IN ('format', 'theme', 'medium'));
+```
+
+- [ ] **Step 2: Confirm by inserting + deleting a probe medium category**
+
+Run:
+```bash
+npx tsx --env-file=.env.local -e "
+import { createClient } from '@supabase/supabase-js';
+const c = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+async function go() {
+  const probe = { name: '__probe__', slug: '__probe__', kind: 'medium', ai_suggested: false };
+  const ins = await c.from('categories').insert(probe).select('id').single();
+  if (ins.error) { console.error('CONSTRAINT NOT YET RELAXED:', ins.error.message); process.exit(1); }
+  await c.from('categories').delete().eq('id', ins.data.id);
+  console.log('OK - kind=medium accepted by constraint');
+}
+go();
+"
+```
+
+Expected: `OK - kind=medium accepted by constraint`.
+
+If this fails: the SQL hasn't been run; stop and ask the user.
+
+---
+
+## Phase 1: filter-state + helper TDD
+
+### Task 1: Extend filter-state tests for `mediums`
+
+**Files:**
+- Modify: `scripts/test-filter-state.ts`
+
+- [ ] **Step 1: Add new tests at the bottom of the file**
+
+Append to `scripts/test-filter-state.ts`:
+
+```typescript
+test("parseSearchParams: parses mediums from medium= param", () => {
+  const s = parseSearchParams({ medium: "ink,acrylic" });
+  assert.deepEqual(s.mediums, ["ink", "acrylic"]);
+});
+
+test("parseSearchParams: empty input has empty mediums array", () => {
+  const s = parseSearchParams({});
+  assert.deepEqual(s.mediums, []);
+});
+
+test("toQueryString: serializes mediums to medium= param", () => {
+  const state = {
+    q: "", themes: [], formats: [], decades: [], artist: null, sort: null, page: 1,
+    mediums: ["ink", "acrylic"],
+  };
+  assert.equal(toQueryString(state), "medium=ink%2Cacrylic");
+});
+
+test("toQueryString round-trip preserves mediums", () => {
+  const state = {
+    q: "x", themes: ["animals"], formats: [], decades: [], artist: null, sort: null, page: 1,
+    mediums: ["ink", "acrylic"],
+  };
+  const re = parseSearchParams(Object.fromEntries(new URLSearchParams(toQueryString(state))));
+  assert.deepEqual(re.mediums, state.mediums);
+});
+```
+
+- [ ] **Step 2: Run the tests and verify the new ones fail**
+
+Run: `npx tsx --test scripts/test-filter-state.ts`
+Expected: 4 new test failures with errors mentioning the missing `mediums` field on the parsed object.
+
+---
+
+### Task 2: Add `mediums` to FilterState + parse/serialize
+
+**Files:**
+- Modify: `src/lib/filter-state.ts`
+
+- [ ] **Step 1: Update the FilterState interface and parser/serializer**
+
+In `src/lib/filter-state.ts`:
+
+1. Add `mediums: string[];` to the `FilterState` interface (between `formats` and `decades` for alphabetical-ish grouping).
+
+2. In `parseSearchParams`, add `mediums: parseList(params.medium),` to the returned object (between `formats` and `decades`).
+
+3. In `toQueryString`, add this block right after the `formats` serialization:
+
+```typescript
+if (state.mediums.length) out.set("medium", state.mediums.join(","));
+```
+
+The full updated parseSearchParams return becomes:
+
+```typescript
+return {
+  q: pickFirst(params.q),
+  themes: parseList(params.theme),
+  formats: parseList(params.format),
+  mediums: parseList(params.medium),
+  decades: parseList(params.decade),
+  artist: pickFirst(params.artist) || null,
+  sort: parseSort(params.sort),
+  page: parsePage(params.page),
+};
+```
+
+- [ ] **Step 2: Run tests and verify all pass**
+
+Run: `npx tsx --test scripts/test-filter-state.ts`
+Expected: all tests pass (including the 4 new ones plus the existing 10).
+
+---
+
+### Task 3: Add a tiny medium-bucket helper with tests
+
+**Files:**
+- Create: `scripts/test-medium-buckets.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/test-medium-buckets.ts`:
+
+```typescript
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { mediumToBuckets, parseProposedBuckets } from "./lib/medium-buckets";
+
+test("mediumToBuckets: returns buckets from the map", () => {
+  const map = { "Ink on paper": ["Ink"], "Acrylic and ink on paper": ["Acrylic", "Ink"] };
+  assert.deepEqual(mediumToBuckets(map, "Ink on paper"), ["Ink"]);
+  assert.deepEqual(mediumToBuckets(map, "Acrylic and ink on paper"), ["Acrylic", "Ink"]);
+});
+
+test("mediumToBuckets: returns empty for unknown medium", () => {
+  assert.deepEqual(mediumToBuckets({}, "Crayon on bark"), []);
+});
+
+test("mediumToBuckets: trims whitespace before lookup", () => {
+  const map = { "Ink on paper": ["Ink"] };
+  assert.deepEqual(mediumToBuckets(map, "  Ink on paper  "), ["Ink"]);
+});
+
+test("mediumToBuckets: returns empty for null/empty input", () => {
+  assert.deepEqual(mediumToBuckets({}, ""), []);
+  assert.deepEqual(mediumToBuckets({}, null), []);
+});
+
+test("parseProposedBuckets: splits semicolon-joined cell, trims, drops empties", () => {
+  assert.deepEqual(parseProposedBuckets("Ink"), ["Ink"]);
+  assert.deepEqual(parseProposedBuckets("Color Stix; Ink; Colored pencil"), ["Color Stix", "Ink", "Colored pencil"]);
+  assert.deepEqual(parseProposedBuckets("  Ink  ;;  Pastel  "), ["Ink", "Pastel"]);
+  assert.deepEqual(parseProposedBuckets(""), []);
+});
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `npx tsx --test scripts/test-medium-buckets.ts`
+Expected: tests fail with `Cannot find module './lib/medium-buckets'`.
+
+---
+
+### Task 4: Implement the medium-bucket helper
+
+**Files:**
+- Create: `scripts/lib/medium-buckets.ts`
+
+- [ ] **Step 1: Write the helper**
+
+Run: `mkdir -p scripts/lib`
+
+Create `scripts/lib/medium-buckets.ts`:
+
+```typescript
+/**
+ * Pure helpers for the medium normalization workflow.
+ * - mediumToBuckets: lookup an artwork's medium string in the
+ *   normalized bucket map. Returns the array of bucket names the
+ *   artwork should be tagged with, or [] if the medium is unknown
+ *   or empty.
+ * - parseProposedBuckets: parse the semicolon-joined cell from the
+ *   Phase 1 CSV (e.g. "Color Stix; Ink; Colored pencil") into an
+ *   array of bucket names.
+ */
+
+export type BucketMap = Record<string, string[]>;
+
+export function mediumToBuckets(map: BucketMap, medium: string | null): string[] {
+  if (medium === null) return [];
+  const trimmed = medium.trim();
+  if (!trimmed) return [];
+  return map[trimmed] || [];
+}
+
+export function parseProposedBuckets(cell: string): string[] {
+  if (!cell) return [];
+  return cell
+    .split(";")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+```
+
+- [ ] **Step 2: Verify all tests pass**
+
+Run: `npx tsx --test scripts/test-medium-buckets.ts`
+Expected: all 5 tests pass.
+
+---
+
+## Phase 2: Phase-1 LLM proposal script
+
+### Task 5: Implement `scripts/normalize-mediums-propose.ts`
+
+**Files:**
+- Create: `scripts/normalize-mediums-propose.ts`
+
+- [ ] **Step 1: Write the script**
+
+Create `scripts/normalize-mediums-propose.ts`:
+
+```typescript
+#!/usr/bin/env npx tsx
+/**
+ * normalize-mediums-propose.ts (Phase 1)
+ *
+ * Fetches every distinct medium string in the catalog, asks Claude to
+ * propose a small (~12-18) bucket vocabulary of pure materials and a
+ * mapping from each input string to one or more buckets. Writes
+ * `tmp/medium-buckets_<ISO>.csv` for human review in Sheets.
+ *
+ * Run: npx tsx --env-file=.env.local scripts/normalize-mediums-propose.ts
+ */
+
+import fs from "fs";
+import path from "path";
+import { createClient } from "@supabase/supabase-js";
+import Anthropic from "@anthropic-ai/sdk";
+
+const TMP_DIR = path.join(__dirname, "..", "tmp");
+const TIMESTAMP = new Date().toISOString().replace(/[:.]/g, "-");
+const OUTPUT_FILE = path.join(TMP_DIR, `medium-buckets_${TIMESTAMP}.csv`);
+
+const SUPABASE_URL =
+  process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY;
+if (!SUPABASE_URL || !SUPABASE_KEY || !ANTHROPIC_KEY) {
+  console.error("Error: set NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, ANTHROPIC_API_KEY");
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+const anthropic = new Anthropic({ apiKey: ANTHROPIC_KEY });
+
+const MODEL = "claude-sonnet-4-6";
+
+const SYSTEM_PROMPT = `You are an expert museum cataloger normalizing artwork medium descriptions into a small set of material-only buckets, following CDWA (Categories for the Description of Works of Art) conventions.
+
+Goals:
+- Propose ~12-18 buckets covering the materials present. Materials only — pigments, drawing tools, sculpture materials, fiber materials. NOT support (paper, canvas, etc.) and NOT technique (drawing, painting). Examples of bucket-worthy material names: Ink, Acrylic, Watercolor, Oil paint, Pastel, Oil pastel, Color Stix, Colored pencil, Pencil/Graphite, Marker, Pen, Crayon, Charcoal, Ceramic, Wood, Fiber/Yarn.
+- For each input medium string, return an array of bucket names listing every material present. CDWA prefers enumeration: a 3-material piece gets 3 tags. Common case is 1 tag.
+- Use the bucket name "Other" only when you genuinely cannot enumerate (e.g. "Mixed media on paper" with no specifics).
+- Combine related materials when sensible (e.g. "Pen on paper" + "Ink on paper" both → "Ink"; "Oil pastel on paper" + "Pastel on paper" — your call whether to keep separate).
+- Bucket names should be short and human-readable for a dropdown filter.
+
+Respond ONLY with valid JSON in this shape (no markdown, no fences):
+{
+  "buckets": ["Ink", "Acrylic", ...],
+  "mapping": {
+    "Ink on paper": ["Ink"],
+    "Color Stix, ink, and colored pencil on paper": ["Color Stix", "Ink", "Colored pencil"],
+    ...
+  }
+}
+
+Every input medium string must appear as a key in "mapping". Every bucket name in "mapping" values must appear in "buckets".`;
+
+interface MediumRow { medium: string; count: number; }
+
+function csvField(v: string | null | undefined): string {
+  if (v === null || v === undefined) return "";
+  const s = String(v);
+  if (/[",\n\r]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+  return s;
+}
+
+function writeCsv(filePath: string, columns: string[], rows: Record<string, string>[]): void {
+  const header = columns.join(",");
+  const body = rows.map((r) => columns.map((c) => csvField(r[c])).join(",")).join("\n");
+  fs.writeFileSync(filePath, header + "\n" + body + "\n");
+}
+
+async function main() {
+  // 1. Fetch all distinct mediums + counts
+  console.log("Fetching mediums from DB...");
+  const all: { medium: string | null }[] = [];
+  let off = 0;
+  while (true) {
+    const { data, error } = await supabase
+      .from("artworks")
+      .select("medium")
+      .not("medium", "is", null)
+      .range(off, off + 999);
+    if (error) { console.error(error); process.exit(1); }
+    if (!data || data.length === 0) break;
+    all.push(...data);
+    if (data.length < 1000) break;
+    off += 1000;
+  }
+
+  const counts = new Map<string, number>();
+  for (const r of all) {
+    const m = (r.medium || "").trim();
+    if (!m) continue;
+    counts.set(m, (counts.get(m) || 0) + 1);
+  }
+  const distinct: MediumRow[] = [...counts.entries()]
+    .map(([medium, count]) => ({ medium, count }))
+    .sort((a, b) => b.count - a.count);
+
+  console.log(`Found ${distinct.length} distinct medium strings across ${all.length} artworks`);
+
+  // 2. Send to Claude for normalization
+  console.log("Calling Claude for bucket proposal + mapping (this may take 10-30s)...");
+  const userMessage = `Here are the distinct medium strings from the catalog (with row counts in parentheses):\n\n${distinct
+    .map((d) => `${d.medium} (${d.count})`)
+    .join("\n")}`;
+
+  const response = await anthropic.messages.create({
+    model: MODEL,
+    max_tokens: 8192,
+    system: SYSTEM_PROMPT,
+    messages: [{ role: "user", content: userMessage }],
+  });
+
+  const text = response.content[0].type === "text" ? response.content[0].text : "";
+  const cleaned = text.replace(/```json\n?/g, "").replace(/```\n?/g, "").trim();
+
+  let parsed: { buckets: string[]; mapping: Record<string, string[]> };
+  try {
+    parsed = JSON.parse(cleaned);
+  } catch {
+    console.error("Claude returned non-JSON response. Raw text:");
+    console.error(text);
+    process.exit(1);
+  }
+
+  if (!parsed.buckets || !parsed.mapping) {
+    console.error("Claude response missing 'buckets' or 'mapping'. Raw:");
+    console.error(text);
+    process.exit(1);
+  }
+
+  // 3. Write CSV
+  if (!fs.existsSync(TMP_DIR)) fs.mkdirSync(TMP_DIR, { recursive: true });
+  const rows = distinct.map((d) => {
+    const buckets = parsed.mapping[d.medium] || [];
+    const note = buckets.length === 0 ? "WARNING: not in Claude mapping" : "";
+    return {
+      medium: d.medium,
+      count: String(d.count),
+      proposed_buckets: buckets.join("; "),
+      notes: note,
+    };
+  });
+  writeCsv(OUTPUT_FILE, ["medium", "count", "proposed_buckets", "notes"], rows);
+
+  // 4. Summary
+  const bucketCounts = new Map<string, number>();
+  for (const d of distinct) {
+    const buckets = parsed.mapping[d.medium] || [];
+    for (const b of buckets) bucketCounts.set(b, (bucketCounts.get(b) || 0) + d.count);
+  }
+  const multiBucketRows = distinct.filter((d) => (parsed.mapping[d.medium] || []).length > 1).length;
+
+  console.log("\n=== Proposed Buckets ===");
+  parsed.buckets.forEach((b) => {
+    const c = bucketCounts.get(b) || 0;
+    console.log(`  ${b.padEnd(24)} ${c} artworks`);
+  });
+  console.log(`\nMulti-bucket strings (multiple materials): ${multiBucketRows}`);
+  console.log(`\nCSV: ${OUTPUT_FILE}`);
+  console.log("\nNext: open the CSV in Sheets, edit `proposed_buckets` if needed, save, then:");
+  console.log(`  npm run medium:apply -- ${OUTPUT_FILE}`);
+}
+
+main().catch((err) => { console.error("Fatal:", err); process.exit(1); });
+```
+
+- [ ] **Step 2: Verify modules resolve**
+
+Run: `npx tsx scripts/normalize-mediums-propose.ts 2>&1 | head -3`
+Expected: prints `Error: set NEXT_PUBLIC_SUPABASE_URL ...` (env-var guard fires; proves the file parses).
+
+---
+
+## Phase 3: Phase-2 apply script
+
+### Task 6: Implement `scripts/normalize-mediums-apply.ts`
+
+**Files:**
+- Create: `scripts/normalize-mediums-apply.ts`
+
+- [ ] **Step 1: Write the script**
+
+Create `scripts/normalize-mediums-apply.ts`:
+
+```typescript
+#!/usr/bin/env npx tsx
+/**
+ * normalize-mediums-apply.ts (Phase 2)
+ *
+ * Reads the (possibly-edited) CSV from Phase 1 and applies the
+ * normalized bucket assignments to the DB:
+ *   - Upserts kind='medium' rows in the categories table
+ *   - For each artwork, diffs its medium-category attachments against
+ *     what the CSV says it should have (adding missing, removing extra)
+ *   - Persists scripts/data/medium-buckets.json for the importers
+ *   - Writes per-row log to tmp/medium-apply-log_<ts>.csv
+ *
+ * Run: npx tsx --env-file=.env.local scripts/normalize-mediums-apply.ts <path-to-csv>
+ */
+
+import fs from "fs";
+import path from "path";
+import readline from "readline";
+import { parse } from "csv-parse/sync";
+import { createClient } from "@supabase/supabase-js";
+import { slugify } from "../src/lib/utils";
+import { parseProposedBuckets, BucketMap } from "./lib/medium-buckets";
+
+const TMP_DIR = path.join(__dirname, "..", "tmp");
+const DATA_DIR = path.join(__dirname, "data");
+const LOOKUP_FILE = path.join(DATA_DIR, "medium-buckets.json");
+const TIMESTAMP = new Date().toISOString().replace(/[:.]/g, "-");
+const LOG_FILE = path.join(TMP_DIR, `medium-apply-log_${TIMESTAMP}.csv`);
+
+const SUPABASE_URL =
+  process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error("Error: set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY");
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+interface CsvRow {
+  medium: string;
+  count: string;
+  proposed_buckets: string;
+  notes: string;
+}
+
+function csvField(v: string | null | undefined): string {
+  if (v === null || v === undefined) return "";
+  const s = String(v);
+  if (/[",\n\r]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+  return s;
+}
+
+function writeCsv(filePath: string, columns: string[], rows: Record<string, string>[]): void {
+  const header = columns.join(",");
+  const body = rows.map((r) => columns.map((c) => csvField(r[c])).join(",")).join("\n");
+  fs.writeFileSync(filePath, header + "\n" + body + "\n");
+}
+
+async function confirm(prompt: string): Promise<boolean> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(prompt + " [y/N] ", (answer) => {
+      rl.close();
+      resolve(answer.trim().toLowerCase() === "y");
+    });
+  });
+}
+
+async function main() {
+  const csvPath = process.argv[2];
+  if (!csvPath) {
+    console.error("Usage: npx tsx scripts/normalize-mediums-apply.ts <path-to-csv>");
+    process.exit(1);
+  }
+  if (!fs.existsSync(csvPath)) {
+    console.error(`CSV not found: ${csvPath}`);
+    process.exit(1);
+  }
+
+  // 1. Parse CSV → bucket map
+  const raw = fs.readFileSync(csvPath, "utf-8");
+  const rows: CsvRow[] = parse(raw, {
+    columns: true,
+    skip_empty_lines: true,
+    relax_quotes: true,
+    relax_column_count: true,
+  });
+  console.log(`Parsed ${rows.length} medium-row entries from ${path.basename(csvPath)}`);
+
+  const map: BucketMap = {};
+  const uniqueBuckets = new Set<string>();
+  for (const row of rows) {
+    const medium = (row.medium || "").trim();
+    if (!medium) continue;
+    const buckets = parseProposedBuckets(row.proposed_buckets);
+    map[medium] = buckets;
+    for (const b of buckets) uniqueBuckets.add(b);
+  }
+  const bucketList = [...uniqueBuckets].sort();
+  console.log(`\nDetected ${bucketList.length} unique buckets:`);
+  bucketList.forEach((b) => console.log(`  ${b}`));
+
+  const ok = await confirm("\nProceed to upsert these buckets and apply attachments?");
+  if (!ok) { console.log("Aborted."); process.exit(0); }
+
+  // 2. Upsert bucket categories
+  console.log("\nUpserting kind='medium' categories...");
+  const bucketRows = bucketList.map((name) => ({
+    name,
+    slug: slugify(name),
+    kind: "medium" as const,
+    ai_suggested: false,
+  }));
+  const { data: upserted, error: upsertErr } = await supabase
+    .from("categories")
+    .upsert(bucketRows, { onConflict: "slug", ignoreDuplicates: false })
+    .select("id, name, slug, kind");
+  if (upsertErr) { console.error("Upsert failed:", upsertErr); process.exit(1); }
+  const bucketIdByName: Record<string, string> = {};
+  for (const c of upserted || []) bucketIdByName[c.name] = c.id;
+  console.log(`  ${(upserted || []).length} bucket categories ensured`);
+
+  // 3. Page through artworks; diff and apply
+  console.log("\nFetching all artworks with non-null medium...");
+  const allArt: { id: string; medium: string }[] = [];
+  let off = 0;
+  while (true) {
+    const { data, error } = await supabase
+      .from("artworks")
+      .select("id, medium")
+      .not("medium", "is", null)
+      .range(off, off + 999);
+    if (error) { console.error(error); process.exit(1); }
+    if (!data || data.length === 0) break;
+    allArt.push(...(data as any));
+    if (data.length < 1000) break;
+    off += 1000;
+  }
+  console.log(`Found ${allArt.length} artworks with medium`);
+
+  // Pre-fetch existing medium-category attachments per artwork (one query)
+  const { data: existingAcs, error: acErr } = await supabase
+    .from("artwork_categories")
+    .select("artwork_id, category:categories!inner(id, kind)")
+    .eq("category.kind", "medium");
+  if (acErr) { console.error(acErr); process.exit(1); }
+  const existingByArtwork = new Map<string, Set<string>>();
+  for (const ac of (existingAcs || []) as any[]) {
+    if (!existingByArtwork.has(ac.artwork_id)) existingByArtwork.set(ac.artwork_id, new Set());
+    existingByArtwork.get(ac.artwork_id)!.add(ac.category.id);
+  }
+
+  // Apply diffs
+  const log: Record<string, string>[] = [];
+  let updated = 0;
+  let unchanged = 0;
+  let errors = 0;
+
+  for (const art of allArt) {
+    const medium = (art.medium || "").trim();
+    const desiredBuckets = map[medium] || [];
+    const desiredIds = new Set(
+      desiredBuckets.map((b) => bucketIdByName[b]).filter((id): id is string => !!id)
+    );
+    const currentIds = existingByArtwork.get(art.id) || new Set<string>();
+
+    const toAdd = [...desiredIds].filter((id) => !currentIds.has(id));
+    const toRemove = [...currentIds].filter((id) => !desiredIds.has(id));
+
+    if (toAdd.length === 0 && toRemove.length === 0) {
+      unchanged++;
+      continue;
+    }
+
+    let rowError = "";
+    if (toRemove.length > 0) {
+      const { error } = await supabase
+        .from("artwork_categories")
+        .delete()
+        .eq("artwork_id", art.id)
+        .in("category_id", toRemove);
+      if (error) rowError = `delete: ${error.message}`;
+    }
+    if (!rowError && toAdd.length > 0) {
+      const { error } = await supabase
+        .from("artwork_categories")
+        .upsert(
+          toAdd.map((category_id) => ({ artwork_id: art.id, category_id })),
+          { onConflict: "artwork_id,category_id", ignoreDuplicates: true }
+        );
+      if (error) rowError = `insert: ${error.message}`;
+    }
+
+    if (rowError) {
+      errors++;
+      log.push({
+        artwork_id: art.id,
+        medium,
+        applied_buckets: desiredBuckets.join("; "),
+        status: `error: ${rowError}`,
+      });
+    } else {
+      updated++;
+      log.push({
+        artwork_id: art.id,
+        medium,
+        applied_buckets: desiredBuckets.join("; "),
+        status: "ok",
+      });
+    }
+  }
+
+  // 4. Persist lookup map
+  if (!fs.existsSync(DATA_DIR)) fs.mkdirSync(DATA_DIR, { recursive: true });
+  const lookup = {
+    version: TIMESTAMP,
+    buckets: bucketList,
+    map,
+  };
+  fs.writeFileSync(LOOKUP_FILE, JSON.stringify(lookup, null, 2) + "\n");
+
+  // 5. Write log
+  if (!fs.existsSync(TMP_DIR)) fs.mkdirSync(TMP_DIR, { recursive: true });
+  writeCsv(LOG_FILE, ["artwork_id", "medium", "applied_buckets", "status"], log);
+
+  // 6. Summary
+  console.log("\n=== Summary ===");
+  console.log(`Artworks scanned:  ${allArt.length}`);
+  console.log(`Tag updates:       ${updated}`);
+  console.log(`Unchanged:         ${unchanged}`);
+  console.log(`Errors:            ${errors}`);
+  console.log(`\nLookup map: ${LOOKUP_FILE}`);
+  console.log(`Log:        ${LOG_FILE}`);
+}
+
+main().catch((err) => { console.error("Fatal:", err); process.exit(1); });
+```
+
+- [ ] **Step 2: Add npm scripts**
+
+In `package.json`, add to the `"scripts"` block (near the other normalization-style scripts):
+
+```json
+"medium:propose": "tsx --env-file=.env.local scripts/normalize-mediums-propose.ts",
+"medium:apply": "tsx --env-file=.env.local scripts/normalize-mediums-apply.ts",
+```
+
+Verify with `npm run | grep medium:`
+Expected: prints both scripts.
+
+- [ ] **Step 3: Verify both scripts parse**
+
+Run: `npx tsx scripts/normalize-mediums-apply.ts 2>&1 | head -3`
+Expected: prints `Usage: npx tsx scripts/normalize-mediums-apply.ts <path-to-csv>` (the missing-arg guard, proving the file parses).
+
+---
+
+## Phase 4: Run the workflow on production
+
+### Task 7: Run Phase 1 (LLM proposal)
+
+**Files:** none (execution; produces gitignored CSV in `tmp/`)
+
+- [ ] **Step 1: Run the propose script**
+
+Run: `npm run medium:propose`
+
+Expected output ends with:
+```
+=== Proposed Buckets ===
+  Ink                      ~600 artworks
+  Acrylic                  ~250 artworks
+  ...
+
+Multi-bucket strings (multiple materials): ~50
+
+CSV: /Users/cullfam/code/cg_clir/tmp/medium-buckets_<timestamp>.csv
+
+Next: open the CSV in Sheets, edit `proposed_buckets` if needed, save, then:
+  npm run medium:apply -- /Users/cullfam/code/cg_clir/tmp/medium-buckets_<timestamp>.csv
+```
+
+Cost: ~$0.05 in Claude API.
+
+If the script errors with non-JSON or schema-mismatch errors: report the raw response to the user; the prompt may need a tweak.
+
+- [ ] **Step 2: Show the user the bucket vocabulary**
+
+After the script completes, print the proposed bucket list to the chat for the user's review. Tell them to open the CSV in Sheets, edit if needed (rename, merge, split, fix specific assignments), and confirm when ready to apply.
+
+---
+
+### Task 8: User reviews CSV, then run Phase 2
+
+**Files:** none (execution)
+
+- [ ] **Step 1: Wait for user confirmation**
+
+Once the user says the CSV is ready (whether they edited it or not), run:
+
+```bash
+npm run medium:apply -- <path-from-task-7-output>
+```
+
+The script prints the bucket list it parsed from the CSV and asks for `[y/N]` confirmation. Type `y` to proceed.
+
+Expected output ends with:
+```
+=== Summary ===
+Artworks scanned:  ~2710
+Tag updates:       ~2710
+Unchanged:         0
+Errors:            0
+
+Lookup map: /Users/cullfam/code/cg_clir/scripts/data/medium-buckets.json
+Log:        /Users/cullfam/code/cg_clir/tmp/medium-apply-log_<timestamp>.csv
+```
+
+If errors > 0: report to the user. The log CSV has per-row details.
+
+- [ ] **Step 2: Spot-check a few artworks**
+
+Run:
+```bash
+npx tsx --env-file=.env.local -e "
+import { createClient } from '@supabase/supabase-js';
+const c = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+async function check(sku) {
+  const { data } = await c.from('artworks').select('sku, medium, categories:artwork_categories(category:categories!inner(name, kind))').eq('sku', sku).maybeSingle();
+  if (!data) return console.log(sku, '→ not found');
+  const mediums = (data.categories || []).filter(c => c.category.kind === 'medium').map(c => c.category.name);
+  console.log(sku, '|', data.medium, '|', mediums.join(', '));
+}
+async function go() {
+  await check('RB 25');
+  await check('JS 5');
+  await check('CLIR2024.233');
+  await check('DA 109');
+}
+go();
+"
+```
+
+Expected: each row prints with `sku | original medium | attached medium-category names`. Verify the attachments make semantic sense given the original medium string.
+
+---
+
+## Phase 5: Importer integration
+
+### Task 9: Update import-csv.ts to attach mediums
+
+**Files:**
+- Modify: `scripts/import-csv.ts`
+
+- [ ] **Step 1: Add helper imports + load the lookup map**
+
+At the top of `scripts/import-csv.ts`, add (alongside the existing imports):
+
+```typescript
+import { mediumToBuckets, BucketMap } from "./lib/medium-buckets";
+```
+
+After the `supabase` client is constructed (around line 30), add:
+
+```typescript
+// Load the persisted medium bucket map (from the medium normalization workflow).
+// Importers attach medium categories to new artworks based on this map.
+const BUCKETS_FILE = path.join(__dirname, "data", "medium-buckets.json");
+let bucketMap: BucketMap = {};
+let bucketIdByName: Record<string, string> = {};
+if (fs.existsSync(BUCKETS_FILE)) {
+  const lookup = JSON.parse(fs.readFileSync(BUCKETS_FILE, "utf-8"));
+  bucketMap = lookup.map || {};
+  // bucketIdByName is populated below after we resolve category IDs from the DB.
+}
+```
+
+- [ ] **Step 2: Resolve bucket IDs from DB before the artwork upsert loop**
+
+Find the place where artists are resolved (the `artistIdLookup` construction). After that block, add:
+
+```typescript
+// Resolve medium-category IDs (slug → id) so we can attach without
+// per-row category lookups during the artwork upsert loop.
+if (Object.keys(bucketMap).length > 0) {
+  const { data: mediumCats } = await supabase
+    .from("categories")
+    .select("id, name")
+    .eq("kind", "medium");
+  for (const c of mediumCats || []) bucketIdByName[c.name] = c.id;
+}
+```
+
+- [ ] **Step 3: After artwork upsert, attach medium categories**
+
+After the `withInventory` upsert returns and `artworkCount` is incremented, add a follow-up pass that attaches medium categories. The artwork row has been upserted on `inventory_number`; we need its `id` to insert into `artwork_categories`.
+
+Insert this block right after the existing upsert success path (after `artworkCount += withInventory.length;`):
+
+```typescript
+// Attach medium categories for any rows whose medium is in the lookup map.
+const unknownMediums = new Set<string>();
+for (const r of withInventory) {
+  const buckets = mediumToBuckets(bucketMap, r.medium);
+  if (buckets.length === 0) {
+    if (r.medium) unknownMediums.add(r.medium);
+    continue;
+  }
+  const categoryIds = buckets.map((b) => bucketIdByName[b]).filter(Boolean);
+  if (categoryIds.length === 0) continue;
+
+  // Need the artwork id — look up by inventory_number (just upserted)
+  const { data: art } = await supabase
+    .from("artworks")
+    .select("id")
+    .eq("inventory_number", r.inventory_number!)
+    .single();
+  if (!art) continue;
+
+  await supabase
+    .from("artwork_categories")
+    .upsert(
+      categoryIds.map((category_id) => ({ artwork_id: art.id, category_id })),
+      { onConflict: "artwork_id,category_id", ignoreDuplicates: true }
+    );
+}
+if (unknownMediums.size > 0) {
+  console.warn(`\nWARNING: ${unknownMediums.size} medium strings not in bucket map (artworks have no medium tag):`);
+  [...unknownMediums].sort().forEach((m) => console.warn(`  ${m}`));
+  console.warn("Re-run `npm run medium:propose` to absorb these into the vocabulary.");
+}
+```
+
+- [ ] **Step 4: Verify the script still parses**
+
+Run: `npx tsx scripts/import-csv.ts 2>&1 | head -3`
+Expected: prints the env-var error or the existing CSV-not-found error. Either way, no syntax/import errors.
+
+---
+
+### Task 10: Update import-archive.ts to attach mediums
+
+**Files:**
+- Modify: `scripts/import-archive.ts`
+
+- [ ] **Step 1: Add helper imports + load lookup at top**
+
+Near the existing `import` lines (the script imports `dateToDecade` from `../src/lib/decades` already), add:
+
+```typescript
+import { mediumToBuckets, BucketMap } from "./lib/medium-buckets";
+```
+
+After the `anthropic` client is constructed (around line 70), add:
+
+```typescript
+const BUCKETS_FILE = path.join(__dirname, "data", "medium-buckets.json");
+let bucketMap: BucketMap = {};
+let bucketIdByName: Record<string, string> = {};
+if (fs.existsSync(BUCKETS_FILE)) {
+  const lookup = JSON.parse(fs.readFileSync(BUCKETS_FILE, "utf-8"));
+  bucketMap = lookup.map || {};
+}
+```
+
+- [ ] **Step 2: Resolve bucket IDs once at script start**
+
+Inside the `main()` function, after the artworks are fetched but before the worker loop starts, add:
+
+```typescript
+if (Object.keys(bucketMap).length > 0) {
+  const { data: mediumCats } = await supabase
+    .from("categories")
+    .select("id, name")
+    .eq("kind", "medium");
+  for (const c of mediumCats || []) bucketIdByName[c.name] = c.id;
+}
+```
+
+- [ ] **Step 3: Attach mediums in Branch B insert path**
+
+In the Branch B handler (the path that creates a new artwork with image + Vision + themes), after `attachThemes(newId, themes)` is called, add:
+
+```typescript
+// Attach medium categories from the lookup map
+const mediumStr = (insertPayload.medium || "").trim();
+const buckets = mediumToBuckets(bucketMap, mediumStr);
+if (buckets.length > 0) {
+  const categoryIds = buckets.map((b) => bucketIdByName[b]).filter(Boolean);
+  if (categoryIds.length > 0) {
+    await supabase
+      .from("artwork_categories")
+      .upsert(
+        categoryIds.map((category_id) => ({ artwork_id: newId, category_id })),
+        { onConflict: "artwork_id,category_id", ignoreDuplicates: true }
+      );
+  }
+} else if (mediumStr) {
+  // Track unknown mediums in the log (we'll need to pipe this through)
+  log.notes = log.notes
+    ? `${log.notes}; medium not in bucket map: ${mediumStr}`
+    : `medium not in bucket map: ${mediumStr}`;
+}
+```
+
+- [ ] **Step 4: Verify the script still parses**
+
+Run: `npx tsx scripts/import-archive.ts 2>&1 | head -3`
+Expected: prints `Error: Set NEXT_PUBLIC_SUPABASE_URL ...` (env-var guard).
+
+---
+
+## Phase 6: UI integration
+
+### Task 11: Extend collection-query.ts to handle 3 category dimensions
+
+**Files:**
+- Modify: `src/lib/collection-query.ts`
+
+- [ ] **Step 1: Update categoryFilteredIds signature**
+
+Find `categoryFilteredIds` (around line 80). Add a third parameter for mediums and extend the intersection:
+
+```typescript
+async function categoryFilteredIds(
+  supabase: SupabaseClient,
+  themes: string[],
+  formats: string[],
+  mediums: string[]
+): Promise<string[]> {
+  async function idsFor(slugs: string[], kind: "theme" | "format" | "medium"): Promise<Set<string>> {
+    if (slugs.length === 0) return new Set();
+    const rows = await fetchAllRows<{ artwork_id: string }>(() =>
+      supabase
+        .from("artwork_categories")
+        .select("artwork_id, category:categories!inner(slug, kind)")
+        .eq("category.kind", kind)
+        .in("category.slug", slugs)
+    );
+    return new Set(rows.map((r: any) => r.artwork_id));
+  }
+
+  const [themeIds, formatIds, mediumIds] = await Promise.all([
+    idsFor(themes, "theme"),
+    idsFor(formats, "format"),
+    idsFor(mediums, "medium"),
+  ]);
+
+  // Intersect only the active sets; if one dim isn't filtered, it doesn't constrain.
+  const sets: Set<string>[] = [];
+  if (themes.length > 0) sets.push(themeIds);
+  if (formats.length > 0) sets.push(formatIds);
+  if (mediums.length > 0) sets.push(mediumIds);
+  if (sets.length === 0) return []; // shouldn't be called in this case
+  if (sets.length === 1) return [...sets[0]];
+  return [...sets[0]].filter((id) => sets.slice(1).every((s) => s.has(id)));
+}
+```
+
+- [ ] **Step 2: Extend applySingleDimEmbeddedFilter for mediums**
+
+Replace the existing `applySingleDimEmbeddedFilter`:
+
+```typescript
+function applySingleDimEmbeddedFilter(
+  q: any,
+  themes: string[],
+  formats: string[],
+  mediums: string[]
+): any {
+  if (themes.length > 0) {
+    return q
+      .eq("artwork_categories.category.kind", "theme")
+      .in("artwork_categories.category.slug", themes);
+  }
+  if (formats.length > 0) {
+    return q
+      .eq("artwork_categories.category.kind", "format")
+      .in("artwork_categories.category.slug", formats);
+  }
+  if (mediums.length > 0) {
+    return q
+      .eq("artwork_categories.category.kind", "medium")
+      .in("artwork_categories.category.slug", mediums);
+  }
+  return q;
+}
+```
+
+- [ ] **Step 3: Update ExceptDim type**
+
+Find the `ExceptDim` type (near the top, after constants). Update to include `"mediums"`:
+
+```typescript
+type ExceptDim = "themes" | "formats" | "mediums" | "decades" | "artist" | "q" | "none";
+```
+
+- [ ] **Step 4: Update queryArtworks to pass mediums through**
+
+In `queryArtworks`, replace the existing `themes` / `formats` / `isOneDim` / `isTwoDim` block (around line 230) with:
+
+```typescript
+  const themes = state.themes;
+  const formats = state.formats;
+  const mediums = state.mediums;
+  const activeCatDims = [themes.length > 0, formats.length > 0, mediums.length > 0].filter(Boolean).length;
+  const isOneDim = activeCatDims === 1;
+  const isMultiDim = activeCatDims >= 2;
+
+  let intersectedIds: string[] | null = null;
+  if (isMultiDim) {
+    intersectedIds = await categoryFilteredIds(supabase, themes, formats, mediums);
+    if (intersectedIds.length === 0) return { artworks: [], total: 0 };
+  }
+```
+
+Then in the same function, change the `applySingleDimEmbeddedFilter` call to pass mediums:
+
+```typescript
+  if (isOneDim) {
+    q = applySingleDimEmbeddedFilter(q, themes, formats, mediums);
+  } else if (isMultiDim) {
+    q = q.in("id", intersectedIds!);
+  }
+```
+
+(Replace `isTwoDim` references with `isMultiDim` in this function.)
+
+- [ ] **Step 5: Update candidateIdsExcept the same way**
+
+In `candidateIdsExcept`, find:
+
+```typescript
+  const themes = except === "themes" ? [] : state.themes;
+  const formats = except === "formats" ? [] : state.formats;
+  const isOneDim = (themes.length > 0) !== (formats.length > 0);
+  const isTwoDim = themes.length > 0 && formats.length > 0;
+```
+
+Replace with:
+
+```typescript
+  const themes = except === "themes" ? [] : state.themes;
+  const formats = except === "formats" ? [] : state.formats;
+  const mediums = except === "mediums" ? [] : state.mediums;
+  const activeCatDims = [themes.length > 0, formats.length > 0, mediums.length > 0].filter(Boolean).length;
+  const isOneDim = activeCatDims === 1;
+  const isMultiDim = activeCatDims >= 2;
+
+  let intersectedIds: string[] | null = null;
+  if (isMultiDim) {
+    intersectedIds = await categoryFilteredIds(supabase, themes, formats, mediums);
+    if (intersectedIds.length === 0) return new Set();
+  }
+```
+
+And in the same function change `applySingleDimEmbeddedFilter(q, themes, formats)` to `applySingleDimEmbeddedFilter(q, themes, formats, mediums)`, and `isTwoDim` to `isMultiDim`.
+
+- [ ] **Step 6: Add mediums facet to getFacetCounts + FacetCounts interface**
+
+Update the `FacetCounts` interface near the top:
+
+```typescript
+export interface FacetCounts {
+  themes: Record<string, number>;
+  formats: Record<string, number>;
+  mediums: Record<string, number>;
+  decades: Record<string, number>;
+  availableArtistSlugs: Set<string>;
+}
+```
+
+Update `getFacetCounts` to compute mediums in parallel:
+
+```typescript
+export async function getFacetCounts(
+  supabase: SupabaseClient,
+  state: FilterState,
+  cohort: Cohort
+): Promise<FacetCounts> {
+  const artistId = await resolveArtistId(supabase, state.artist);
+
+  const [themeIds, formatIds, mediumIds, decadeIds, artistIds] = await Promise.all([
+    candidateIdsExcept(supabase, state, cohort, artistId, "themes"),
+    candidateIdsExcept(supabase, state, cohort, artistId, "formats"),
+    candidateIdsExcept(supabase, state, cohort, artistId, "mediums"),
+    candidateIdsExcept(supabase, state, cohort, artistId, "decades"),
+    candidateIdsExcept(supabase, state, cohort, artistId, "artist"),
+  ]);
+
+  const [themes, formats, mediums, decades, availableArtistSlugs] = await Promise.all([
+    countCategoriesForIds(supabase, themeIds, "theme"),
+    countCategoriesForIds(supabase, formatIds, "format"),
+    countCategoriesForIds(supabase, mediumIds, "medium"),
+    countDecadesForIds(supabase, decadeIds),
+    artistsForIds(supabase, artistIds),
+  ]);
+
+  return { themes, formats, mediums, decades, availableArtistSlugs };
+}
+```
+
+Update the `countCategoriesForIds` signature to accept `medium` as a kind value:
+
+```typescript
+async function countCategoriesForIds(
+  supabase: SupabaseClient,
+  candidateIds: Set<string>,
+  kind: "theme" | "format" | "medium"
+): Promise<Record<string, number>> {
+```
+
+(Body unchanged.)
+
+- [ ] **Step 7: Verify type-check still passes**
+
+Run: `npm run lint 2>&1 | tail -5`
+Expected: no errors.
+
+---
+
+### Task 12: Add Medium dropdown to FilterBar
+
+**Files:**
+- Modify: `src/components/FilterBar.tsx`
+
+- [ ] **Step 1: Add `mediumOptions` prop**
+
+In `FilterBarProps`, add after `formatOptions`:
+
+```typescript
+  mediumOptions: { value: string; label: string; count: number }[];
+```
+
+- [ ] **Step 2: Render the Medium dropdown after Format**
+
+In the JSX, find the Format dropdown block (the one wrapped in `{isCollection && (`). After it, before the Artist dropdown, add:
+
+```tsx
+        {isCollection && (
+          <MultiSelectDropdown
+            label="Medium"
+            options={mediumOptions}
+            selected={state.mediums}
+            onChange={(mediums) => navigate({ ...state, mediums })}
+          />
+        )}
+```
+
+- [ ] **Step 3: Add medium chips to the active-filter row**
+
+In the `chips` array construction (near where theme/format chips are pushed), add:
+
+```typescript
+  for (const m of state.mediums) {
+    chips.push({
+      label: mediumOptions.find((o) => o.value === m)?.label || m,
+      onRemove: () => navigate({ ...state, mediums: state.mediums.filter((x) => x !== m) }),
+    });
+  }
+```
+
+- [ ] **Step 4: Update Clear all to also clear mediums**
+
+Find the `onClearAll` prop on `<ActiveFilterChips>`. Update to include mediums in the clear:
+
+```tsx
+        onClearAll={() => navigate({ ...state, themes: [], formats: [], mediums: [], decades: [], artist: null })}
+```
+
+- [ ] **Step 5: Destructure the new prop in the function signature**
+
+The function signature should now read:
+
+```typescript
+export default function FilterBar({
+  state,
+  cohort,
+  themeOptions,
+  formatOptions,
+  mediumOptions,
+  decadeOptions,
+  artistOptions,
+}: FilterBarProps) {
+```
+
+- [ ] **Step 6: Lint**
+
+Run: `npm run lint 2>&1 | tail -3`
+Expected: no errors.
+
+---
+
+### Task 13: Plumb medium options through the home page
+
+**Files:**
+- Modify: `src/app/page.tsx`
+
+- [ ] **Step 1: Fetch medium categories alongside themes/formats**
+
+Find the existing `Promise.all` at the top of `HomePage` (~line 27). It currently fetches artworks, facets, formatCats, themeCats, allArtists. Add a `mediumCats` fetch:
+
+```typescript
+  const [{ artworks, total }, facets, formatCats, themeCats, mediumCats, allArtists] = await Promise.all([
+    queryArtworks(supabase, state, "artwork"),
+    getFacetCounts(supabase, state, "artwork"),
+    supabase.from("categories").select("name, slug").eq("kind", "format").order("name"),
+    supabase.from("categories").select("name, slug").eq("kind", "theme").order("name"),
+    supabase.from("categories").select("name, slug").eq("kind", "medium").order("name"),
+    supabase.from("artists").select("slug, first_name, last_name").order("last_name").order("first_name"),
+  ]);
+```
+
+- [ ] **Step 2: Build mediumOptions and pass to FilterBar**
+
+After the existing `decadeOptions` construction, add:
+
+```typescript
+  const mediumOptions = (mediumCats.data || []).map((c) => ({
+    value: c.slug,
+    label: c.name,
+    count: facets.mediums[c.slug] || 0,
+  }));
+```
+
+In the `<FilterBar ... />` JSX, add the new prop between `formatOptions` and `decadeOptions`:
+
+```tsx
+        formatOptions={formatOptions}
+        mediumOptions={mediumOptions}
+        decadeOptions={decadeOptions}
+```
+
+- [ ] **Step 3: Update preserveParams in Pagination**
+
+In the `<Pagination>` element, update the `preserveParams` to include `medium`:
+
+```tsx
+              preserveParams={["q", "theme", "format", "medium", "decade", "artist", "sort"]}
+```
+
+- [ ] **Step 4: Lint**
+
+Run: `npm run lint 2>&1 | tail -3`
+Expected: no errors.
+
+---
+
+### Task 14: Update ephemera page to pass empty mediumOptions
+
+**Files:**
+- Modify: `src/app/ephemera/page.tsx`
+
+- [ ] **Step 1: Add the missing prop**
+
+In the `<FilterBar>` JSX in `src/app/ephemera/page.tsx`, add `mediumOptions={[]}` alongside the existing empty `themeOptions={[]} formatOptions={[]} decadeOptions={[]}`. The cohort doesn't surface medium dropdowns (it's skipped via `isCollection` in FilterBar) but the prop is required.
+
+```tsx
+      <FilterBar
+        state={state}
+        cohort="ephemera"
+        themeOptions={[]}
+        formatOptions={[]}
+        mediumOptions={[]}
+        decadeOptions={[]}
+        artistOptions={artistOptions}
+      />
+```
+
+- [ ] **Step 2: Lint**
+
+Run: `npm run lint 2>&1 | tail -3`
+Expected: no errors.
+
+---
+
+### Task 15: Sync the migration SQL
+
+**Files:**
+- Modify: `supabase/migrations/001_initial.sql`
+
+- [ ] **Step 1: Update the kind CHECK constraint to allow medium**
+
+Find the `categories` table definition. Update the `kind` column's CHECK to include `'medium'`:
+
+```sql
+  kind          TEXT CHECK (kind IN ('format', 'theme', 'medium')),
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `grep "kind.*CHECK" supabase/migrations/001_initial.sql`
+Expected: shows the line with all three kinds listed.
+
+---
+
+### Task 16: Smoke test the UI
+
+**Files:** none (verification)
+
+- [ ] **Step 1: Run lint + tests**
+
+Run: `npm run lint 2>&1 | tail -3`
+Expected: clean.
+
+Run: `npx tsx --test scripts/test-filter-state.ts scripts/test-medium-buckets.ts 2>&1 | tail -5`
+Expected: all tests pass (14 in filter-state, 5 in medium-buckets).
+
+- [ ] **Step 2: Start dev server**
+
+Run: `npm run dev` (use `run_in_background`).
+
+Wait until `Ready in <X>ms`.
+
+- [ ] **Step 3: Verify Medium dropdown appears**
+
+Run: `curl -s http://localhost:3000/ | grep -oE '"children":"Medium[^"]*"' | head -3`
+Expected: prints `"children":"Medium ▾"` (or `"children":"Medium (N) ▾"` if pre-selected).
+
+- [ ] **Step 4: Verify a medium-filtered URL works**
+
+Pick a known medium bucket (e.g., `ink` if that slug was created by Phase 2). Then:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" "http://localhost:3000/?medium=ink"
+curl -s -o /dev/null -w "%{http_code}\n" "http://localhost:3000/?medium=ink,acrylic"
+curl -s -o /dev/null -w "%{http_code}\n" "http://localhost:3000/?medium=ink&theme=animals"
+```
+
+Expected: all `200`.
+
+- [ ] **Step 5: Verify Medium does NOT appear on /ephemera**
+
+Run: `curl -s "http://localhost:3000/ephemera" | grep -oE '"children":"Medium[^"]*"' | head -3`
+Expected: no output (Medium dropdown is hidden on the ephemera cohort).
+
+- [ ] **Step 6: Stop dev server**
+
+Kill the background process.
+
+---
+
+### Task 17: Commit Phase 6 + final cleanup
+
+**Files:** none (git only)
+
+- [ ] **Step 1: Stage all changes**
+
+Run:
+```bash
+git add scripts/test-filter-state.ts scripts/test-medium-buckets.ts \
+  scripts/lib/medium-buckets.ts \
+  scripts/normalize-mediums-propose.ts scripts/normalize-mediums-apply.ts \
+  scripts/data/medium-buckets.json \
+  scripts/import-csv.ts scripts/import-archive.ts \
+  src/lib/filter-state.ts src/lib/collection-query.ts \
+  src/components/FilterBar.tsx \
+  src/app/page.tsx src/app/ephemera/page.tsx \
+  supabase/migrations/001_initial.sql \
+  package.json
+git status
+```
+
+Expected: ~12 files staged.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+Add Medium normalization workflow + Medium filter dropdown
+
+Two-phase LLM workflow normalizes the catalog's 283 free-text medium
+strings into a small (~12-18) bucket vocabulary of pure materials,
+following CDWA conventions:
+
+- scripts/normalize-mediums-propose.ts: Phase 1. Calls Claude with the
+  distinct medium strings, gets back a bucket vocabulary + per-string
+  mapping (multi-tag where the medium describes multiple materials).
+  Writes tmp/medium-buckets_<ts>.csv for human review in Sheets.
+
+- scripts/normalize-mediums-apply.ts: Phase 2. Reads the
+  (possibly-edited) CSV, upserts kind='medium' rows in the categories
+  table, diffs each artwork's medium-category attachments against
+  the desired set, persists scripts/data/medium-buckets.json for the
+  importers.
+
+- scripts/data/medium-buckets.json: source-controlled lookup map
+  consumed by import-csv.ts and import-archive.ts on insert. Unknown
+  mediums are logged as warnings; affected artworks land with no
+  medium tag until the next normalization pass.
+
+UI: new "Medium" multi-select dropdown in FilterBar (after Format).
+collection-query.ts generalized from 2 to 3 category dimensions —
+the 1-dim embedded filter and 2+-dim catIds intersection paths
+extend cleanly via a small refactor of the active-dim count.
+
+Schema: extended the categories.kind CHECK constraint to allow
+'medium' (manually applied via Supabase SQL Editor; source-controlled
+migration file synced).
+
+Spec: docs/superpowers/specs/2026-04-25-medium-normalization-design.md
+Plan: docs/superpowers/plans/2026-04-25-medium-normalization.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: commit succeeds.
+
+---
+
+## Done
+
+At this point:
+- The DB has a `kind='medium'` taxonomy with ~12-18 buckets and ~2,710 artworks attached to one or more medium categories.
+- The home page has a working Medium dropdown with facet counts that compose correctly with theme / format / decade / artist / search.
+- `scripts/data/medium-buckets.json` ships in source control. Future imports automatically attach medium categories on insert.
+- Unknown mediums in future imports surface as console warnings (action item: re-run `npm run medium:propose`).
+
+Hand-off:
+- The bucket vocabulary is editable: re-run Phase 1, edit the CSV, run Phase 2 again — the diff-based apply handles add/remove/reassign cleanly.
+- A future enhancement could surface medium tags on the artwork detail page or as small chips on cards. Both are out of scope for v1.

--- a/docs/superpowers/specs/2026-04-25-medium-normalization-design.md
+++ b/docs/superpowers/specs/2026-04-25-medium-normalization-design.md
@@ -1,0 +1,211 @@
+# Medium Normalization & Filter — Design
+
+**Date:** 2026-04-25
+**Status:** Ready for implementation
+
+---
+
+## Goal
+
+Add a "Medium" filter dropdown to the public collection browse, backed by a normalized taxonomy of art materials (Ink, Acrylic, Pastel, Ceramic, Wood, etc.). Each artwork can be attached to multiple medium tags reflecting all materials used in its creation. The original free-text `artworks.medium` field (e.g. `"Color Stix, ink, and colored pencil on paper"`) stays untouched as the canonical CDWA "Materials/Techniques Description" for display.
+
+The work has three parts:
+1. A **two-phase LLM workflow** that proposes a small bucket vocabulary and a per-medium-string mapping (`tmp/medium-buckets.csv`), reviewed by a human, then applied to the DB.
+2. A **persisted lookup map** (`scripts/data/medium-buckets.json`) that future importers consult so newly-imported artworks get the right tags without another LLM call.
+3. **UI integration**: a new multi-select Medium dropdown in `FilterBar`, plumbed through `collection-query.ts` the same way Theme and Format already work.
+
+---
+
+## Background: CDWA conventions (the reasoning behind the model)
+
+CDWA — *Categories for the Description of Works of Art* (the Getty's authoritative cataloging standard) — distinguishes:
+
+- **Medium** = the material applied to the work (ink, acrylic, pastel, charcoal, ceramic, …)
+- **Support** = the surface it's applied to (paper, canvas, wood panel, …)
+
+Display syntax is "medium on support" — `oil on canvas`, `ink on paper`. CDWA explicitly recommends enumerating individual materials when known rather than lumping into "mixed media" — *"thoroughness and a high level of exhaustivity are preferred over a cursory analysis."*
+
+This spec follows CDWA's enumeration preference: each artwork attaches to every material present, and we expose those materials as a faceted filter. The "medium on support" display string remains intact in `artworks.medium` and is what the artwork detail page already shows.
+
+References:
+- [Materials/Techniques — Categories for the Description of Works of Art (Getty)](https://www.getty.edu/publications/categories-description-works-art/categories/object-architecture-group/7/)
+
+---
+
+## Storage
+
+### Reuse the existing categories taxonomy
+
+A new `kind = 'medium'` slice of the `categories` table:
+
+```sql
+-- No schema migration needed; existing constraint is permissive enough
+-- once we update the application's contract.
+-- Add 'medium' to the allowed kinds via:
+ALTER TABLE categories DROP CONSTRAINT IF EXISTS categories_kind_check;
+ALTER TABLE categories ADD CONSTRAINT categories_kind_check
+  CHECK (kind IN ('format', 'theme', 'medium'));
+```
+
+Each medium bucket is a row in `categories` with `kind='medium'`, `name='Acrylic'`, `slug='acrylic'`, etc. Artworks attach via the existing `artwork_categories` many-to-many — same shape as Theme and Format. An artwork can have N medium tags. Cohort + cohort-vs-medium queries plug into the existing `collection-query.ts` pattern with a few additions.
+
+### Why not a separate column
+
+A `normalized_medium TEXT` column on `artworks` would be simpler for a single-tag world but breaks our many-to-many requirement. Categories table reuses every piece of FilterBar / faceted-count infrastructure built for Theme and Format. The choice is consistent.
+
+---
+
+## Bucket taxonomy
+
+**Materials only, ~12–18 buckets, no Support facet, no enumerated "Mixed Media" bucket for hybrids** (an artwork using Acrylic + Ink simply has both tags). One catch-all `"Other"` bucket exists for genuinely-unspecifiable cases.
+
+The exact bucket vocabulary is set during Phase 1 by the LLM proposal + human review. Likely buckets based on the current top-20 mediums:
+
+| Bucket | Examples it would absorb |
+|---|---|
+| Ink | "Ink on paper", "Pen on paper", "Ink on newspaper", "Ink and watercolor on paper" (also tags Watercolor) |
+| Pastel | "Pastel on paper" |
+| Oil pastel | "Oil pastel on paper" |
+| Color Stix | "Color Stix on paper", "Prismastix on wood" (also tags Wood) |
+| Colored pencil | "Colored pencil on paper" |
+| Pencil / Graphite | "Graphite, ink and watercolor on paper" (also tags Ink + Watercolor) |
+| Marker | "Marker on paper" |
+| Acrylic | "Acrylic on paper", "Acrylic on magazine" |
+| Watercolor | "Watercolor on paper" |
+| Oil paint | "Oil on canvas" |
+| Crayon | "Crayon on paper" |
+| Charcoal | "Charcoal on paper" |
+| Ceramic | "Ceramic" |
+| Wood | "Prismastix on wood" |
+| Fiber / Yarn | "Wool", "Embroidery thread" |
+| Other | catch-all when the LLM can't confidently bucket the input |
+
+Bucket names are exposed verbatim in the dropdown UI. Slugs are kebab-cased (`color-stix`, `oil-paint`).
+
+**Support is intentionally NOT a separate facet for v1.** The existing Format taxonomy (Drawing / Painting / Sculpture / Fiber / etc.) already covers the meaningful 2D-vs-3D distinction. Adding Support as a third axis would surface "Paper" for ~90% of the catalog and add no real signal.
+
+---
+
+## Phase 1: LLM proposal + CSV review
+
+**Script:** `scripts/normalize-mediums-propose.ts`
+**npm:** `medium:propose`
+
+1. Query the DB for every distinct `medium` string (with row counts) where `medium IS NOT NULL`.
+2. Send the full list (~283 strings) to Claude (`claude-sonnet-4-6`) in a single call. System prompt asks for:
+   - a small bucket vocabulary (~12–18 buckets) of pure materials
+   - for each input string, an array of bucket names the artwork should be tagged with
+   - rationale notes for borderline cases
+3. Parse the JSON response. Write `tmp/medium-buckets_<timestamp>.csv` with columns:
+
+   | `medium` | `count` | `proposed_buckets` | `notes` |
+   |---|---|---|---|
+   | `Ink on paper` | 324 | `Ink` | |
+   | `Color Stix, ink, and colored pencil on paper` | 90 | `Color Stix; Ink; Colored pencil` | |
+   | `Mixed media on paper` | 65 | `Other` | LLM unable to enumerate |
+   | … | | | |
+
+   Multi-bucket assignments are semicolon-joined in the `proposed_buckets` cell so the user can edit in Sheets without CSV escaping pain.
+
+4. Print a summary: bucket vocabulary, count of strings per bucket, count of multi-bucket strings.
+
+The user opens the CSV in Sheets, edits where needed (rename buckets, merge buckets, fix specific assignments, add buckets the LLM missed), saves.
+
+### Edge cases for the proposal
+
+- **Empty / NULL medium**: ~561 artworks. Excluded from the proposal. They stay with no medium category attached. Acceptable — they don't appear in the medium filter.
+- **Idempotency**: re-running Phase 1 produces a fresh timestamped CSV; the user picks which to apply.
+- **Cost**: one Claude Sonnet call with ~283 strings + ~50-line system prompt → ~$0.05.
+
+---
+
+## Phase 2: Apply to DB
+
+**Script:** `scripts/normalize-mediums-apply.ts`
+**npm:** `medium:apply`
+
+Takes one argument: the path to the (possibly-edited) CSV from Phase 1.
+
+1. Parse CSV, build `Map<string, string[]>` of medium → buckets.
+2. Validate: every bucket name in `proposed_buckets` is either a known existing `kind='medium'` category or a new bucket to be created. Print the bucket vocabulary detected from the CSV; require user confirmation (`y/N`) before any DB writes.
+3. Upsert all bucket categories with `kind='medium'`. Build `Map<bucketName, categoryId>`.
+4. Page through every artwork with non-null medium. For each row:
+   - Look up the artwork's medium string in the CSV map.
+   - Compute the desired set of medium-category IDs.
+   - Diff against existing `artwork_categories` rows where `category.kind='medium'`. Add missing, remove extra.
+5. Persist `scripts/data/medium-buckets.json` (the verified-clean lookup map) for the importers' use.
+6. Write a per-row log to `tmp/medium-apply-log_<timestamp>.csv` with columns: `artwork_id, medium, applied_buckets, status`.
+
+---
+
+## Future imports: persisted lookup
+
+`scripts/data/medium-buckets.json` ships in source control. Shape:
+
+```json
+{
+  "version": "2026-04-25",
+  "buckets": ["Ink", "Pastel", "Oil pastel", "Color Stix", "Colored pencil", "Pencil", "Marker", "Acrylic", "Watercolor", "Oil paint", "Crayon", "Charcoal", "Ceramic", "Wood", "Fiber", "Other"],
+  "map": {
+    "Ink on paper": ["Ink"],
+    "Acrylic on paper": ["Acrylic"],
+    "Color Stix, ink, and colored pencil on paper": ["Color Stix", "Ink", "Colored pencil"],
+    "Mixed media on paper": ["Other"]
+  }
+}
+```
+
+**Update both importers to consult this map on insert:**
+
+- `scripts/import-csv.ts` — on each artwork row, look up its medium string in `map`. Attach the corresponding medium categories via `artwork_categories`.
+- `scripts/import-archive.ts` (Branch B path) — same.
+
+**Unknown medium handling:**
+- If a future import has a medium string not in `map`, the script logs a warning to stdout listing the unrecognized strings and the affected artwork SKUs. Those artworks insert with NO medium tag — they won't appear in any medium filter until the next normalization pass.
+- The maintainer periodically re-runs Phase 1 to absorb new strings into the vocabulary, edits the CSV, runs Phase 2 to refresh the DB and the lookup map.
+
+This trades dynamism for predictability + auditability. New mediums never silently get classified by an LLM whose output drifts.
+
+---
+
+## UI integration
+
+`FilterBar` gains a fourth `MultiSelectDropdown`, label `Medium`, populated from `kind='medium'` categories with facet counts. Position: after `Format` in the dropdown row.
+
+`collection-query.ts` changes:
+
+- `applyAllFilters` / scalar pass: when `state.mediums` is non-empty AND themes/formats are also non-empty, the existing two-dim category intersection logic in `categoryFilteredIds` extends to handle the third dimension (themes ∩ formats ∩ mediums via the same per-kind ID set fetch + intersection).
+- New `applySingleDimEmbeddedFilter` cases for medium-only, theme+medium, format+medium, theme+format+medium combinations. The dimension count grows from 2 to 3, so the truth table for "embedded vs catIds .in()" gets more entries:
+  - 0 cat dims active: no extra filter
+  - 1 cat dim active (theme XOR format XOR medium): embedded INNER filter (already implemented for theme/format; extend to medium)
+  - ≥ 2 cat dims active: catIds intersection .in()
+
+The cohort + scalar (decade, artist, q) filtering paths are unchanged.
+
+`FilterState` (in `src/lib/filter-state.ts`) gains a `mediums: string[]` field with `medium=` URL param parsing & serialization, mirroring `themes` / `formats`. Active-filter chips and "Clear all" extend to include medium.
+
+`getFacetCounts` adds a `mediums: Record<string, number>` entry computed via the same `candidateIdsExcept` + `countCategoriesForIds` pattern.
+
+---
+
+## Out of scope (explicit)
+
+- **Support facet.** Format already covers the meaningful 2D/3D split.
+- **A "Technique" facet.** CDWA distinguishes materials from techniques (e.g., "etching"). The current data is purely material-focused; technique extraction would require its own LLM pass.
+- **Real-time LLM classification on insert.** Would add per-row latency + cost + drift risk. Saved lookup is sufficient.
+- **Editing the bucket vocabulary via the admin console.** v1 is "edit the CSV, run Phase 2." A real admin UI for the medium taxonomy is a future enhancement.
+- **Display of medium pill badges on artwork cards.** The detail page continues to show the integrated CDWA phrase via `artworks.medium`. Surfacing the bucket tags as visible chips on cards is deferred (could feel cluttered alongside title + artist).
+- **Backfilling the ~561 empty-medium artworks.** Requires source data we don't have. They stay un-tagged.
+
+---
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| LLM proposes too many buckets (e.g. 40) | System prompt explicitly requests ~12–18 + reviewer can merge during CSV review |
+| LLM mis-buckets (e.g. "Color Stix" → "Crayon") | CSV review catches it before any DB write |
+| User edits CSV in Sheets and breaks the multi-value `;`-joined cells | Phase 2 validates the CSV shape and surfaces errors before applying |
+| Taxonomy drift over time as new medium strings appear in imports | Importers log unknowns; periodic re-run of Phase 1 absorbs them |
+| The `categories` constraint check rejects `'medium'` until the migration runs | Phase 2 will fail with a clear error message if the user hasn't run the ALTER first |
+| Race condition on bucket category creation under concurrency | N/A — Phase 2 is single-threaded; importers consume the static map and don't create new buckets |

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "triage:report": "tsx --env-file=.env.local scripts/catalog-triage-report.ts",
     "backfill:decade": "tsx --env-file=.env.local scripts/backfill-decade.ts",
     "migrate:all": "tsx --env-file=.env.local scripts/migrate-and-describe.ts",
-    "db:migrate": "tsx scripts/run-migration.ts"
+    "db:migrate": "tsx scripts/run-migration.ts",
+    "medium:propose": "tsx --env-file=.env.local scripts/normalize-mediums-propose.ts",
+    "medium:apply": "tsx --env-file=.env.local scripts/normalize-mediums-apply.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1023.0",

--- a/scripts/data/medium-buckets.json
+++ b/scripts/data/medium-buckets.json
@@ -1,0 +1,1048 @@
+{
+  "version": "2026-04-26T16-02-51-738Z",
+  "buckets": [
+    "Acrylic",
+    "Ceramic",
+    "Collage",
+    "Color Stix",
+    "Colored pencil",
+    "Crayon",
+    "Fiber/Yarn",
+    "Graphite/Pencil",
+    "Ink",
+    "Marker",
+    "Oil pastel",
+    "Other",
+    "Pastel",
+    "Sequins/Beads",
+    "Watercolor",
+    "Wood"
+  ],
+  "map": {
+    "Ink on paper": [
+      "Ink"
+    ],
+    "Oil pastel on paper": [
+      "Oil pastel"
+    ],
+    "Acrylic on paper": [
+      "Acrylic"
+    ],
+    "Pastel on paper": [
+      "Pastel"
+    ],
+    "Color Stix on paper": [
+      "Color Stix"
+    ],
+    "Colored pencil on paper": [
+      "Colored pencil"
+    ],
+    "Acrylic and ink on paper": [
+      "Acrylic",
+      "Ink"
+    ],
+    "Color Stix, ink, and colored pencil on paper": [
+      "Color Stix",
+      "Ink",
+      "Colored pencil"
+    ],
+    "Ceramic": [
+      "Ceramic"
+    ],
+    "Watercolor on paper": [
+      "Watercolor"
+    ],
+    "Graphite, ink and watercolor on paper": [
+      "Graphite/Pencil",
+      "Ink",
+      "Watercolor"
+    ],
+    "Mixed media on paper": [
+      "Other"
+    ],
+    "Colored pencil and ink on paper": [
+      "Colored pencil",
+      "Ink"
+    ],
+    "Watercolor and ink on paper": [
+      "Watercolor",
+      "Ink"
+    ],
+    "Pen on paper": [
+      "Ink"
+    ],
+    "Ink and pastel on paper": [
+      "Ink",
+      "Pastel"
+    ],
+    "Ink and watercolor on paper": [
+      "Ink",
+      "Watercolor"
+    ],
+    "Acrylic on magazine": [
+      "Acrylic"
+    ],
+    "Ink on newspaper": [
+      "Ink"
+    ],
+    "Prismastix on wood": [
+      "Color Stix",
+      "Wood"
+    ],
+    "Ink and marker on paper": [
+      "Ink",
+      "Marker"
+    ],
+    "Collage": [
+      "Collage"
+    ],
+    "Acrylic on wood": [
+      "Acrylic",
+      "Wood"
+    ],
+    "Fiber and found objects": [
+      "Fiber/Yarn"
+    ],
+    "Prismastix on paper": [
+      "Color Stix"
+    ],
+    "Ink and colored pencil on paper": [
+      "Ink",
+      "Colored pencil"
+    ],
+    "Graphite on paper": [
+      "Graphite/Pencil"
+    ],
+    "Ink on magazine": [
+      "Ink"
+    ],
+    "Sharpie on paper": [
+      "Marker"
+    ],
+    "Rug": [
+      "Fiber/Yarn"
+    ],
+    "Marker on paper": [
+      "Marker"
+    ],
+    "Acrylic and Sharpie on paper": [
+      "Acrylic",
+      "Marker"
+    ],
+    "Color Stix and Sharpie on paper": [
+      "Color Stix",
+      "Marker"
+    ],
+    "Oil pastel and ink on paper": [
+      "Oil pastel",
+      "Ink"
+    ],
+    "Ink and pencil on paper": [
+      "Ink",
+      "Graphite/Pencil"
+    ],
+    "Acrylic and pen on paper": [
+      "Acrylic",
+      "Ink"
+    ],
+    "Pen and colored pencil on paper": [
+      "Ink",
+      "Colored pencil"
+    ],
+    "Wrapped sculpture": [
+      "Other"
+    ],
+    "Wool, Roving, twine, cardboard": [
+      "Fiber/Yarn"
+    ],
+    "Acrylic and colored pencil on paper": [
+      "Acrylic",
+      "Colored pencil"
+    ],
+    "Ink and crayon on paper": [
+      "Ink",
+      "Crayon"
+    ],
+    "Acrylic on wood sculpture": [
+      "Acrylic",
+      "Wood"
+    ],
+    "Crayon and ink on paper": [
+      "Crayon",
+      "Ink"
+    ],
+    "Color Stix and ink on paper": [
+      "Color Stix",
+      "Ink"
+    ],
+    "Watercolor and oil pastel on paper": [
+      "Watercolor",
+      "Oil pastel"
+    ],
+    "Wood sculpture": [
+      "Wood"
+    ],
+    "Pencil on paper": [
+      "Graphite/Pencil"
+    ],
+    "Acrylic on canvas": [
+      "Acrylic"
+    ],
+    "Acrylic on found photograph": [
+      "Acrylic"
+    ],
+    "Wrapped fiber sculpture": [
+      "Fiber/Yarn"
+    ],
+    "Color Stix and graphite on paper": [
+      "Color Stix",
+      "Graphite/Pencil"
+    ],
+    "Art Stix on paper": [
+      "Color Stix"
+    ],
+    "Acrylic on found photo": [
+      "Acrylic"
+    ],
+    "Weaving": [
+      "Fiber/Yarn"
+    ],
+    "Acrylic and graphite on paper": [
+      "Acrylic",
+      "Graphite/Pencil"
+    ],
+    "Watercolor and graphite on paper": [
+      "Watercolor",
+      "Graphite/Pencil"
+    ],
+    "Watercolor and Sharpie on paper": [
+      "Watercolor",
+      "Marker"
+    ],
+    "Art Stix on paper puppet": [
+      "Color Stix"
+    ],
+    "Art Stix on paper cutout": [
+      "Color Stix"
+    ],
+    "Chalk pastel on paper": [
+      "Pastel"
+    ],
+    "Acrylic and watercolor on paper": [
+      "Acrylic",
+      "Watercolor"
+    ],
+    "Oil pastel and acrylic on paper": [
+      "Oil pastel",
+      "Acrylic"
+    ],
+    "Pencil and watercolor on paper": [
+      "Graphite/Pencil",
+      "Watercolor"
+    ],
+    "Ink and oil pastel on paper": [
+      "Ink",
+      "Oil pastel"
+    ],
+    "Acrylic on photograph": [
+      "Acrylic"
+    ],
+    "Relief print": [
+      "Other"
+    ],
+    "Color pencil on paper": [
+      "Colored pencil"
+    ],
+    "Pastel and ink on paper": [
+      "Pastel",
+      "Ink"
+    ],
+    "Etching": [
+      "Other"
+    ],
+    "Tempera on paper": [
+      "Acrylic"
+    ],
+    "Watercolor pencil on paper": [
+      "Colored pencil",
+      "Watercolor"
+    ],
+    "Sequin sculpture": [
+      "Sequins/Beads"
+    ],
+    "Wrap sculpture": [
+      "Other"
+    ],
+    "Sequins on styrofoam": [
+      "Sequins/Beads"
+    ],
+    "Acrylic, graphite and ink on paper": [
+      "Acrylic",
+      "Graphite/Pencil",
+      "Ink"
+    ],
+    "Burned wood": [
+      "Wood"
+    ],
+    "Ink and watercolor pencil on paper": [
+      "Ink",
+      "Colored pencil",
+      "Watercolor"
+    ],
+    "Pastel and watercolor on paper": [
+      "Pastel",
+      "Watercolor"
+    ],
+    "Gel pen on paper": [
+      "Ink"
+    ],
+    "Ink, crayon, and watercolor on paper": [
+      "Ink",
+      "Crayon",
+      "Watercolor"
+    ],
+    "Watercolor, acrylic and Sharpie on paper": [
+      "Watercolor",
+      "Acrylic",
+      "Marker"
+    ],
+    "Ink on paper cutout": [
+      "Ink"
+    ],
+    "Oil pastel and Sharpie on paper": [
+      "Oil pastel",
+      "Marker"
+    ],
+    "Oil pastel and watercolor on paper": [
+      "Oil pastel",
+      "Watercolor"
+    ],
+    "Paper,Oil pastel": [
+      "Oil pastel"
+    ],
+    "Hand colored etching": [
+      "Other"
+    ],
+    "Basket": [
+      "Fiber/Yarn"
+    ],
+    "Mixed media on wood": [
+      "Wood",
+      "Other"
+    ],
+    "Oil pastel on wood": [
+      "Oil pastel",
+      "Wood"
+    ],
+    "Ink on found photograph": [
+      "Ink"
+    ],
+    "Mixed media on wood panel": [
+      "Wood",
+      "Other"
+    ],
+    "Prisma on paper": [
+      "Colored pencil"
+    ],
+    "Acrylic on found paper": [
+      "Acrylic"
+    ],
+    "Pins and sequins in styrofoam": [
+      "Sequins/Beads"
+    ],
+    "Prisma stix on paper": [
+      "Color Stix"
+    ],
+    "Ink and acrylic on paper": [
+      "Ink",
+      "Acrylic"
+    ],
+    "watercolor and ink": [
+      "Watercolor",
+      "Ink"
+    ],
+    "Acrylic, watercolor, and ink on paper": [
+      "Acrylic",
+      "Watercolor",
+      "Ink"
+    ],
+    "ink on acetate": [
+      "Ink"
+    ],
+    "Acrylic and ink on panel": [
+      "Acrylic",
+      "Ink"
+    ],
+    "Ink on matboard": [
+      "Ink"
+    ],
+    "Ink and graphite on paper": [
+      "Ink",
+      "Graphite/Pencil"
+    ],
+    "Wool yarn, Acrylic yarn, Branches, Cardboard cones, Polyester fabric, Silk fabric": [
+      "Fiber/Yarn"
+    ],
+    "Watercolor and crayon on paper": [
+      "Watercolor",
+      "Crayon"
+    ],
+    "Acrylic, ink, and Sharpie on paper": [
+      "Acrylic",
+      "Ink",
+      "Marker"
+    ],
+    "Mixed media": [
+      "Other"
+    ],
+    "Pen and colored pencil": [
+      "Ink",
+      "Colored pencil"
+    ],
+    "Acrylic yarn, twine, wooden sticks, Raffia": [
+      "Fiber/Yarn"
+    ],
+    "Print on paper": [
+      "Other"
+    ],
+    "Ink on wood": [
+      "Ink",
+      "Wood"
+    ],
+    "Watercolor, graphite, and crayon on paper": [
+      "Watercolor",
+      "Graphite/Pencil",
+      "Crayon"
+    ],
+    "Acrylic on unstretched canvas": [
+      "Acrylic"
+    ],
+    "Pencil and pastel on paper": [
+      "Graphite/Pencil",
+      "Pastel"
+    ],
+    "Oil pastel and Color Stix on paper": [
+      "Oil pastel",
+      "Color Stix"
+    ],
+    "Acrylic and pastel on paper": [
+      "Acrylic",
+      "Pastel"
+    ],
+    "Paper,Oil pastel,Sharpie": [
+      "Oil pastel",
+      "Marker"
+    ],
+    "Acrylic": [
+      "Acrylic"
+    ],
+    "Watercolor and colored pencil on paper": [
+      "Watercolor",
+      "Colored pencil"
+    ],
+    "Oil pastel and colored pencil on paper": [
+      "Oil pastel",
+      "Colored pencil"
+    ],
+    "Graphite and crayon": [
+      "Graphite/Pencil",
+      "Crayon"
+    ],
+    "Acrylic yarn,Polyester fabric": [
+      "Fiber/Yarn"
+    ],
+    "Poster": [
+      "Other"
+    ],
+    "Textile": [
+      "Fiber/Yarn"
+    ],
+    "Chalk and oil pastel on paper": [
+      "Pastel",
+      "Oil pastel"
+    ],
+    "Pen on wood": [
+      "Ink",
+      "Wood"
+    ],
+    "Handmade book": [
+      "Other"
+    ],
+    "Sequined sculpture": [
+      "Sequins/Beads"
+    ],
+    "Crochet": [
+      "Fiber/Yarn"
+    ],
+    "Colored Pencil/Sharpie on paper": [
+      "Colored pencil",
+      "Marker"
+    ],
+    "Acrylic Marker on Wood": [
+      "Acrylic",
+      "Marker",
+      "Wood"
+    ],
+    "Chine-collé etching": [
+      "Collage"
+    ],
+    "Cardboard sculpture": [
+      "Other"
+    ],
+    "Graphite and crayon on paper": [
+      "Graphite/Pencil",
+      "Crayon"
+    ],
+    "Acrylic on leather and textile pillow": [
+      "Acrylic",
+      "Fiber/Yarn"
+    ],
+    "Acrylic on record": [
+      "Acrylic"
+    ],
+    "Monoprint": [
+      "Other"
+    ],
+    "Acrylic and ink on wood": [
+      "Acrylic",
+      "Ink",
+      "Wood"
+    ],
+    "Pillow": [
+      "Fiber/Yarn"
+    ],
+    "Pencil and acrylic on paper": [
+      "Graphite/Pencil",
+      "Acrylic"
+    ],
+    "Oil pastel acrylic and watercolor on paper": [
+      "Oil pastel",
+      "Acrylic",
+      "Watercolor"
+    ],
+    "white ink and typewriter on paper": [
+      "Ink"
+    ],
+    "acrylic, ink, and color stix on paper": [
+      "Acrylic",
+      "Ink",
+      "Color Stix"
+    ],
+    "Acrylic yarn,Cotton fabric,String,Silk flowers,Mixed media": [
+      "Fiber/Yarn"
+    ],
+    "Ink, marker, and oil pastel on paper": [
+      "Ink",
+      "Marker",
+      "Oil pastel"
+    ],
+    "LD21": [
+      "Other"
+    ],
+    "Acrylic yarn,cardboard": [
+      "Fiber/Yarn"
+    ],
+    "Color Stix and marker on paper": [
+      "Color Stix",
+      "Marker"
+    ],
+    "Sharpie": [
+      "Marker"
+    ],
+    "Hooked Rug": [
+      "Fiber/Yarn"
+    ],
+    "Sharpie and magazine cutouts on mat board": [
+      "Marker",
+      "Collage"
+    ],
+    "Handcolored print on paper": [
+      "Other"
+    ],
+    "Ink and pastel on folded paper card": [
+      "Ink",
+      "Pastel"
+    ],
+    "acrylic, ink, and typewriter on paper": [
+      "Acrylic",
+      "Ink"
+    ],
+    "Looped rug": [
+      "Fiber/Yarn"
+    ],
+    "wax pencil": [
+      "Graphite/Pencil"
+    ],
+    "Acrylic on foamboard": [
+      "Acrylic"
+    ],
+    "Silkscreen on paper": [
+      "Other"
+    ],
+    "Fiber sculpture": [
+      "Fiber/Yarn"
+    ],
+    "Risograph print": [
+      "Other"
+    ],
+    "Acrylic and textile on wood sculpture": [
+      "Acrylic",
+      "Fiber/Yarn",
+      "Wood"
+    ],
+    "LD1": [
+      "Other"
+    ],
+    "Acrylic, Sharpie, and acrylic pen on paper": [
+      "Acrylic",
+      "Marker"
+    ],
+    "Ink and colorstix on paper": [
+      "Ink",
+      "Color Stix"
+    ],
+    "Ink, pencil, and watercolor on paper": [
+      "Ink",
+      "Graphite/Pencil",
+      "Watercolor"
+    ],
+    "Magazine cutouts": [
+      "Collage"
+    ],
+    "Colored pecnil on paper": [
+      "Colored pencil"
+    ],
+    "Color Stix and colored pencil on paper": [
+      "Color Stix",
+      "Colored pencil"
+    ],
+    "LD2": [
+      "Other"
+    ],
+    "Ceramic and wood": [
+      "Ceramic",
+      "Wood"
+    ],
+    "Ceramic with light bulb": [
+      "Ceramic"
+    ],
+    "Fabric sculpture": [
+      "Fiber/Yarn"
+    ],
+    "Monoprint on paper": [
+      "Other"
+    ],
+    "Sharpie, graphite, colored pencil, and Color Stix on paper": [
+      "Marker",
+      "Graphite/Pencil",
+      "Colored pencil",
+      "Color Stix"
+    ],
+    "watercolor, ink, and glitter on paper": [
+      "Watercolor",
+      "Ink",
+      "Other"
+    ],
+    "Acrylic, Sharpie and Color Stix on paper": [
+      "Acrylic",
+      "Marker",
+      "Color Stix"
+    ],
+    "Acrylic yarn, Polyester fabric": [
+      "Fiber/Yarn"
+    ],
+    "Ink on paper,Graphite on paper": [
+      "Ink",
+      "Graphite/Pencil"
+    ],
+    "Pastel on paper book": [
+      "Pastel"
+    ],
+    "Ceramic with light fixture": [
+      "Ceramic"
+    ],
+    "Acrylic and Sharpie on canvas": [
+      "Acrylic",
+      "Marker"
+    ],
+    "Sharpie and watercolor on paper": [
+      "Marker",
+      "Watercolor"
+    ],
+    "Paper,Acrylic": [
+      "Acrylic"
+    ],
+    "Acrylic on Canvas": [
+      "Acrylic"
+    ],
+    "DS 057": [
+      "Other"
+    ],
+    "Yarn basket": [
+      "Fiber/Yarn"
+    ],
+    "Paper,Oil pastel,Watercolor": [
+      "Oil pastel",
+      "Watercolor"
+    ],
+    "Acrylic, paint pen, and ink on paper": [
+      "Acrylic",
+      "Marker",
+      "Ink"
+    ],
+    "Mixed media wood sculpture": [
+      "Wood",
+      "Other"
+    ],
+    "Ink on clothing": [
+      "Ink"
+    ],
+    "Acrylic yarn, cardboard, plexiglass, Paper": [
+      "Fiber/Yarn"
+    ],
+    "Acrylic and foil on paper": [
+      "Acrylic",
+      "Other"
+    ],
+    "Sequin, beads, and styrofoam": [
+      "Sequins/Beads"
+    ],
+    "Mixed media sculpture": [
+      "Other"
+    ],
+    "Cotton yarn": [
+      "Fiber/Yarn"
+    ],
+    "wax pencil on paper": [
+      "Graphite/Pencil"
+    ],
+    "Embroidered canvas": [
+      "Fiber/Yarn"
+    ],
+    "Cyanotype": [
+      "Other"
+    ],
+    "Colored pencil and ink": [
+      "Colored pencil",
+      "Ink"
+    ],
+    "DS 68": [
+      "Other"
+    ],
+    "Sharpie and crayon on paper": [
+      "Marker",
+      "Crayon"
+    ],
+    "Watercolor collage": [
+      "Watercolor",
+      "Collage"
+    ],
+    "Pastel and colored pencil on paper": [
+      "Pastel",
+      "Colored pencil"
+    ],
+    "Oil pastel": [
+      "Oil pastel"
+    ],
+    "Woven basket": [
+      "Fiber/Yarn"
+    ],
+    "Oil pastel, marker, and crayon on paper": [
+      "Oil pastel",
+      "Marker",
+      "Crayon"
+    ],
+    "Watercolor and pencil on paper": [
+      "Watercolor",
+      "Graphite/Pencil"
+    ],
+    "Watercolor": [
+      "Watercolor"
+    ],
+    "Ink, crayon, and print cutout on mat board": [
+      "Ink",
+      "Crayon",
+      "Collage"
+    ],
+    "Pastel and color pencil on paper": [
+      "Pastel",
+      "Colored pencil"
+    ],
+    "Acrylic and charcoal on unstretched canvas": [
+      "Acrylic"
+    ],
+    "Ink on folded paper": [
+      "Ink"
+    ],
+    "Ink on book page": [
+      "Ink"
+    ],
+    "Artstix on paper": [
+      "Color Stix"
+    ],
+    "Acrylic on Wood": [
+      "Acrylic",
+      "Wood"
+    ],
+    "Colored pencil on wood cutout": [
+      "Colored pencil",
+      "Wood"
+    ],
+    "Mixed media collage on paper": [
+      "Collage",
+      "Other"
+    ],
+    "Watercolor, acrylic and Sharpie on paper,Watercolor and graphite on paper": [
+      "Watercolor",
+      "Acrylic",
+      "Marker",
+      "Graphite/Pencil"
+    ],
+    "DS 67": [
+      "Other"
+    ],
+    "Graphite and color pencil": [
+      "Graphite/Pencil",
+      "Colored pencil"
+    ],
+    "Acrylic yarn, cardboard, plexiglass, paper": [
+      "Fiber/Yarn"
+    ],
+    "Pencil and ink on paper": [
+      "Graphite/Pencil",
+      "Ink"
+    ],
+    "Paper,Crayon": [
+      "Crayon"
+    ],
+    "Acrylic and ink on wood cutout": [
+      "Acrylic",
+      "Ink",
+      "Wood"
+    ],
+    "Ink on dress": [
+      "Ink"
+    ],
+    "Ink and pencil and paper": [
+      "Ink",
+      "Graphite/Pencil"
+    ],
+    "Acrylic on book page": [
+      "Acrylic"
+    ],
+    "Pastel on wood": [
+      "Pastel",
+      "Wood"
+    ],
+    "Ink on magazine page": [
+      "Ink"
+    ],
+    "Oil pastel on wood sculpture": [
+      "Oil pastel",
+      "Wood"
+    ],
+    "Crayon on paper": [
+      "Crayon"
+    ],
+    "Mixed media on board": [
+      "Other"
+    ],
+    "Acrylic yarn,Paper,Bike wheel,Roving,Fleece,Upholstery fabric,String,Wicker basket,Wooden chair": [],
+    "Paint markers on wood": [
+      "Marker",
+      "Wood"
+    ],
+    "LD23": [
+      "Other"
+    ],
+    "LD24": [
+      "Other"
+    ],
+    "Beads, found objects, acrylic resin on wood": [
+      "Sequins/Beads",
+      "Wood"
+    ],
+    "Acrylic yarn, Cotton fabric, String, Silk flowers, Mixed media": [
+      "Fiber/Yarn"
+    ],
+    "Acrylic and pencil on paper": [
+      "Acrylic",
+      "Graphite/Pencil"
+    ],
+    "Woven bag": [
+      "Fiber/Yarn"
+    ],
+    "Acrylic on lamp shade": [
+      "Acrylic"
+    ],
+    "Pastel and pencil on paper": [
+      "Pastel",
+      "Graphite/Pencil"
+    ],
+    "Prismacolor on paper": [
+      "Colored pencil"
+    ],
+    "Acrylic, marker, and ink on paper": [
+      "Acrylic",
+      "Marker",
+      "Ink"
+    ],
+    "Oil pastel, crayon, watercolor, and colored pencil on paper collage": [
+      "Oil pastel",
+      "Crayon",
+      "Watercolor",
+      "Colored pencil",
+      "Collage"
+    ],
+    "Sculpture wrapped with a variety of materials": [
+      "Other"
+    ],
+    "Watercolor, ink, and sticker on paper": [
+      "Watercolor",
+      "Ink",
+      "Other"
+    ],
+    "Pastel on paper record sleeve": [
+      "Pastel"
+    ],
+    "Acrylic and oil pastel on paper": [
+      "Acrylic",
+      "Oil pastel"
+    ],
+    "Oil pastel and marker on paper": [
+      "Oil pastel",
+      "Marker"
+    ],
+    "15.5x22": [
+      "Other"
+    ],
+    "Colored pencil and watercolor on paper": [
+      "Colored pencil",
+      "Watercolor"
+    ],
+    "Marker and crayon on paper": [
+      "Marker",
+      "Crayon"
+    ],
+    "Watercolor, acrylic, and graphite on paper": [
+      "Watercolor",
+      "Acrylic",
+      "Graphite/Pencil"
+    ],
+    "Oil pastel and graphite on paper": [
+      "Oil pastel",
+      "Graphite/Pencil"
+    ],
+    "Prisma color on wood": [
+      "Colored pencil",
+      "Wood"
+    ],
+    "Pastel on wood cutout": [
+      "Pastel",
+      "Wood"
+    ],
+    "Ink and masking tape on paper": [
+      "Ink",
+      "Other"
+    ],
+    "Beads, Sequins and Dress Pins on Styrofoam": [
+      "Sequins/Beads"
+    ],
+    "Yarn on monks cloth": [
+      "Fiber/Yarn"
+    ],
+    "Ink and acrylic on paper book": [
+      "Ink",
+      "Acrylic"
+    ],
+    "Colored pencil and graphite on paper": [
+      "Colored pencil",
+      "Graphite/Pencil"
+    ],
+    "Prisma stix on wood": [
+      "Color Stix",
+      "Wood"
+    ],
+    "gel pen and ink on wood": [
+      "Ink",
+      "Wood"
+    ],
+    "Glitter and relief print": [
+      "Other"
+    ],
+    "ColorStix on Paper": [
+      "Color Stix"
+    ],
+    "Soft sculpture": [
+      "Fiber/Yarn"
+    ],
+    "Marker and pen on paper": [
+      "Marker",
+      "Ink"
+    ],
+    "Marker on vintage linen": [
+      "Marker",
+      "Fiber/Yarn"
+    ],
+    "Ink and acrylic marker on paper": [
+      "Ink",
+      "Acrylic",
+      "Marker"
+    ],
+    "Watercolor on paper cutout": [
+      "Watercolor"
+    ],
+    "Pen on wood sculpture": [
+      "Ink",
+      "Wood"
+    ],
+    "Print": [
+      "Other"
+    ],
+    "Colorstix on paper": [
+      "Color Stix"
+    ],
+    "Color Stix, acrylic, ink, and colored pencil on paper": [
+      "Color Stix",
+      "Acrylic",
+      "Ink",
+      "Colored pencil"
+    ],
+    "Incised clay": [
+      "Ceramic"
+    ],
+    "Colored pencil and chalk pastel on paper": [
+      "Colored pencil",
+      "Pastel"
+    ],
+    "Crayon on textile": [
+      "Crayon",
+      "Fiber/Yarn"
+    ],
+    "Acrylic yarn,Raffia,Cotton fabric,Cotton yarn,Wool,Wood,Plastic coated wire,Felt": [
+      "Fiber/Yarn",
+      "Wood"
+    ],
+    "Collage and ink on paper": [
+      "Collage",
+      "Ink"
+    ],
+    "Watercolor, oil pastel, and pencil on paper": [
+      "Watercolor",
+      "Oil pastel",
+      "Graphite/Pencil"
+    ],
+    "Paper,Oil pastel,Acrylic": [
+      "Oil pastel",
+      "Acrylic"
+    ],
+    "Wool,Roving,twine,cardboard": [
+      "Fiber/Yarn"
+    ],
+    "Oil pastel, acrylic, and watercolor on paper": [
+      "Oil pastel",
+      "Acrylic",
+      "Watercolor"
+    ]
+  }
+}

--- a/scripts/import-archive.ts
+++ b/scripts/import-archive.ts
@@ -400,7 +400,8 @@ async function main() {
     const { data: mediumCats } = await supabase
       .from("categories")
       .select("id, name")
-      .eq("kind", "medium");
+      .eq("kind", "medium")
+      .limit(10000);
     for (const c of mediumCats || []) bucketIdByName[c.name] = c.id;
     console.log(`Loaded ${Object.keys(bucketIdByName).length} medium category IDs.`);
     if (Object.keys(bucketIdByName).length === 0) {

--- a/scripts/import-archive.ts
+++ b/scripts/import-archive.ts
@@ -31,6 +31,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import { normalizeThemes, VALID_THEMES } from "../src/lib/themes";
 import { slugify, parseNumeric } from "../src/lib/utils";
 import { dateToDecade } from "../src/lib/decades";
+import { mediumToBuckets, BucketMap } from "./lib/medium-buckets";
 
 // ─── Config ───────────────────────────────────────────────────────────────
 const TMP_DIR = path.join(__dirname, "..", "tmp");
@@ -71,6 +72,19 @@ const r2 = new S3Client({
   },
 });
 const anthropic = new Anthropic({ apiKey: ANTHROPIC_KEY });
+
+// Load the persisted medium bucket map (from the medium normalization workflow).
+const BUCKETS_FILE = path.join(__dirname, "data", "medium-buckets.json");
+let bucketMap: BucketMap = {};
+const bucketIdByName: Record<string, string> = {};
+if (fs.existsSync(BUCKETS_FILE)) {
+  const lookup = JSON.parse(fs.readFileSync(BUCKETS_FILE, "utf-8"));
+  if (!lookup.map || typeof lookup.map !== "object") {
+    console.warn(`WARNING: ${BUCKETS_FILE} is missing a 'map' key — medium attachments disabled.`);
+  } else {
+    bucketMap = lookup.map;
+  }
+}
 
 const CONCURRENCY = parseInt(process.env.CONCURRENCY || "3", 10);
 const PAGE_SIZE = 1000;
@@ -282,6 +296,21 @@ async function attachThemes(artworkId: string, themes: string[]): Promise<void> 
   }
 }
 
+async function attachMediums(artworkId: string, mediumStr: string | null): Promise<void> {
+  const buckets = mediumToBuckets(bucketMap, mediumStr);
+  if (buckets.length === 0) return;
+  const rows: { artwork_id: string; category_id: string }[] = [];
+  for (const b of buckets) {
+    const categoryId = bucketIdByName[b];
+    if (categoryId) rows.push({ artwork_id: artworkId, category_id: categoryId });
+  }
+  if (rows.length === 0) return;
+  const { error } = await supabase
+    .from("artwork_categories")
+    .upsert(rows, { onConflict: "artwork_id,category_id", ignoreDuplicates: true });
+  if (error) throw new Error(`Failed to attach mediums to artwork ${artworkId}: ${error.message}`);
+}
+
 const artistCache = new Map<string, string>(); // slug -> artist id
 const artistInflight = new Map<string, Promise<string>>();
 
@@ -366,6 +395,21 @@ async function main() {
     offset += PAGE_SIZE;
   }
   console.log(`Fetched ${dbSkuToId.size} DB artworks with SKUs`);
+
+  if (Object.keys(bucketMap).length > 0) {
+    const { data: mediumCats } = await supabase
+      .from("categories")
+      .select("id, name")
+      .eq("kind", "medium");
+    for (const c of mediumCats || []) bucketIdByName[c.name] = c.id;
+    console.log(`Loaded ${Object.keys(bucketIdByName).length} medium category IDs.`);
+    if (Object.keys(bucketIdByName).length === 0) {
+      console.warn(
+        "WARNING: bucket map exists but no kind='medium' categories in the DB. " +
+        "Run `npm run medium:apply -- <csv>` first or medium tags will be skipped."
+      );
+    }
+  }
 
   // 3. Load progress checkpoint
   const progress = loadProgress();
@@ -486,6 +530,7 @@ async function main() {
             log.ai_status = "skipped_no_image";
             // Continue to themes anyway — row exists with original URL
             await attachThemes(newId, themes);
+            await attachMediums(newId, insertPayload.medium);
             log.themes_attached = themes.join("; ");
             return;
           }
@@ -500,6 +545,7 @@ async function main() {
             log.image_status = `upload_failed: ${(err as Error).message}`;
             log.ai_status = "skipped_no_image";
             await attachThemes(newId, themes);
+            await attachMediums(newId, insertPayload.medium);
             log.themes_attached = themes.join("; ");
             return;
           }
@@ -528,6 +574,7 @@ async function main() {
         }
 
         await attachThemes(newId, themes);
+        await attachMediums(newId, insertPayload.medium);
         log.themes_attached = themes.join("; ");
       }
 

--- a/scripts/import-archive.ts
+++ b/scripts/import-archive.ts
@@ -400,8 +400,7 @@ async function main() {
     const { data: mediumCats } = await supabase
       .from("categories")
       .select("id, name")
-      .eq("kind", "medium")
-      .limit(10000);
+      .eq("kind", "medium");
     for (const c of mediumCats || []) bucketIdByName[c.name] = c.id;
     console.log(`Loaded ${Object.keys(bucketIdByName).length} medium category IDs.`);
     if (Object.keys(bucketIdByName).length === 0) {

--- a/scripts/import-csv.ts
+++ b/scripts/import-csv.ts
@@ -218,8 +218,6 @@ async function main() {
               .from("artworks")
               .select("id, inventory_number, medium")
               .in("inventory_number", inventoryNumbers);
-            const idByInv = new Map<string, string>();
-            for (const a of artRows || []) idByInv.set(a.inventory_number, a.id);
 
             const acRows: { artwork_id: string; category_id: string }[] = [];
             const unknownInThisBatch = new Set<string>();

--- a/scripts/import-csv.ts
+++ b/scripts/import-csv.ts
@@ -14,6 +14,7 @@ import { parse } from "csv-parse/sync";
 import { createClient } from "@supabase/supabase-js";
 import { slugify, parseNumeric, parseTags } from "../src/lib/utils";
 import { dateToDecade } from "../src/lib/decades";
+import { mediumToBuckets, BucketMap } from "./lib/medium-buckets";
 
 // ─── Config ───────────────────────────────────────────────────────────────
 const CSV_PATH =
@@ -33,6 +34,17 @@ if (!SUPABASE_URL || !SUPABASE_KEY) {
 const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
   auth: { autoRefreshToken: false, persistSession: false },
 });
+
+// Load the persisted medium bucket map (from the medium normalization workflow).
+// Importers attach medium categories to new artworks based on this map.
+const BUCKETS_FILE = path.join(__dirname, "data", "medium-buckets.json");
+let bucketMap: BucketMap = {};
+let bucketIdByName: Record<string, string> = {};
+if (fs.existsSync(BUCKETS_FILE)) {
+  const lookup = JSON.parse(fs.readFileSync(BUCKETS_FILE, "utf-8"));
+  bucketMap = lookup.map || {};
+  // bucketIdByName is populated below after we resolve category IDs from the DB.
+}
 
 // ─── Types ────────────────────────────────────────────────────────────────
 interface CsvRow {
@@ -114,6 +126,17 @@ async function main() {
   }
   console.log(`Upserted ${upsertedArtists?.length || 0} artists.`);
 
+  // Resolve medium-category IDs (name → id) so we can attach without
+  // per-row category lookups during the artwork upsert loop.
+  if (Object.keys(bucketMap).length > 0) {
+    const { data: mediumCats } = await supabase
+      .from("categories")
+      .select("id, name")
+      .eq("kind", "medium");
+    for (const c of mediumCats || []) bucketIdByName[c.name] = c.id;
+    console.log(`Loaded ${Object.keys(bucketIdByName).length} medium category IDs.`);
+  }
+
   // ── Step 2: Upsert artworks ────────────────────────────────────────────
   console.log("\n--- Upserting artworks ---");
 
@@ -121,6 +144,7 @@ async function main() {
   const BATCH_SIZE = 100;
   let artworkCount = 0;
   let skippedCount = 0;
+  const unknownMediums = new Set<string>();
 
   for (let i = 0; i < rows.length; i += BATCH_SIZE) {
     const batch = rows.slice(i, i + BATCH_SIZE);
@@ -184,6 +208,39 @@ async function main() {
           );
         } else {
           artworkCount += withInventory.length;
+
+          // Attach medium categories from the lookup map for any rows whose
+          // medium string is in the bucket map. Single batched select gets
+          // ids; then a single upsert applies all attachments for the batch.
+          if (Object.keys(bucketMap).length > 0) {
+            const inventoryNumbers = withInventory.map((r) => r.inventory_number!);
+            const { data: artRows } = await supabase
+              .from("artworks")
+              .select("id, inventory_number, medium")
+              .in("inventory_number", inventoryNumbers);
+            const idByInv = new Map<string, string>();
+            for (const a of artRows || []) idByInv.set(a.inventory_number, a.id);
+
+            const acRows: { artwork_id: string; category_id: string }[] = [];
+            const unknownInThisBatch = new Set<string>();
+            for (const a of artRows || []) {
+              const buckets = mediumToBuckets(bucketMap, a.medium);
+              if (buckets.length === 0) {
+                if (a.medium) unknownInThisBatch.add(a.medium);
+                continue;
+              }
+              for (const b of buckets) {
+                const categoryId = bucketIdByName[b];
+                if (categoryId) acRows.push({ artwork_id: a.id, category_id: categoryId });
+              }
+            }
+            if (acRows.length > 0) {
+              await supabase
+                .from("artwork_categories")
+                .upsert(acRows, { onConflict: "artwork_id,category_id", ignoreDuplicates: true });
+            }
+            for (const m of unknownInThisBatch) unknownMediums.add(m);
+          }
         }
       }
 
@@ -212,6 +269,12 @@ async function main() {
   console.log(
     `\n\nDone! Imported ${artworkCount} artworks, skipped ${skippedCount} (no title).`
   );
+
+  if (unknownMediums.size > 0) {
+    console.warn(`\nWARNING: ${unknownMediums.size} medium strings not in bucket map (artworks have no medium tag):`);
+    [...unknownMediums].sort().forEach((m) => console.warn(`  ${m}`));
+    console.warn("Re-run `npm run medium:propose` to absorb these into the vocabulary.");
+  }
 
   // ── Step 3: Summary ────────────────────────────────────────────────────
   const { count: totalArtworks } = await supabase

--- a/scripts/import-csv.ts
+++ b/scripts/import-csv.ts
@@ -42,7 +42,11 @@ let bucketMap: BucketMap = {};
 let bucketIdByName: Record<string, string> = {};
 if (fs.existsSync(BUCKETS_FILE)) {
   const lookup = JSON.parse(fs.readFileSync(BUCKETS_FILE, "utf-8"));
-  bucketMap = lookup.map || {};
+  if (!lookup.map || typeof lookup.map !== "object") {
+    console.warn(`WARNING: ${BUCKETS_FILE} is missing a 'map' key — medium attachments disabled.`);
+  } else {
+    bucketMap = lookup.map;
+  }
   // bucketIdByName is populated below after we resolve category IDs from the DB.
 }
 
@@ -135,6 +139,12 @@ async function main() {
       .eq("kind", "medium");
     for (const c of mediumCats || []) bucketIdByName[c.name] = c.id;
     console.log(`Loaded ${Object.keys(bucketIdByName).length} medium category IDs.`);
+    if (Object.keys(bucketIdByName).length === 0) {
+      console.warn(
+        "WARNING: bucket map exists but no kind='medium' categories in the DB. " +
+        "Run `npm run medium:apply -- <csv>` first or medium tags will be skipped."
+      );
+    }
   }
 
   // ── Step 2: Upsert artworks ────────────────────────────────────────────
@@ -242,7 +252,9 @@ async function main() {
         }
       }
 
-      // Insert records without inventory numbers (can't upsert without unique key)
+      // Insert records without inventory numbers (can't upsert without unique key).
+      // Note: medium-category attachment is intentionally skipped here — without a
+      // stable unique key we can't reliably re-fetch their ids after insert.
       if (withoutInventory.length > 0) {
         const { error } = await supabase
           .from("artworks")

--- a/scripts/lib/medium-buckets.ts
+++ b/scripts/lib/medium-buckets.ts
@@ -1,0 +1,27 @@
+/**
+ * Pure helpers for the medium normalization workflow.
+ * - mediumToBuckets: lookup an artwork's medium string in the
+ *   normalized bucket map. Returns the array of bucket names the
+ *   artwork should be tagged with, or [] if the medium is unknown
+ *   or empty.
+ * - parseProposedBuckets: parse the semicolon-joined cell from the
+ *   Phase 1 CSV (e.g. "Color Stix; Ink; Colored pencil") into an
+ *   array of bucket names.
+ */
+
+export type BucketMap = Record<string, string[]>;
+
+export function mediumToBuckets(map: BucketMap, medium: string | null): string[] {
+  if (medium === null) return [];
+  const trimmed = medium.trim();
+  if (!trimmed) return [];
+  return map[trimmed] || [];
+}
+
+export function parseProposedBuckets(cell: string): string[] {
+  if (!cell) return [];
+  return cell
+    .split(";")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}

--- a/scripts/normalize-mediums-apply.ts
+++ b/scripts/normalize-mediums-apply.ts
@@ -1,0 +1,239 @@
+#!/usr/bin/env npx tsx
+/**
+ * normalize-mediums-apply.ts (Phase 2)
+ *
+ * Reads the (possibly-edited) CSV from Phase 1 and applies the
+ * normalized bucket assignments to the DB:
+ *   - Upserts kind='medium' rows in the categories table
+ *   - For each artwork, diffs its medium-category attachments against
+ *     what the CSV says it should have (adding missing, removing extra)
+ *   - Persists scripts/data/medium-buckets.json for the importers
+ *   - Writes per-row log to tmp/medium-apply-log_<ts>.csv
+ *
+ * Run: npx tsx --env-file=.env.local scripts/normalize-mediums-apply.ts <path-to-csv>
+ */
+
+import fs from "fs";
+import path from "path";
+import readline from "readline";
+import { parse } from "csv-parse/sync";
+import { createClient } from "@supabase/supabase-js";
+import { slugify } from "../src/lib/utils";
+import { parseProposedBuckets, BucketMap } from "./lib/medium-buckets";
+
+const TMP_DIR = path.join(__dirname, "..", "tmp");
+const DATA_DIR = path.join(__dirname, "data");
+const LOOKUP_FILE = path.join(DATA_DIR, "medium-buckets.json");
+const TIMESTAMP = new Date().toISOString().replace(/[:.]/g, "-");
+const LOG_FILE = path.join(TMP_DIR, `medium-apply-log_${TIMESTAMP}.csv`);
+
+const SUPABASE_URL =
+  process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error("Error: set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY");
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+interface CsvRow {
+  medium: string;
+  count: string;
+  proposed_buckets: string;
+  notes: string;
+}
+
+function csvField(v: string | null | undefined): string {
+  if (v === null || v === undefined) return "";
+  const s = String(v);
+  if (/[",\n\r]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+  return s;
+}
+
+function writeCsv(filePath: string, columns: string[], rows: Record<string, string>[]): void {
+  const header = columns.join(",");
+  const body = rows.map((r) => columns.map((c) => csvField(r[c])).join(",")).join("\n");
+  fs.writeFileSync(filePath, header + "\n" + body + "\n");
+}
+
+async function confirm(prompt: string): Promise<boolean> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(prompt + " [y/N] ", (answer) => {
+      rl.close();
+      resolve(answer.trim().toLowerCase() === "y");
+    });
+  });
+}
+
+async function main() {
+  const csvPath = process.argv[2];
+  if (!csvPath) {
+    console.error("Usage: npx tsx scripts/normalize-mediums-apply.ts <path-to-csv>");
+    process.exit(1);
+  }
+  if (!fs.existsSync(csvPath)) {
+    console.error(`CSV not found: ${csvPath}`);
+    process.exit(1);
+  }
+
+  // 1. Parse CSV → bucket map
+  const raw = fs.readFileSync(csvPath, "utf-8");
+  const rows: CsvRow[] = parse(raw, {
+    columns: true,
+    skip_empty_lines: true,
+    relax_quotes: true,
+    relax_column_count: true,
+  });
+  console.log(`Parsed ${rows.length} medium-row entries from ${path.basename(csvPath)}`);
+
+  const map: BucketMap = {};
+  const uniqueBuckets = new Set<string>();
+  for (const row of rows) {
+    const medium = (row.medium || "").trim();
+    if (!medium) continue;
+    const buckets = parseProposedBuckets(row.proposed_buckets);
+    map[medium] = buckets;
+    for (const b of buckets) uniqueBuckets.add(b);
+  }
+  const bucketList = [...uniqueBuckets].sort();
+  console.log(`\nDetected ${bucketList.length} unique buckets:`);
+  bucketList.forEach((b) => console.log(`  ${b}`));
+
+  const ok = await confirm("\nProceed to upsert these buckets and apply attachments?");
+  if (!ok) { console.log("Aborted."); process.exit(0); }
+
+  // 2. Upsert bucket categories
+  console.log("\nUpserting kind='medium' categories...");
+  const bucketRows = bucketList.map((name) => ({
+    name,
+    slug: slugify(name),
+    kind: "medium" as const,
+    ai_suggested: false,
+  }));
+  const { data: upserted, error: upsertErr } = await supabase
+    .from("categories")
+    .upsert(bucketRows, { onConflict: "slug", ignoreDuplicates: false })
+    .select("id, name, slug, kind");
+  if (upsertErr) { console.error("Upsert failed:", upsertErr); process.exit(1); }
+  const bucketIdByName: Record<string, string> = {};
+  for (const c of upserted || []) bucketIdByName[c.name] = c.id;
+  console.log(`  ${(upserted || []).length} bucket categories ensured`);
+
+  // 3. Page through artworks; diff and apply
+  console.log("\nFetching all artworks with non-null medium...");
+  const allArt: { id: string; medium: string }[] = [];
+  let off = 0;
+  while (true) {
+    const { data, error } = await supabase
+      .from("artworks")
+      .select("id, medium")
+      .not("medium", "is", null)
+      .range(off, off + 999);
+    if (error) { console.error(error); process.exit(1); }
+    if (!data || data.length === 0) break;
+    allArt.push(...(data as any));
+    if (data.length < 1000) break;
+    off += 1000;
+  }
+  console.log(`Found ${allArt.length} artworks with medium`);
+
+  // Pre-fetch existing medium-category attachments per artwork (one query)
+  const { data: existingAcs, error: acErr } = await supabase
+    .from("artwork_categories")
+    .select("artwork_id, category:categories!inner(id, kind)")
+    .eq("category.kind", "medium");
+  if (acErr) { console.error(acErr); process.exit(1); }
+  const existingByArtwork = new Map<string, Set<string>>();
+  for (const ac of (existingAcs || []) as any[]) {
+    if (!existingByArtwork.has(ac.artwork_id)) existingByArtwork.set(ac.artwork_id, new Set());
+    existingByArtwork.get(ac.artwork_id)!.add(ac.category.id);
+  }
+
+  // Apply diffs
+  const log: Record<string, string>[] = [];
+  let updated = 0;
+  let unchanged = 0;
+  let errors = 0;
+
+  for (const art of allArt) {
+    const medium = (art.medium || "").trim();
+    const desiredBuckets = map[medium] || [];
+    const desiredIds = new Set(
+      desiredBuckets.map((b) => bucketIdByName[b]).filter((id): id is string => !!id)
+    );
+    const currentIds = existingByArtwork.get(art.id) || new Set<string>();
+
+    const toAdd = [...desiredIds].filter((id) => !currentIds.has(id));
+    const toRemove = [...currentIds].filter((id) => !desiredIds.has(id));
+
+    if (toAdd.length === 0 && toRemove.length === 0) {
+      unchanged++;
+      continue;
+    }
+
+    let rowError = "";
+    if (toRemove.length > 0) {
+      const { error } = await supabase
+        .from("artwork_categories")
+        .delete()
+        .eq("artwork_id", art.id)
+        .in("category_id", toRemove);
+      if (error) rowError = `delete: ${error.message}`;
+    }
+    if (!rowError && toAdd.length > 0) {
+      const { error } = await supabase
+        .from("artwork_categories")
+        .upsert(
+          toAdd.map((category_id) => ({ artwork_id: art.id, category_id })),
+          { onConflict: "artwork_id,category_id", ignoreDuplicates: true }
+        );
+      if (error) rowError = `insert: ${error.message}`;
+    }
+
+    if (rowError) {
+      errors++;
+      log.push({
+        artwork_id: art.id,
+        medium,
+        applied_buckets: desiredBuckets.join("; "),
+        status: `error: ${rowError}`,
+      });
+    } else {
+      updated++;
+      log.push({
+        artwork_id: art.id,
+        medium,
+        applied_buckets: desiredBuckets.join("; "),
+        status: "ok",
+      });
+    }
+  }
+
+  // 4. Persist lookup map
+  if (!fs.existsSync(DATA_DIR)) fs.mkdirSync(DATA_DIR, { recursive: true });
+  const lookup = {
+    version: TIMESTAMP,
+    buckets: bucketList,
+    map,
+  };
+  fs.writeFileSync(LOOKUP_FILE, JSON.stringify(lookup, null, 2) + "\n");
+
+  // 5. Write log
+  if (!fs.existsSync(TMP_DIR)) fs.mkdirSync(TMP_DIR, { recursive: true });
+  writeCsv(LOG_FILE, ["artwork_id", "medium", "applied_buckets", "status"], log);
+
+  // 6. Summary
+  console.log("\n=== Summary ===");
+  console.log(`Artworks scanned:  ${allArt.length}`);
+  console.log(`Tag updates:       ${updated}`);
+  console.log(`Unchanged:         ${unchanged}`);
+  console.log(`Errors:            ${errors}`);
+  console.log(`\nLookup map: ${LOOKUP_FILE}`);
+  console.log(`Log:        ${LOG_FILE}`);
+}
+
+main().catch((err) => { console.error("Fatal:", err); process.exit(1); });

--- a/scripts/normalize-mediums-apply.ts
+++ b/scripts/normalize-mediums-apply.ts
@@ -123,6 +123,16 @@ async function main() {
   for (const c of upserted || []) bucketIdByName[c.name] = c.id;
   console.log(`  ${(upserted || []).length} bucket categories ensured`);
 
+  // Surface any bucket name that didn't land in the lookup (e.g. slug collision
+  // collapsed two names into one row, leaving the second name unresolved).
+  const missingBucketNames = bucketList.filter((name) => !bucketIdByName[name]);
+  if (missingBucketNames.length > 0) {
+    console.error(`\nERROR: ${missingBucketNames.length} bucket name(s) did not resolve to a category id:`);
+    missingBucketNames.forEach((n) => console.error(`  ${n} (slug: ${slugify(n)})`));
+    console.error("This usually means two bucket names slugify to the same value. Rename one in the CSV.");
+    process.exit(1);
+  }
+
   // 3. Page through artworks; diff and apply
   console.log("\nFetching all artworks with non-null medium...");
   const allArt: { id: string; medium: string }[] = [];
@@ -141,14 +151,25 @@ async function main() {
   }
   console.log(`Found ${allArt.length} artworks with medium`);
 
-  // Pre-fetch existing medium-category attachments per artwork (one query)
-  const { data: existingAcs, error: acErr } = await supabase
-    .from("artwork_categories")
-    .select("artwork_id, category:categories!inner(id, kind)")
-    .eq("category.kind", "medium");
-  if (acErr) { console.error(acErr); process.exit(1); }
+  // Pre-fetch existing medium-category attachments per artwork. Paginate
+  // through results — PostgREST caps responses at 1000 rows by default,
+  // and re-runs of this script can easily exceed that.
+  const existingAcs: { artwork_id: string; category: { id: string; kind: string } }[] = [];
+  let acOff = 0;
+  while (true) {
+    const { data, error } = await supabase
+      .from("artwork_categories")
+      .select("artwork_id, category:categories!inner(id, kind)")
+      .eq("category.kind", "medium")
+      .range(acOff, acOff + 999);
+    if (error) { console.error(error); process.exit(1); }
+    if (!data || data.length === 0) break;
+    existingAcs.push(...(data as any));
+    if (data.length < 1000) break;
+    acOff += 1000;
+  }
   const existingByArtwork = new Map<string, Set<string>>();
-  for (const ac of (existingAcs || []) as any[]) {
+  for (const ac of existingAcs) {
     if (!existingByArtwork.has(ac.artwork_id)) existingByArtwork.set(ac.artwork_id, new Set());
     existingByArtwork.get(ac.artwork_id)!.add(ac.category.id);
   }
@@ -196,6 +217,7 @@ async function main() {
 
     if (rowError) {
       errors++;
+      console.error(`  ERR ${art.id}: ${rowError}`);
       log.push({
         artwork_id: art.id,
         medium,

--- a/scripts/normalize-mediums-propose.ts
+++ b/scripts/normalize-mediums-propose.ts
@@ -1,0 +1,168 @@
+#!/usr/bin/env npx tsx
+/**
+ * normalize-mediums-propose.ts (Phase 1)
+ *
+ * Fetches every distinct medium string in the catalog, asks Claude to
+ * propose a small (~12-18) bucket vocabulary of pure materials and a
+ * mapping from each input string to one or more buckets. Writes
+ * `tmp/medium-buckets_<ISO>.csv` for human review in Sheets.
+ *
+ * Run: npx tsx --env-file=.env.local scripts/normalize-mediums-propose.ts
+ */
+
+import fs from "fs";
+import path from "path";
+import { createClient } from "@supabase/supabase-js";
+import Anthropic from "@anthropic-ai/sdk";
+
+const TMP_DIR = path.join(__dirname, "..", "tmp");
+const TIMESTAMP = new Date().toISOString().replace(/[:.]/g, "-");
+const OUTPUT_FILE = path.join(TMP_DIR, `medium-buckets_${TIMESTAMP}.csv`);
+
+const SUPABASE_URL =
+  process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY;
+if (!SUPABASE_URL || !SUPABASE_KEY || !ANTHROPIC_KEY) {
+  console.error("Error: set NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, ANTHROPIC_API_KEY");
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+const anthropic = new Anthropic({ apiKey: ANTHROPIC_KEY });
+
+const MODEL = "claude-sonnet-4-6";
+
+const SYSTEM_PROMPT = `You are an expert museum cataloger normalizing artwork medium descriptions into a small set of material-only buckets, following CDWA (Categories for the Description of Works of Art) conventions.
+
+Goals:
+- Propose ~12-18 buckets covering the materials present. Materials only — pigments, drawing tools, sculpture materials, fiber materials. NOT support (paper, canvas, etc.) and NOT technique (drawing, painting). Examples of bucket-worthy material names: Ink, Acrylic, Watercolor, Oil paint, Pastel, Oil pastel, Color Stix, Colored pencil, Pencil/Graphite, Marker, Pen, Crayon, Charcoal, Ceramic, Wood, Fiber/Yarn.
+- For each input medium string, return an array of bucket names listing every material present. CDWA prefers enumeration: a 3-material piece gets 3 tags. Common case is 1 tag.
+- Use the bucket name "Other" only when you genuinely cannot enumerate (e.g. "Mixed media on paper" with no specifics).
+- Combine related materials when sensible (e.g. "Pen on paper" + "Ink on paper" both → "Ink"; "Oil pastel on paper" + "Pastel on paper" — your call whether to keep separate).
+- Bucket names should be short and human-readable for a dropdown filter.
+
+Respond ONLY with valid JSON in this shape (no markdown, no fences):
+{
+  "buckets": ["Ink", "Acrylic", ...],
+  "mapping": {
+    "Ink on paper": ["Ink"],
+    "Color Stix, ink, and colored pencil on paper": ["Color Stix", "Ink", "Colored pencil"],
+    ...
+  }
+}
+
+Every input medium string must appear as a key in "mapping". Every bucket name in "mapping" values must appear in "buckets".`;
+
+interface MediumRow { medium: string; count: number; }
+
+function csvField(v: string | null | undefined): string {
+  if (v === null || v === undefined) return "";
+  const s = String(v);
+  if (/[",\n\r]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+  return s;
+}
+
+function writeCsv(filePath: string, columns: string[], rows: Record<string, string>[]): void {
+  const header = columns.join(",");
+  const body = rows.map((r) => columns.map((c) => csvField(r[c])).join(",")).join("\n");
+  fs.writeFileSync(filePath, header + "\n" + body + "\n");
+}
+
+async function main() {
+  // 1. Fetch all distinct mediums + counts
+  console.log("Fetching mediums from DB...");
+  const all: { medium: string | null }[] = [];
+  let off = 0;
+  while (true) {
+    const { data, error } = await supabase
+      .from("artworks")
+      .select("medium")
+      .not("medium", "is", null)
+      .range(off, off + 999);
+    if (error) { console.error(error); process.exit(1); }
+    if (!data || data.length === 0) break;
+    all.push(...data);
+    if (data.length < 1000) break;
+    off += 1000;
+  }
+
+  const counts = new Map<string, number>();
+  for (const r of all) {
+    const m = (r.medium || "").trim();
+    if (!m) continue;
+    counts.set(m, (counts.get(m) || 0) + 1);
+  }
+  const distinct: MediumRow[] = [...counts.entries()]
+    .map(([medium, count]) => ({ medium, count }))
+    .sort((a, b) => b.count - a.count);
+
+  console.log(`Found ${distinct.length} distinct medium strings across ${all.length} artworks`);
+
+  // 2. Send to Claude for normalization
+  console.log("Calling Claude for bucket proposal + mapping (this may take 10-30s)...");
+  const userMessage = `Here are the distinct medium strings from the catalog (with row counts in parentheses):\n\n${distinct
+    .map((d) => `${d.medium} (${d.count})`)
+    .join("\n")}`;
+
+  const response = await anthropic.messages.create({
+    model: MODEL,
+    max_tokens: 8192,
+    system: SYSTEM_PROMPT,
+    messages: [{ role: "user", content: userMessage }],
+  });
+
+  const text = response.content[0].type === "text" ? response.content[0].text : "";
+  const cleaned = text.replace(/```json\n?/g, "").replace(/```\n?/g, "").trim();
+
+  let parsed: { buckets: string[]; mapping: Record<string, string[]> };
+  try {
+    parsed = JSON.parse(cleaned);
+  } catch {
+    console.error("Claude returned non-JSON response. Raw text:");
+    console.error(text);
+    process.exit(1);
+  }
+
+  if (!parsed.buckets || !parsed.mapping) {
+    console.error("Claude response missing 'buckets' or 'mapping'. Raw:");
+    console.error(text);
+    process.exit(1);
+  }
+
+  // 3. Write CSV
+  if (!fs.existsSync(TMP_DIR)) fs.mkdirSync(TMP_DIR, { recursive: true });
+  const rows = distinct.map((d) => {
+    const buckets = parsed.mapping[d.medium] || [];
+    const note = buckets.length === 0 ? "WARNING: not in Claude mapping" : "";
+    return {
+      medium: d.medium,
+      count: String(d.count),
+      proposed_buckets: buckets.join("; "),
+      notes: note,
+    };
+  });
+  writeCsv(OUTPUT_FILE, ["medium", "count", "proposed_buckets", "notes"], rows);
+
+  // 4. Summary
+  const bucketCounts = new Map<string, number>();
+  for (const d of distinct) {
+    const buckets = parsed.mapping[d.medium] || [];
+    for (const b of buckets) bucketCounts.set(b, (bucketCounts.get(b) || 0) + d.count);
+  }
+  const multiBucketRows = distinct.filter((d) => (parsed.mapping[d.medium] || []).length > 1).length;
+
+  console.log("\n=== Proposed Buckets ===");
+  parsed.buckets.forEach((b) => {
+    const c = bucketCounts.get(b) || 0;
+    console.log(`  ${b.padEnd(24)} ${c} artworks`);
+  });
+  console.log(`\nMulti-bucket strings (multiple materials): ${multiBucketRows}`);
+  console.log(`\nCSV: ${OUTPUT_FILE}`);
+  console.log("\nNext: open the CSV in Sheets, edit `proposed_buckets` if needed, save, then:");
+  console.log(`  npm run medium:apply -- ${OUTPUT_FILE}`);
+}
+
+main().catch((err) => { console.error("Fatal:", err); process.exit(1); });

--- a/scripts/normalize-mediums-propose.ts
+++ b/scripts/normalize-mediums-propose.ts
@@ -114,6 +114,10 @@ async function main() {
     messages: [{ role: "user", content: userMessage }],
   });
 
+  if (response.stop_reason === "max_tokens") {
+    console.error("Claude hit max_tokens limit — response truncated. Increase max_tokens or reduce input.");
+    process.exit(1);
+  }
   const text = response.content[0].type === "text" ? response.content[0].text : "";
   const cleaned = text.replace(/```json\n?/g, "").replace(/```\n?/g, "").trim();
 

--- a/scripts/test-filter-state.ts
+++ b/scripts/test-filter-state.ts
@@ -8,6 +8,7 @@ test("parseSearchParams: empty input yields empty state", () => {
     q: "",
     themes: [],
     formats: [],
+    mediums: [],
     decades: [],
     artist: null,
     sort: null,
@@ -55,6 +56,7 @@ test("toQueryString: round-trips a populated state", () => {
     q: "lightbulbs",
     themes: ["animals", "abstract"],
     formats: ["drawings"],
+    mediums: [],
     decades: ["1990s"],
     artist: "dan-miller",
     sort: "newest",
@@ -67,21 +69,21 @@ test("toQueryString: round-trips a populated state", () => {
 
 test("toQueryString: omits empty fields", () => {
   const state: FilterState = {
-    q: "", themes: [], formats: [], decades: [], artist: null, sort: null, page: 1,
+    q: "", themes: [], formats: [], mediums: [], decades: [], artist: null, sort: null, page: 1,
   };
   assert.equal(toQueryString(state), "");
 });
 
 test("toQueryString: omits page=1 (default)", () => {
   const state: FilterState = {
-    q: "x", themes: [], formats: [], decades: [], artist: null, sort: null, page: 1,
+    q: "x", themes: [], formats: [], mediums: [], decades: [], artist: null, sort: null, page: 1,
   };
   assert.equal(toQueryString(state), "q=x");
 });
 
 test("toQueryString: includes page when > 1", () => {
   const state: FilterState = {
-    q: "", themes: [], formats: [], decades: [], artist: null, sort: null, page: 3,
+    q: "", themes: [], formats: [], mediums: [], decades: [], artist: null, sort: null, page: 3,
   };
   assert.equal(toQueryString(state), "page=3");
 });

--- a/scripts/test-filter-state.ts
+++ b/scripts/test-filter-state.ts
@@ -85,3 +85,30 @@ test("toQueryString: includes page when > 1", () => {
   };
   assert.equal(toQueryString(state), "page=3");
 });
+
+test("parseSearchParams: parses mediums from medium= param", () => {
+  const s = parseSearchParams({ medium: "ink,acrylic" });
+  assert.deepEqual(s.mediums, ["ink", "acrylic"]);
+});
+
+test("parseSearchParams: empty input has empty mediums array", () => {
+  const s = parseSearchParams({});
+  assert.deepEqual(s.mediums, []);
+});
+
+test("toQueryString: serializes mediums to medium= param", () => {
+  const state = {
+    q: "", themes: [], formats: [], decades: [], artist: null, sort: null, page: 1,
+    mediums: ["ink", "acrylic"],
+  };
+  assert.equal(toQueryString(state), "medium=ink%2Cacrylic");
+});
+
+test("toQueryString round-trip preserves mediums", () => {
+  const state = {
+    q: "x", themes: ["animals"], formats: [], decades: [], artist: null, sort: null, page: 1,
+    mediums: ["ink", "acrylic"],
+  };
+  const re = parseSearchParams(Object.fromEntries(new URLSearchParams(toQueryString(state))));
+  assert.deepEqual(re.mediums, state.mediums);
+});

--- a/scripts/test-medium-buckets.ts
+++ b/scripts/test-medium-buckets.ts
@@ -1,0 +1,30 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { mediumToBuckets, parseProposedBuckets } from "./lib/medium-buckets";
+
+test("mediumToBuckets: returns buckets from the map", () => {
+  const map = { "Ink on paper": ["Ink"], "Acrylic and ink on paper": ["Acrylic", "Ink"] };
+  assert.deepEqual(mediumToBuckets(map, "Ink on paper"), ["Ink"]);
+  assert.deepEqual(mediumToBuckets(map, "Acrylic and ink on paper"), ["Acrylic", "Ink"]);
+});
+
+test("mediumToBuckets: returns empty for unknown medium", () => {
+  assert.deepEqual(mediumToBuckets({}, "Crayon on bark"), []);
+});
+
+test("mediumToBuckets: trims whitespace before lookup", () => {
+  const map = { "Ink on paper": ["Ink"] };
+  assert.deepEqual(mediumToBuckets(map, "  Ink on paper  "), ["Ink"]);
+});
+
+test("mediumToBuckets: returns empty for null/empty input", () => {
+  assert.deepEqual(mediumToBuckets({}, ""), []);
+  assert.deepEqual(mediumToBuckets({}, null), []);
+});
+
+test("parseProposedBuckets: splits semicolon-joined cell, trims, drops empties", () => {
+  assert.deepEqual(parseProposedBuckets("Ink"), ["Ink"]);
+  assert.deepEqual(parseProposedBuckets("Color Stix; Ink; Colored pencil"), ["Color Stix", "Ink", "Colored pencil"]);
+  assert.deepEqual(parseProposedBuckets("  Ink  ;;  Pastel  "), ["Ink", "Pastel"]);
+  assert.deepEqual(parseProposedBuckets(""), []);
+});

--- a/src/app/ephemera/page.tsx
+++ b/src/app/ephemera/page.tsx
@@ -50,6 +50,7 @@ export default async function EphemeraPage({ searchParams }: EphemeraPageProps) 
         cohort="ephemera"
         themeOptions={[]}
         formatOptions={[]}
+        mediumOptions={[]}
         decadeOptions={[]}
         artistOptions={artistOptions}
       />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,11 +24,12 @@ export default async function HomePage({ searchParams }: HomePageProps) {
   const state = parseSearchParams(raw);
   const supabase = createServerSupabaseClient();
 
-  const [{ artworks, total }, facets, formatCats, themeCats, allArtists] = await Promise.all([
+  const [{ artworks, total }, facets, formatCats, themeCats, mediumCats, allArtists] = await Promise.all([
     queryArtworks(supabase, state, "artwork"),
     getFacetCounts(supabase, state, "artwork"),
     supabase.from("categories").select("name, slug").eq("kind", "format").order("name"),
     supabase.from("categories").select("name, slug").eq("kind", "theme").order("name"),
+    supabase.from("categories").select("name, slug").eq("kind", "medium").order("name"),
     supabase.from("artists").select("slug, first_name, last_name").order("last_name").order("first_name"),
   ]);
 
@@ -41,6 +42,11 @@ export default async function HomePage({ searchParams }: HomePageProps) {
     value: c.slug,
     label: c.name,
     count: facets.formats[c.slug] || 0,
+  }));
+  const mediumOptions = (mediumCats.data || []).map((c) => ({
+    value: c.slug,
+    label: c.name,
+    count: facets.mediums[c.slug] || 0,
   }));
   const decadeOptions = Object.keys(facets.decades).sort().map((d) => ({
     value: d,
@@ -67,6 +73,7 @@ export default async function HomePage({ searchParams }: HomePageProps) {
         cohort="artwork"
         themeOptions={themeOptions}
         formatOptions={formatOptions}
+        mediumOptions={mediumOptions}
         decadeOptions={decadeOptions}
         artistOptions={artistOptions}
       />
@@ -89,7 +96,7 @@ export default async function HomePage({ searchParams }: HomePageProps) {
               currentPage={state.page}
               totalPages={totalPages}
               baseUrl="/"
-              preserveParams={["q", "theme", "format", "decade", "artist", "sort"]}
+              preserveParams={["q", "theme", "format", "medium", "decade", "artist", "sort"]}
             />
           )}
         </>

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -12,6 +12,7 @@ interface FilterBarProps {
   cohort: "artwork" | "ephemera";
   themeOptions: { value: string; label: string; count: number }[];
   formatOptions: { value: string; label: string; count: number }[];
+  mediumOptions: { value: string; label: string; count: number }[];
   decadeOptions: { value: string; label: string; count: number }[];
   artistOptions: { slug: string; name: string; available: boolean }[];
 }
@@ -25,6 +26,7 @@ export default function FilterBar({
   cohort,
   themeOptions,
   formatOptions,
+  mediumOptions,
   decadeOptions,
   artistOptions,
 }: FilterBarProps) {
@@ -56,6 +58,12 @@ export default function FilterBar({
     chips.push({
       label: formatOptions.find((o) => o.value === f)?.label || f,
       onRemove: () => navigate({ ...state, formats: state.formats.filter((x) => x !== f) }),
+    });
+  }
+  for (const m of state.mediums) {
+    chips.push({
+      label: mediumOptions.find((o) => o.value === m)?.label || m,
+      onRemove: () => navigate({ ...state, mediums: state.mediums.filter((x) => x !== m) }),
     });
   }
   for (const d of state.decades) {
@@ -106,6 +114,14 @@ export default function FilterBar({
             onChange={(formats) => navigate({ ...state, formats })}
           />
         )}
+        {isCollection && (
+          <MultiSelectDropdown
+            label="Medium"
+            options={mediumOptions}
+            selected={state.mediums}
+            onChange={(mediums) => navigate({ ...state, mediums })}
+          />
+        )}
         <ArtistTypeaheadDropdown
           artists={artistOptions}
           selected={state.artist}
@@ -131,7 +147,7 @@ export default function FilterBar({
 
       <ActiveFilterChips
         chips={chips}
-        onClearAll={() => navigate({ ...state, themes: [], formats: [], decades: [], artist: null })}
+        onClearAll={() => navigate({ ...state, themes: [], formats: [], mediums: [], decades: [], artist: null })}
       />
     </div>
   );

--- a/src/lib/collection-query.ts
+++ b/src/lib/collection-query.ts
@@ -135,6 +135,8 @@ async function categoryFilteredIds(
   if (mediums.length > 0) sets.push(mediumIds);
   if (sets.length === 0) return []; // shouldn't be called in this case
   if (sets.length === 1) return [...sets[0]];
+  // Iterate the smallest set; cost is O(|smallest| * (sets.length - 1)) lookups.
+  sets.sort((a, b) => a.size - b.size);
   return [...sets[0]].filter((id) => sets.slice(1).every((s) => s.has(id)));
 }
 

--- a/src/lib/collection-query.ts
+++ b/src/lib/collection-query.ts
@@ -337,13 +337,26 @@ async function candidateIdsExcept(
 
   const selectStr = buildSelect(isOneDim, "id");
 
+  // Multi-dim path: a stripped facet (e.g. formats∩mediums while computing
+  // the themes facet) can produce 700+ intersected IDs. Passing those through
+  // `.in("id", ids)` blows PostgREST's URL length limit, so for multi-dim we
+  // fetch candidates matching the scalar filters and intersect client-side
+  // — the same pattern as countCategoriesForIds / artistsForIds below.
+  if (isMultiDim) {
+    const intersectedSet = new Set(intersectedIds!);
+    const rows = await fetchAllRows<{ id: string }>(() => {
+      let q = supabase.from("artworks").select("id");
+      q = applyScalarFilters(q, state, cohort, artistId, except);
+      return q;
+    });
+    return new Set(rows.filter((r: any) => intersectedSet.has(r.id)).map((r: any) => r.id));
+  }
+
   const rows = await fetchAllRows<{ id: string }>(() => {
     let q = supabase.from("artworks").select(selectStr);
     q = applyScalarFilters(q, state, cohort, artistId, except);
     if (isOneDim) {
       q = applySingleDimEmbeddedFilter(q, themes, formats, mediums);
-    } else if (isMultiDim) {
-      q = q.in("id", intersectedIds!);
     }
     return q;
   });

--- a/src/lib/collection-query.ts
+++ b/src/lib/collection-query.ts
@@ -5,13 +5,13 @@
  * Filter strategy by dimension:
  *   - Cohort, on_website, search (FTS), decade, artist: applied inline
  *     on the main query — small, indexed, fast.
- *   - Theme XOR Format (one category dim active): embedded INNER join +
- *     `.eq()` / `.in()` on the embedded path. PostgREST INNER JOIN
- *     filters the parent rows correctly.
- *   - Theme AND Format (both active): pre-resolve the intersected
- *     artwork-id set via `categoryFilteredIds`, then `.in("id", ids)`.
- *     The intersection is bounded by min(theme-pop, format-pop), which
- *     is small enough to fit comfortably in a PostgREST URL.
+ *   - Exactly one category dim active (theme XOR format XOR medium):
+ *     embedded INNER join + `.eq()` / `.in()` on the embedded path.
+ *     PostgREST INNER JOIN filters the parent rows correctly.
+ *   - ≥2 category dims active: pre-resolve the intersected artwork-id
+ *     set via `categoryFilteredIds`, then `.in("id", ids)`. The
+ *     intersection is bounded by min(active-dim populations), which is
+ *     small enough to fit comfortably in a PostgREST URL.
  *   - We avoid `.in("id", hugeSet)` patterns (e.g., 1,400-id Drawings
  *     filter), which exceed PostgREST's URI length limit.
  *
@@ -45,6 +45,7 @@ export interface ArtworkResult {
 export interface FacetCounts {
   themes: Record<string, number>;
   formats: Record<string, number>;
+  mediums: Record<string, number>;
   decades: Record<string, number>;
   availableArtistSlugs: Set<string>;
 }
@@ -52,7 +53,7 @@ export interface FacetCounts {
 const PAGE_SIZE = 24;
 const FETCH_PAGE = 1000;
 
-type ExceptDim = "themes" | "formats" | "decades" | "artist" | "q" | "none";
+type ExceptDim = "themes" | "formats" | "mediums" | "decades" | "artist" | "q" | "none";
 
 /**
  * Page through all matching rows. PostgREST has a default `max-rows`
@@ -100,16 +101,16 @@ async function resolveArtistId(
 }
 
 /**
- * Resolve themes + formats to the intersected set of artwork IDs that
- * satisfy both. Used only when BOTH dimensions are active. Returns null
- * sentinel only when caller misuses (neither dim active).
+ * Resolve themes + formats + mediums to the intersected set of artwork IDs
+ * that satisfy all active dimensions. Used only when ≥2 dimensions are active.
  */
 async function categoryFilteredIds(
   supabase: SupabaseClient,
   themes: string[],
-  formats: string[]
+  formats: string[],
+  mediums: string[]
 ): Promise<string[]> {
-  async function idsFor(slugs: string[], kind: "theme" | "format"): Promise<Set<string>> {
+  async function idsFor(slugs: string[], kind: "theme" | "format" | "medium"): Promise<Set<string>> {
     if (slugs.length === 0) return new Set();
     const rows = await fetchAllRows<{ artwork_id: string }>(() =>
       supabase
@@ -121,12 +122,20 @@ async function categoryFilteredIds(
     return new Set(rows.map((r: any) => r.artwork_id));
   }
 
-  const [themeIds, formatIds] = await Promise.all([
+  const [themeIds, formatIds, mediumIds] = await Promise.all([
     idsFor(themes, "theme"),
     idsFor(formats, "format"),
+    idsFor(mediums, "medium"),
   ]);
 
-  return [...themeIds].filter((id) => formatIds.has(id));
+  // Intersect only the active sets; an inactive dim doesn't constrain.
+  const sets: Set<string>[] = [];
+  if (themes.length > 0) sets.push(themeIds);
+  if (formats.length > 0) sets.push(formatIds);
+  if (mediums.length > 0) sets.push(mediumIds);
+  if (sets.length === 0) return []; // shouldn't be called in this case
+  if (sets.length === 1) return [...sets[0]];
+  return [...sets[0]].filter((id) => sets.slice(1).every((s) => s.has(id)));
 }
 
 // ─── Scalar + category filter application (sync; no thenable trap) ──────
@@ -160,7 +169,12 @@ function applyScalarFilters(
   return q;
 }
 
-function applySingleDimEmbeddedFilter(q: any, themes: string[], formats: string[]): any {
+function applySingleDimEmbeddedFilter(
+  q: any,
+  themes: string[],
+  formats: string[],
+  mediums: string[]
+): any {
   if (themes.length > 0) {
     return q
       .eq("artwork_categories.category.kind", "theme")
@@ -170,6 +184,11 @@ function applySingleDimEmbeddedFilter(q: any, themes: string[], formats: string[
     return q
       .eq("artwork_categories.category.kind", "format")
       .in("artwork_categories.category.slug", formats);
+  }
+  if (mediums.length > 0) {
+    return q
+      .eq("artwork_categories.category.kind", "medium")
+      .in("artwork_categories.category.slug", mediums);
   }
   return q;
 }
@@ -232,12 +251,14 @@ export async function queryArtworks(
   const artistId = await resolveArtistId(supabase, state.artist);
   const themes = state.themes;
   const formats = state.formats;
-  const isOneDim = (themes.length > 0) !== (formats.length > 0);
-  const isTwoDim = themes.length > 0 && formats.length > 0;
+  const mediums = state.mediums;
+  const activeCatDims = [themes.length > 0, formats.length > 0, mediums.length > 0].filter(Boolean).length;
+  const isOneDim = activeCatDims === 1;
+  const isMultiDim = activeCatDims >= 2;
 
   let intersectedIds: string[] | null = null;
-  if (isTwoDim) {
-    intersectedIds = await categoryFilteredIds(supabase, themes, formats);
+  if (isMultiDim) {
+    intersectedIds = await categoryFilteredIds(supabase, themes, formats, mediums);
     if (intersectedIds.length === 0) return { artworks: [], total: 0 };
   }
 
@@ -246,8 +267,8 @@ export async function queryArtworks(
   q = applyScalarFilters(q, state, cohort, artistId, "none");
 
   if (isOneDim) {
-    q = applySingleDimEmbeddedFilter(q, themes, formats);
-  } else if (isTwoDim) {
+    q = applySingleDimEmbeddedFilter(q, themes, formats, mediums);
+  } else if (isMultiDim) {
     q = q.in("id", intersectedIds!);
   }
 
@@ -273,21 +294,23 @@ export async function getFacetCounts(
 ): Promise<FacetCounts> {
   const artistId = await resolveArtistId(supabase, state.artist);
 
-  const [themeIds, formatIds, decadeIds, artistIds] = await Promise.all([
+  const [themeIds, formatIds, mediumIds, decadeIds, artistIds] = await Promise.all([
     candidateIdsExcept(supabase, state, cohort, artistId, "themes"),
     candidateIdsExcept(supabase, state, cohort, artistId, "formats"),
+    candidateIdsExcept(supabase, state, cohort, artistId, "mediums"),
     candidateIdsExcept(supabase, state, cohort, artistId, "decades"),
     candidateIdsExcept(supabase, state, cohort, artistId, "artist"),
   ]);
 
-  const [themes, formats, decades, availableArtistSlugs] = await Promise.all([
+  const [themes, formats, mediums, decades, availableArtistSlugs] = await Promise.all([
     countCategoriesForIds(supabase, themeIds, "theme"),
     countCategoriesForIds(supabase, formatIds, "format"),
+    countCategoriesForIds(supabase, mediumIds, "medium"),
     countDecadesForIds(supabase, decadeIds),
     artistsForIds(supabase, artistIds),
   ]);
 
-  return { themes, formats, decades, availableArtistSlugs };
+  return { themes, formats, mediums, decades, availableArtistSlugs };
 }
 
 async function candidateIdsExcept(
@@ -299,12 +322,14 @@ async function candidateIdsExcept(
 ): Promise<Set<string>> {
   const themes = except === "themes" ? [] : state.themes;
   const formats = except === "formats" ? [] : state.formats;
-  const isOneDim = (themes.length > 0) !== (formats.length > 0);
-  const isTwoDim = themes.length > 0 && formats.length > 0;
+  const mediums = except === "mediums" ? [] : state.mediums;
+  const activeCatDims = [themes.length > 0, formats.length > 0, mediums.length > 0].filter(Boolean).length;
+  const isOneDim = activeCatDims === 1;
+  const isMultiDim = activeCatDims >= 2;
 
   let intersectedIds: string[] | null = null;
-  if (isTwoDim) {
-    intersectedIds = await categoryFilteredIds(supabase, themes, formats);
+  if (isMultiDim) {
+    intersectedIds = await categoryFilteredIds(supabase, themes, formats, mediums);
     if (intersectedIds.length === 0) return new Set();
   }
 
@@ -314,8 +339,8 @@ async function candidateIdsExcept(
     let q = supabase.from("artworks").select(selectStr);
     q = applyScalarFilters(q, state, cohort, artistId, except);
     if (isOneDim) {
-      q = applySingleDimEmbeddedFilter(q, themes, formats);
-    } else if (isTwoDim) {
+      q = applySingleDimEmbeddedFilter(q, themes, formats, mediums);
+    } else if (isMultiDim) {
       q = q.in("id", intersectedIds!);
     }
     return q;
@@ -333,7 +358,7 @@ async function candidateIdsExcept(
 async function countCategoriesForIds(
   supabase: SupabaseClient,
   candidateIds: Set<string>,
-  kind: "theme" | "format"
+  kind: "theme" | "format" | "medium"
 ): Promise<Record<string, number>> {
   if (candidateIds.size === 0) return {};
   const rows = await fetchAllRows<any>(() =>

--- a/src/lib/filter-state.ts
+++ b/src/lib/filter-state.ts
@@ -10,6 +10,7 @@ export interface FilterState {
   q: string;
   themes: string[];
   formats: string[];
+  mediums: string[];
   decades: string[];
   artist: string | null;
   sort: SortKey | null;
@@ -47,6 +48,7 @@ export function parseSearchParams(params: Record<string, RawParam>): FilterState
     q: pickFirst(params.q),
     themes: parseList(params.theme),
     formats: parseList(params.format),
+    mediums: parseList(params.medium),
     decades: parseList(params.decade),
     artist: pickFirst(params.artist) || null,
     sort: parseSort(params.sort),
@@ -59,6 +61,7 @@ export function toQueryString(state: FilterState): string {
   if (state.q) out.set("q", state.q);
   if (state.themes.length) out.set("theme", state.themes.join(","));
   if (state.formats.length) out.set("format", state.formats.join(","));
+  if (state.mediums.length) out.set("medium", state.mediums.join(","));
   if (state.decades.length) out.set("decade", state.decades.join(","));
   if (state.artist) out.set("artist", state.artist);
   if (state.sort) out.set("sort", state.sort);

--- a/supabase/migrations/001_initial.sql
+++ b/supabase/migrations/001_initial.sql
@@ -25,8 +25,9 @@ CREATE TABLE categories (
   ai_suggested  BOOLEAN DEFAULT false,
   -- Discriminator for what kind of category this is. 'format' is the
   -- existing AI-suggested taxonomy (Drawings, Paintings, etc.); 'theme'
-  -- is the controlled subject taxonomy added in 2026-04-23.
-  kind          TEXT CHECK (kind IN ('format', 'theme')),
+  -- is the controlled subject taxonomy added in 2026-04-23; 'medium' is
+  -- the normalized material taxonomy added in 2026-04-25.
+  kind          TEXT CHECK (kind IN ('format', 'theme', 'medium')),
   created_at    TIMESTAMPTZ DEFAULT now()
 );
 


### PR DESCRIPTION
## Summary

Adds a faceted **Medium** filter dropdown to the public collection, backed by a CDWA-aligned, LLM-derived (and human-reviewed) taxonomy of art materials. Each artwork can be tagged with multiple medium buckets — a piece described as *"Color Stix, ink, and colored pencil on paper"* surfaces in Color Stix + Ink + Colored pencil filters.

- **Two-phase workflow**: Phase 1 (`npm run medium:propose`) calls Claude with all 283 distinct medium strings and proposes a small (~16) bucket vocabulary + per-string mapping into a review CSV. Phase 2 (`npm run medium:apply -- <csv>`) reads the (possibly-edited) CSV, upserts `kind='medium'` categories, and diffs each artwork's attachments. Output: 16 buckets, 2,710 artworks tagged in the production run.
- **Persisted lookup**: `scripts/data/medium-buckets.json` ships in source control. Both importers (`import-csv.ts`, `import-archive.ts`) consult it on insert so newly-imported artworks get the right tags without another LLM call.
- **UI**: New Medium MultiSelectDropdown in FilterBar, plumbed through `collection-query.ts` (extended from 2 to 3 category dimensions). Active-filter chips and Clear-all extended.

Spec: `docs/superpowers/specs/2026-04-25-medium-normalization-design.md`
Plan: `docs/superpowers/plans/2026-04-25-medium-normalization.md`

## Schema migration

The `categories.kind` CHECK constraint was relaxed to allow `'medium'` via SQL Editor before merge:

```sql
ALTER TABLE categories DROP CONSTRAINT IF EXISTS categories_kind_check;
ALTER TABLE categories ADD CONSTRAINT categories_kind_check
  CHECK (kind IN ('format', 'theme', 'medium'));
```

`supabase/migrations/001_initial.sql` is synced to match for fresh-DB setup.

## Bucket vocabulary (16)

Acrylic, Ceramic, Collage, Color Stix, Colored pencil, Crayon, Fiber/Yarn, Graphite/Pencil, Ink, Marker, Oil pastel, Other, Pastel, Sequins/Beads, Watercolor, Wood

12 of 2,710 artworks remain un-bucketed (mixed-media pieces Claude couldn't enumerate); they don't appear in any medium filter — acceptable per design.

## Test plan

- [ ] Open `/` and confirm the new Medium dropdown sits between Format and Artist with facet counts.
- [ ] Pick a medium (e.g., Ink) — count and grid match expectations (~1,033 for Ink).
- [ ] Combine Medium + Theme + Format (3-dim) and verify the page renders 200 (this regressed once during smoke test — fix landed in commit a004e98).
- [ ] Confirm Medium dropdown is hidden on `/ephemera`.
- [ ] Open the `Color Stix on paper` detail page — original medium string is preserved (no display change there).
- [ ] Click an active medium chip to remove it; click "Clear all" and confirm mediums are cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)