### PR TITLE
Audio descriptions: human-recorded + machine-generated, wired into detail page and admin

### DIFF
--- a/src/app/admin/artworks/[id]/page.tsx
+++ b/src/app/admin/artworks/[id]/page.tsx
@@ -38,6 +38,13 @@ export default function EditArtworkPage() {
     on_website: true,
   });
 
+  // Audio state lives outside formData because the upload/transcribe/TTS
+  // actions persist immediately (no Save Changes round-trip needed). We
+  // mirror the latest values onto the artwork object so the player and
+  // status text re-render.
+  const [audioBusy, setAudioBusy] = useState<null | "upload" | "transcribe" | "tts">(null);
+  const [audioMessage, setAudioMessage] = useState<string | null>(null);
+
   useEffect(() => {
     const fetchData = async () => {
       try {
@@ -132,6 +139,66 @@ export default function EditArtworkPage() {
       setSaving(false);
     }
   };
+
+  async function handleAudioUpload(file: File) {
+    setAudioBusy("upload");
+    setAudioMessage(null);
+    try {
+      const fd = new FormData();
+      fd.append("artworkId", artworkId);
+      fd.append("file", file);
+      const resp = await fetch("/api/admin/audio/upload", { method: "POST", body: fd });
+      const json = await resp.json();
+      if (!resp.ok) throw new Error(json.error || `Upload failed: ${resp.status}`);
+      setArtwork((a) => (a ? { ...a, audio_url: json.audio_url, audio_origin: json.audio_origin } : a));
+      setAudioMessage("Audio uploaded.");
+    } catch (err) {
+      setAudioMessage(err instanceof Error ? err.message : "Upload failed");
+    } finally {
+      setAudioBusy(null);
+    }
+  }
+
+  async function handleTranscribe() {
+    setAudioBusy("transcribe");
+    setAudioMessage(null);
+    try {
+      const resp = await fetch("/api/admin/audio/transcribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ artworkId }),
+      });
+      const json = await resp.json();
+      if (!resp.ok) throw new Error(json.error || `Transcribe failed: ${resp.status}`);
+      setFormData((p) => ({ ...p, alt_text_long: json.alt_text_long }));
+      setArtwork((a) => (a ? { ...a, alt_text_long: json.alt_text_long, description_origin: "human" } : a));
+      setAudioMessage("Transcript saved to long alt text.");
+    } catch (err) {
+      setAudioMessage(err instanceof Error ? err.message : "Transcription failed");
+    } finally {
+      setAudioBusy(null);
+    }
+  }
+
+  async function handleGenerateTts() {
+    setAudioBusy("tts");
+    setAudioMessage(null);
+    try {
+      const resp = await fetch("/api/admin/audio/generate-tts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ artworkId }),
+      });
+      const json = await resp.json();
+      if (!resp.ok) throw new Error(json.error || `TTS failed: ${resp.status}`);
+      setArtwork((a) => (a ? { ...a, audio_url: json.audio_url, audio_origin: json.audio_origin } : a));
+      setAudioMessage("Generated audio with ElevenLabs.");
+    } catch (err) {
+      setAudioMessage(err instanceof Error ? err.message : "TTS failed");
+    } finally {
+      setAudioBusy(null);
+    }
+  }
 
   if (loading) {
     return <div className="text-center py-12">Loading...</div>;
@@ -319,6 +386,79 @@ export default function EditArtworkPage() {
             rows={4}
             className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
+        </div>
+
+        {/* Audio description */}
+        <div className="mb-6 p-4 border border-gray-200 rounded bg-gray-50">
+          <label className="block text-sm font-bold text-gray-700 mb-2">
+            Audio description
+          </label>
+          <p className="text-xs text-gray-600 mb-3">
+            Audio is the read-aloud version of the long alt text. The two
+            stay in sync via the Transcribe and Generate buttons below.
+          </p>
+
+          {artwork.audio_url ? (
+            <div className="mb-3">
+              <audio controls preload="metadata" className="w-full" src={artwork.audio_url} />
+              <p className="text-xs text-gray-600 mt-1">
+                Source:{" "}
+                <span className="font-mono">
+                  {artwork.audio_origin || "(no origin recorded)"}
+                </span>
+              </p>
+            </div>
+          ) : (
+            <p className="text-sm text-gray-500 italic mb-3">No audio uploaded.</p>
+          )}
+
+          <div className="space-y-3">
+            <div>
+              <label htmlFor="audio_file" className="block text-xs font-semibold text-gray-700 mb-1">
+                Upload MP3 (replaces existing audio, marks as human-recorded)
+              </label>
+              <input
+                id="audio_file"
+                type="file"
+                accept="audio/*"
+                disabled={audioBusy !== null}
+                onChange={(e) => {
+                  const f = e.target.files?.[0];
+                  if (f) handleAudioUpload(f);
+                  e.target.value = ""; // allow re-uploading the same filename
+                }}
+                className="block text-sm"
+              />
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                disabled={audioBusy !== null || !artwork.audio_url}
+                onClick={handleTranscribe}
+                className="button-secondary text-sm disabled:opacity-50"
+                title={!artwork.audio_url ? "Upload audio first" : "Transcribe audio → long alt text"}
+              >
+                {audioBusy === "transcribe" ? "Transcribing…" : "Transcribe audio → text"}
+              </button>
+              <button
+                type="button"
+                disabled={audioBusy !== null || !formData.alt_text_long}
+                onClick={handleGenerateTts}
+                className="button-secondary text-sm disabled:opacity-50"
+                title={!formData.alt_text_long ? "Long alt text is empty" : "Generate audio from long alt text via ElevenLabs"}
+              >
+                {audioBusy === "tts" ? "Generating…" : "Generate audio from text (ElevenLabs)"}
+              </button>
+            </div>
+
+            {audioBusy === "upload" && (
+              <p className="text-sm text-gray-600">Uploading…</p>
+            )}
+            {audioMessage && (
+              <p className="text-sm text-gray-700">{audioMessage}</p>
+            )}
+          </div>
         </div>
 
         {/* Short alt text - grid page */}

--- a/src/app/api/admin/audio/generate-tts/route.ts
+++ b/src/app/api/admin/audio/generate-tts/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from "next/server";
+import { uploadToR2 } from "@/lib/r2";
+import { requireAdmin, adminSupabase } from "@/lib/admin-auth";
+
+export const maxDuration = 90;
+
+// Default to ElevenLabs's "Rachel" voice. Override via ELEVENLABS_VOICE_ID
+// to standardize the catalog on a different narrator.
+const DEFAULT_VOICE_ID = "21m00Tcm4TlvDq8ikWAM";
+
+/**
+ * POST /api/admin/audio/generate-tts
+ * { artworkId: string }
+ *
+ * Reads alt_text_long from the artwork, sends it to ElevenLabs, uploads
+ * the resulting MP3 to R2, and writes audio_url + audio_origin='tts' on
+ * the artwork. Returns the new audio_url.
+ */
+export async function POST(request: NextRequest) {
+  const unauthed = await requireAdmin();
+  if (unauthed) return unauthed;
+
+  try {
+    const { artworkId } = (await request.json()) as { artworkId?: string };
+    if (!artworkId) {
+      return NextResponse.json({ error: "artworkId is required" }, { status: 400 });
+    }
+    if (!process.env.ELEVENLABS_API_KEY) {
+      return NextResponse.json({ error: "ELEVENLABS_API_KEY not configured" }, { status: 500 });
+    }
+    const voiceId = process.env.ELEVENLABS_VOICE_ID || DEFAULT_VOICE_ID;
+
+    const supabase = adminSupabase();
+    const { data: artwork, error: lookupErr } = await supabase
+      .from("artworks")
+      .select("id, alt_text_long")
+      .eq("id", artworkId)
+      .single();
+    if (lookupErr || !artwork) {
+      return NextResponse.json({ error: "Artwork not found" }, { status: 404 });
+    }
+    const text = (artwork.alt_text_long || "").trim();
+    if (!text) {
+      return NextResponse.json(
+        { error: "Artwork has no alt_text_long to read" },
+        { status: 400 }
+      );
+    }
+
+    const ttsResp = await fetch(
+      `https://api.elevenlabs.io/v1/text-to-speech/${voiceId}`,
+      {
+        method: "POST",
+        headers: {
+          "xi-api-key": process.env.ELEVENLABS_API_KEY,
+          "Content-Type": "application/json",
+          Accept: "audio/mpeg",
+        },
+        body: JSON.stringify({
+          text,
+          model_id: "eleven_multilingual_v2",
+        }),
+      }
+    );
+    if (!ttsResp.ok) {
+      const detail = await ttsResp.text();
+      return NextResponse.json(
+        { error: `ElevenLabs failed: ${ttsResp.status}`, detail: detail.slice(0, 500) },
+        { status: 502 }
+      );
+    }
+
+    const audioBuffer = Buffer.from(await ttsResp.arrayBuffer());
+    const ts = new Date().toISOString().replace(/[:.]/g, "-");
+    const key = `audio/${artworkId}/tts-${ts}.mp3`;
+    const audioUrl = await uploadToR2(key, audioBuffer, "audio/mpeg");
+
+    const { error: updateErr } = await supabase
+      .from("artworks")
+      .update({ audio_url: audioUrl, audio_origin: "tts" })
+      .eq("id", artworkId);
+    if (updateErr) throw updateErr;
+
+    return NextResponse.json({ audio_url: audioUrl, audio_origin: "tts" });
+  } catch (err) {
+    console.error("audio/generate-tts error:", err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "TTS generation failed" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/admin/audio/transcribe/route.ts
+++ b/src/app/api/admin/audio/transcribe/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin, adminSupabase } from "@/lib/admin-auth";
+
+export const maxDuration = 60;
+
+/**
+ * POST /api/admin/audio/transcribe
+ * { artworkId: string }
+ *
+ * Looks up the artwork's audio_url, sends the audio to OpenAI Whisper,
+ * and writes the transcription to alt_text_long with description_origin
+ * set to 'human' (the audio captures human narration; the text is the
+ * derived transcript). Returns the updated text.
+ */
+export async function POST(request: NextRequest) {
+  const unauthed = await requireAdmin();
+  if (unauthed) return unauthed;
+
+  try {
+    const { artworkId } = (await request.json()) as { artworkId?: string };
+    if (!artworkId) {
+      return NextResponse.json({ error: "artworkId is required" }, { status: 400 });
+    }
+    if (!process.env.OPENAI_API_KEY) {
+      return NextResponse.json({ error: "OPENAI_API_KEY not configured" }, { status: 500 });
+    }
+
+    const supabase = adminSupabase();
+    const { data: artwork, error: lookupErr } = await supabase
+      .from("artworks")
+      .select("id, audio_url")
+      .eq("id", artworkId)
+      .single();
+    if (lookupErr || !artwork) {
+      return NextResponse.json({ error: "Artwork not found" }, { status: 404 });
+    }
+    if (!artwork.audio_url) {
+      return NextResponse.json({ error: "Artwork has no audio_url to transcribe" }, { status: 400 });
+    }
+
+    // Pull the MP3 from R2 (public bucket) and forward to Whisper as a Blob.
+    const audioResp = await fetch(artwork.audio_url);
+    if (!audioResp.ok) {
+      return NextResponse.json(
+        { error: `Could not fetch audio: ${audioResp.status}` },
+        { status: 502 }
+      );
+    }
+    const audioBlob = await audioResp.blob();
+
+    const whisperForm = new FormData();
+    whisperForm.append("file", audioBlob, "audio.mp3");
+    whisperForm.append("model", "whisper-1");
+    whisperForm.append("response_format", "text");
+
+    const whisperResp = await fetch("https://api.openai.com/v1/audio/transcriptions", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${process.env.OPENAI_API_KEY}` },
+      body: whisperForm,
+    });
+    if (!whisperResp.ok) {
+      const detail = await whisperResp.text();
+      return NextResponse.json(
+        { error: `Whisper failed: ${whisperResp.status}`, detail: detail.slice(0, 500) },
+        { status: 502 }
+      );
+    }
+    const transcript = (await whisperResp.text()).trim();
+    if (!transcript) {
+      return NextResponse.json({ error: "Whisper returned empty transcript" }, { status: 502 });
+    }
+
+    const { error: updateErr } = await supabase
+      .from("artworks")
+      .update({ alt_text_long: transcript, description_origin: "human" })
+      .eq("id", artworkId);
+    if (updateErr) throw updateErr;
+
+    return NextResponse.json({ alt_text_long: transcript, description_origin: "human" });
+  } catch (err) {
+    console.error("audio/transcribe error:", err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Transcription failed" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/admin/audio/upload/route.ts
+++ b/src/app/api/admin/audio/upload/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+import { uploadToR2 } from "@/lib/r2";
+import { requireAdmin, adminSupabase } from "@/lib/admin-auth";
+
+export const maxDuration = 30;
+
+/**
+ * POST /api/admin/audio/upload
+ * multipart/form-data with `artworkId` and `file` (audio/mpeg).
+ *
+ * Uploads the MP3 to R2 at audio/{artworkId}/{ISO}-{filename} and writes
+ * audio_url + audio_origin='human' on the artwork. Returns the new
+ * audio_url.
+ */
+export async function POST(request: NextRequest) {
+  const unauthed = await requireAdmin();
+  if (unauthed) return unauthed;
+
+  try {
+    const form = await request.formData();
+    const artworkId = form.get("artworkId");
+    const file = form.get("file");
+    if (typeof artworkId !== "string" || !artworkId) {
+      return NextResponse.json({ error: "artworkId is required" }, { status: 400 });
+    }
+    if (!(file instanceof Blob)) {
+      return NextResponse.json({ error: "file is required" }, { status: 400 });
+    }
+    if (file.type && !file.type.startsWith("audio/")) {
+      return NextResponse.json(
+        { error: `Expected audio/*, got ${file.type}` },
+        { status: 400 }
+      );
+    }
+
+    // Use the original filename if the browser supplied one, otherwise default.
+    const originalName = (file as File).name || "audio.mp3";
+    const safeName = originalName.replace(/[^a-zA-Z0-9._-]+/g, "_");
+    const ts = new Date().toISOString().replace(/[:.]/g, "-");
+    const key = `audio/${artworkId}/${ts}-${safeName}`;
+
+    const buffer = Buffer.from(await file.arrayBuffer());
+    const audioUrl = await uploadToR2(key, buffer, file.type || "audio/mpeg");
+
+    const { error: updateErr } = await adminSupabase()
+      .from("artworks")
+      .update({ audio_url: audioUrl, audio_origin: "human" })
+      .eq("id", artworkId);
+    if (updateErr) throw updateErr;
+
+    return NextResponse.json({ audio_url: audioUrl, audio_origin: "human" });
+  } catch (err) {
+    console.error("audio/upload error:", err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Upload failed" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/artwork/[id]/page.tsx
+++ b/src/app/artwork/[id]/page.tsx
@@ -258,26 +258,22 @@ export default async function ArtworkPage({ params, searchParams }: ArtworkPageP
               </div>
             )}
 
-            {artwork.audio_url && (
+            {showVisualDescription && (artwork.audio_url || artwork.alt_text_long) && (
               <div>
                 <dt className="text-sm font-semibold text-gray-600 mb-2">
-                  Audio description
-                </dt>
-                <dd>
-                  <audio controls preload="metadata" className="w-full">
-                    <source src={artwork.audio_url} type="audio/mpeg" />
-                    Your browser does not support the audio element.
-                  </audio>
-                </dd>
-              </div>
-            )}
-
-            {showVisualDescription && artwork.alt_text_long && (
-              <div>
-                <dt className="text-sm font-semibold text-gray-600">
                   Visual description
                 </dt>
-                <dd className="text-gray-900 leading-relaxed">{artwork.alt_text_long}</dd>
+                {artwork.audio_url && (
+                  <dd className="mb-3">
+                    <audio controls preload="metadata" className="w-full">
+                      <source src={artwork.audio_url} type="audio/mpeg" />
+                      Your browser does not support the audio element.
+                    </audio>
+                  </dd>
+                )}
+                {artwork.alt_text_long && (
+                  <dd className="text-gray-900 leading-relaxed">{artwork.alt_text_long}</dd>
+                )}
               </div>
             )}
           </div>

--- a/src/app/artwork/[id]/page.tsx
+++ b/src/app/artwork/[id]/page.tsx
@@ -258,6 +258,20 @@ export default async function ArtworkPage({ params, searchParams }: ArtworkPageP
               </div>
             )}
 
+            {artwork.audio_url && (
+              <div>
+                <dt className="text-sm font-semibold text-gray-600 mb-2">
+                  Audio description
+                </dt>
+                <dd>
+                  <audio controls preload="metadata" className="w-full">
+                    <source src={artwork.audio_url} type="audio/mpeg" />
+                    Your browser does not support the audio element.
+                  </audio>
+                </dd>
+              </div>
+            )}
+
             {showVisualDescription && artwork.alt_text_long && (
               <div>
                 <dt className="text-sm font-semibold text-gray-600">

--- a/src/lib/admin-auth.ts
+++ b/src/lib/admin-auth.ts
@@ -1,0 +1,31 @@
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import { NextResponse } from "next/server";
+
+/**
+ * Gate admin API routes behind the same auth check the admin layout uses
+ * (Supabase session, with a NEXT_PUBLIC_AUTH_BYPASS dev escape hatch).
+ * Returns null on success; returns a 401 NextResponse to throw early on
+ * failure.
+ */
+export async function requireAdmin(): Promise<NextResponse | null> {
+  if (process.env.NEXT_PUBLIC_AUTH_BYPASS === "true") return null;
+  const supabase = createServerSupabaseClient();
+  const { data, error } = await supabase.auth.getSession();
+  if (error || !data?.session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  return null;
+}
+
+/**
+ * Service-role Supabase client for admin write paths. Bypasses RLS, so
+ * only call from API routes that have already gone through requireAdmin.
+ */
+export function adminSupabase(): SupabaseClient {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { autoRefreshToken: false, persistSession: false } }
+  );
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -38,6 +38,8 @@ export interface Artwork {
   alt_text: string | null;
   alt_text_long: string | null;
   description_origin: "human" | "ai" | null;
+  audio_url: string | null;
+  audio_origin: "human" | "tts" | null;
   tags: string[] | null;
   genre: string | null;
   notes: string | null;

--- a/supabase/migrations/001_initial.sql
+++ b/supabase/migrations/001_initial.sql
@@ -57,6 +57,12 @@ CREATE TABLE artworks (
   alt_text          TEXT,
   alt_text_long     TEXT,
   description_origin TEXT CHECK (description_origin IN ('human', 'ai')),
+
+  -- Audio description. audio_url is an R2-hosted MP3 of someone reading
+  -- alt_text_long aloud. audio_origin tracks whether the recording is
+  -- human-narrated or TTS-generated from the text.
+  audio_url         TEXT,
+  audio_origin      TEXT CHECK (audio_origin IN ('human', 'tts')),
   sku               TEXT,
   decade            TEXT,
 


### PR DESCRIPTION
## Summary

Adds audio descriptions as a first-class feature alongside the existing long-form text description. Same content, two formats: a human can record an MP3 of someone reading the long alt text aloud, or staff can have ElevenLabs generate an MP3 from existing text. The artwork detail page renders an embedded player above the visual description prose, both gated together by `description_origin`.

### What's live

- **Schema** — two new columns on `artworks`: `audio_url` (R2-hosted MP3) and `audio_origin` (`'human'` | `'tts'`). Migration synced; production was migrated via SQL Editor.
- **Public detail page** — when `audio_url` is set, an `<audio controls>` player appears at the top of the consolidated "Visual description" section, above the prose. Native audio gives keyboard / screen-reader support out of the box.
- **Admin tooling** — Audio block on the Edit Artwork page with three actions:
  1. **Upload MP3** — multipart upload to R2 at `audio/{artworkId}/{ts}-{filename}.mp3`, sets `audio_origin='human'`.
  2. **Transcribe audio → text** — pulls the MP3 through OpenAI Whisper, writes the transcript to `alt_text_long` with `description_origin='human'`.
  3. **Generate audio from text** — sends `alt_text_long` to ElevenLabs (Multilingual v2, voice configurable via `ELEVENLABS_VOICE_ID`), uploads MP3 to R2, sets `audio_origin='tts'`.

### Sync model

Text and audio are independently editable. The two action buttons are explicit refresh paths, never automatic. Small text edits don't trigger a 30-second TTS regen; re-recording audio doesn't overwrite curated text. The admin chooses when to sync.

### Notable wrinkle worth highlighting

The first cut of the API routes used the cookie-bound server Supabase client and writes silently failed under RLS. Routes now use a service-role client (gated behind `requireAdmin()`). New helper `src/lib/admin-auth.ts` exposes both.

### New env vars (already configured locally + in Vercel)

- `OPENAI_API_KEY` — Whisper
- `ELEVENLABS_API_KEY` — TTS
- `ELEVENLABS_VOICE_ID` — voice to use; defaults to "Rachel" if unset

ElevenLabs requires the Starter plan ($6/mo) to use library voices via API; Free-tier instant-clone voices in "My Voices" work without a paid plan.

### Test plan

- [ ] Open Nicole Storm's NS 399 (`/artwork/6e193c6f-8e6e-4e02-bfa8-0124e811d70f`) and confirm the human-recorded MP3 plays at the top of the Visual description section.
- [ ] Open `/artwork/7a3d23c4-66cf-4208-bf4e-e1a1fc7a7024?ai=1` (CLIR2023.802) and confirm the TTS-generated audio plays.
- [ ] In `/admin/artworks/{id}`, upload an MP3 — confirm it appears in the player below and that `audio_origin` shows "human".
- [ ] Click "Transcribe audio → text" — confirm the long alt text field updates.
- [ ] Click "Generate audio from text (ElevenLabs)" — confirm a new MP3 is generated and the player refreshes; `audio_origin` shows "tts".
- [ ] Edit the long alt text in the form (don't click any audio buttons) — save; confirm the audio is unchanged (proves no auto-sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)