### PR TITLE
Admin refinements: search, save UX, dashboard stats, sidebar trim, scrollable description

### DIFF
--- a/src/app/admin/artists/[id]/page.tsx
+++ b/src/app/admin/artists/[id]/page.tsx
@@ -124,18 +124,22 @@ export default function EditArtistPage() {
       setSaving(true);
       setError(null);
 
-      const { error: updateError } = await supabase
-        .from("artists")
-        .update({
+      // Route through the admin API (service-role) so RLS doesn't
+      // silently drop the write.
+      const resp = await fetch(`/api/admin/artists/${artistId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
           first_name: formData.first_name,
           last_name: formData.last_name,
           bio: formData.bio || null,
           external_url: formData.external_url || null,
-          updated_at: new Date().toISOString(),
-        })
-        .eq("id", artistId);
-
-      if (updateError) throw updateError;
+        }),
+      });
+      if (!resp.ok) {
+        const json = await resp.json().catch(() => ({}));
+        throw new Error(json.error || `Save failed: ${resp.status}`);
+      }
 
       // Stay on the page; flash a success banner that auto-clears.
       setSavedAt(Date.now());

--- a/src/app/admin/artists/[id]/page.tsx
+++ b/src/app/admin/artists/[id]/page.tsx
@@ -50,6 +50,7 @@ export default function EditArtistPage() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<number | null>(null);
 
   const [formData, setFormData] = useState({
     first_name: "",
@@ -136,7 +137,11 @@ export default function EditArtistPage() {
 
       if (updateError) throw updateError;
 
-      router.push("/admin/artists");
+      // Stay on the page; flash a success banner that auto-clears.
+      setSavedAt(Date.now());
+      setTimeout(() => {
+        setSavedAt((current) => (current && Date.now() - current >= 3000 ? null : current));
+      }, 3100);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Error saving artist");
     } finally {
@@ -162,6 +167,12 @@ export default function EditArtistPage() {
         {error && (
           <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded text-red-800">
             {error}
+          </div>
+        )}
+
+        {savedAt && (
+          <div className="mb-6 p-4 bg-green-50 border border-green-200 rounded text-green-800">
+            Saved.
           </div>
         )}
 

--- a/src/app/admin/artworks/[id]/page.tsx
+++ b/src/app/admin/artworks/[id]/page.tsx
@@ -123,15 +123,20 @@ export default function EditArtworkPage() {
         alt_text: formData.alt_text || null,
         alt_text_long: formData.alt_text_long || null,
         on_website: formData.on_website,
-        updated_at: new Date().toISOString(),
       };
 
-      const { error: updateError } = await supabase
-        .from("artworks")
-        .update(updateData)
-        .eq("id", artworkId);
-
-      if (updateError) throw updateError;
+      // Route through the admin API (service-role) so RLS doesn't
+      // silently drop the write — the browser anon-key client lacks
+      // write permission against the artworks table.
+      const resp = await fetch(`/api/admin/artworks/${artworkId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(updateData),
+      });
+      if (!resp.ok) {
+        const json = await resp.json().catch(() => ({}));
+        throw new Error(json.error || `Save failed: ${resp.status}`);
+      }
 
       // Stay on the page; flash a success banner that auto-clears.
       setSavedAt(Date.now());

--- a/src/app/admin/artworks/[id]/page.tsx
+++ b/src/app/admin/artworks/[id]/page.tsx
@@ -23,6 +23,7 @@ export default function EditArtworkPage() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<number | null>(null);
 
   const [formData, setFormData] = useState({
     title: "",
@@ -132,7 +133,11 @@ export default function EditArtworkPage() {
 
       if (updateError) throw updateError;
 
-      router.push("/admin/artworks");
+      // Stay on the page; flash a success banner that auto-clears.
+      setSavedAt(Date.now());
+      setTimeout(() => {
+        setSavedAt((current) => (current && Date.now() - current >= 3000 ? null : current));
+      }, 3100);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Error saving artwork");
     } finally {
@@ -218,6 +223,12 @@ export default function EditArtworkPage() {
         {error && (
           <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded text-red-800">
             {error}
+          </div>
+        )}
+
+        {savedAt && (
+          <div className="mb-6 p-4 bg-green-50 border border-green-200 rounded text-green-800">
+            Saved.
           </div>
         )}
 

--- a/src/app/admin/artworks/page.tsx
+++ b/src/app/admin/artworks/page.tsx
@@ -4,51 +4,102 @@ import Link from "next/link";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import { formatArtistName, resolveImageUrl } from "@/lib/utils";
 
-async function getArtworks(): Promise<any[]> {
-  const supabase = createServerSupabaseClient();
+const PAGE_LIMIT = 100;
 
-  const { data, error } = await supabase
+async function getArtworks(query: string): Promise<{ rows: any[]; truncated: boolean }> {
+  const supabase = createServerSupabaseClient();
+  const q = query.trim();
+
+  // For artist-name matches we need to pre-resolve artist IDs because
+  // PostgREST can't .ilike across an embedded relation in a single .or().
+  let matchingArtistIds: string[] = [];
+  if (q) {
+    const { data: artistRows } = await supabase
+      .from("artists")
+      .select("id")
+      .or(`first_name.ilike.%${q}%,last_name.ilike.%${q}%`);
+    matchingArtistIds = (artistRows || []).map((a: any) => a.id);
+  }
+
+  let builder = supabase
     .from("artworks")
     .select(
       `
       id,
       title,
+      sku,
       image_url,
       medium,
       on_website,
       artist:artists(id, first_name, last_name),
       categories:artwork_categories(category:categories(id, name))
       `
-    )
+    );
+
+  if (q) {
+    const orClauses = [`title.ilike.%${q}%`, `sku.ilike.%${q}%`];
+    if (matchingArtistIds.length > 0) {
+      orClauses.push(`artist_id.in.(${matchingArtistIds.join(",")})`);
+    }
+    builder = builder.or(orClauses.join(","));
+  }
+
+  // Fetch one extra row to detect whether the result was truncated.
+  const { data, error } = await builder
     .order("sort_order", { ascending: true })
-    .limit(50);
+    .limit(PAGE_LIMIT + 1);
 
   if (error) {
     console.error("Error fetching artworks:", error);
-    return [];
+    return { rows: [], truncated: false };
   }
-
-  return data || [];
+  const all = data || [];
+  return { rows: all.slice(0, PAGE_LIMIT), truncated: all.length > PAGE_LIMIT };
 }
 
 export const metadata = {
   title: "Artworks | Admin | Creative Growth Gallery",
 };
 
-export default async function AdminArtworksPage() {
-  const artworks = await getArtworks();
+interface PageProps {
+  searchParams: Promise<{ q?: string }>;
+}
+
+export default async function AdminArtworksPage({ searchParams }: PageProps) {
+  const { q = "" } = await searchParams;
+  const { rows: artworks, truncated } = await getArtworks(q);
 
   return (
     <div>
-      <div className="flex justify-between items-center mb-8">
+      <div className="flex justify-between items-center mb-6">
         <h1 className="text-3xl font-bold text-gray-900">Artworks</h1>
-        <Link
-          href="/admin/artworks/new"
-          className="button-primary"
-        >
+        <Link href="/admin/artworks/new" className="button-primary">
           Add Artwork
         </Link>
       </div>
+
+      <form method="get" className="mb-6 flex items-center gap-3">
+        <input
+          type="text"
+          name="q"
+          defaultValue={q}
+          placeholder="Search by SKU, title, or artist name…"
+          className="flex-1 max-w-md px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+        <button type="submit" className="button-secondary">Search</button>
+        {q && (
+          <Link href="/admin/artworks" className="text-sm text-gray-600 hover:text-gray-900">
+            Clear
+          </Link>
+        )}
+      </form>
+
+      {q && (
+        <p className="text-sm text-gray-600 mb-4">
+          {artworks.length} {artworks.length === 1 ? "match" : "matches"} for &ldquo;{q}&rdquo;
+          {truncated && ` (showing first ${PAGE_LIMIT} — refine your search to narrow further)`}
+        </p>
+      )}
 
       {artworks.length > 0 ? (
         <div className="bg-white rounded-lg shadow overflow-x-auto">
@@ -57,6 +108,9 @@ export default async function AdminArtworksPage() {
               <tr>
                 <th className="px-6 py-3 text-left text-xs font-bold text-gray-600 uppercase tracking-wider">
                   Image
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-bold text-gray-600 uppercase tracking-wider">
+                  SKU
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-bold text-gray-600 uppercase tracking-wider">
                   Title
@@ -95,6 +149,9 @@ export default async function AdminArtworksPage() {
                         />
                       </div>
                     )}
+                  </td>
+                  <td className="px-6 py-4 text-sm text-gray-600 font-mono">
+                    {artwork.sku || "—"}
                   </td>
                   <td className="px-6 py-4 text-sm text-gray-900 font-medium">
                     {artwork.title}
@@ -144,10 +201,14 @@ export default async function AdminArtworksPage() {
         </div>
       ) : (
         <div className="text-center py-12 bg-white rounded-lg">
-          <p className="text-gray-600 mb-4">No artworks yet.</p>
-          <Link href="/admin/artworks/new" className="text-blue-600">
-            Create the first artwork
-          </Link>
+          <p className="text-gray-600 mb-4">
+            {q ? `No artworks match “${q}”.` : "No artworks yet."}
+          </p>
+          {!q && (
+            <Link href="/admin/artworks/new" className="text-blue-600">
+              Create the first artwork
+            </Link>
+          )}
         </div>
       )}
     </div>

--- a/src/app/admin/import/page.tsx
+++ b/src/app/admin/import/page.tsx
@@ -131,28 +131,39 @@ export default function ImportPage() {
           </button>
         </div>
 
-        {/* Import */}
-        <div className="bg-white rounded-lg shadow p-8">
+        {/* Import (disabled) */}
+        <div className="bg-white rounded-lg shadow p-8 opacity-75">
           <h2 className="text-xl font-bold text-gray-900 mb-4">
             Import Collection
           </h2>
           <p className="text-gray-600 mb-6">
-            Use the import script to add artworks in bulk. See documentation for
-            CSV format and usage instructions.
+            Upload a CSV to bulk-create or update artworks. The expected
+            columns mirror the existing Art Cloud export: Title, Artist First
+            Name, Artist Last Name, Date Created, Medium, Height, Width, Depth,
+            Inventory Number, Tags, and On Website.
           </p>
 
-          <p className="text-gray-600 mb-4">
-            Run the import script from your terminal:
-          </p>
+          <div className="border-2 border-dashed border-gray-300 rounded p-6 text-center text-sm text-gray-500 mb-4">
+            <p className="font-semibold mb-1">Browser-based import is disabled.</p>
+            <p>
+              A bulk write through this form would touch every artwork row;
+              we&apos;re holding it until role-based access controls land on
+              the admin so the action is appropriately gated.
+            </p>
+          </div>
 
-          <code className="block bg-gray-100 p-3 rounded text-sm mb-6 text-gray-900">
-            npm run import:csv
-          </code>
+          <button
+            type="button"
+            disabled
+            className="button-primary opacity-50 cursor-not-allowed"
+            title="Disabled until RBAC is in place"
+          >
+            Choose CSV…
+          </button>
 
-          <p className="text-sm text-gray-600">
-            CSV files should include: Title, Artist First Name, Artist Last
-            Name, Date Created, Medium, Height, Width, Depth, Inventory Number,
-            Tags, and On Website columns.
+          <p className="text-xs text-gray-500 mt-4">
+            In the meantime, run the script from a terminal:{" "}
+            <code className="bg-gray-100 px-1 rounded">npm run import:csv</code>
           </p>
         </div>
       </div>

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -39,7 +39,7 @@ export default async function AdminLayout({ children }: AdminLayoutProps) {
   return (
     <div className="flex min-h-screen bg-gray-100">
       {/* Sidebar */}
-      <aside className="w-64 bg-gray-900 text-white">
+      <aside className="w-64 bg-gray-900 text-white relative">
         <div className="p-6 border-b border-gray-700">
           <h1 className="text-xl font-bold">Admin Console</h1>
           <p className="text-sm text-gray-400 mt-2">

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -51,9 +51,7 @@ export default async function AdminLayout({ children }: AdminLayoutProps) {
           <NavLink href="/admin" label="Dashboard" />
           <NavLink href="/admin/artworks" label="Artworks" />
           <NavLink href="/admin/artists" label="Artists" />
-          <NavLink href="/admin/categories" label="Categories" />
           <NavLink href="/admin/import" label="Import/Export" />
-          <NavLink href="/admin/analytics" label="Analytics" />
         </nav>
 
         <div className="absolute bottom-6 left-6 right-6 pt-6 border-t border-gray-700">

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,57 +1,43 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { createServerSupabaseClient } from "@/lib/supabase/server";
-import { formatArtistName } from "@/lib/utils";
 
 async function getStats() {
   const supabase = createServerSupabaseClient();
 
-  const [artworksRes, artistsRes, categoriesRes, downloadsRes] =
+  const [activeArtworksRes, ephemeraRes, artistsRes, humanDescRes, audioRes] =
     await Promise.all([
       supabase
         .from("artworks")
         .select("*", { count: "exact", head: true })
-        .eq("on_website", true),
+        .eq("on_website", true)
+        .or("tags.is.null,tags.not.cs.{ephemera}"),
+      supabase
+        .from("artworks")
+        .select("*", { count: "exact", head: true })
+        .eq("on_website", true)
+        .contains("tags", ["ephemera"]),
       supabase
         .from("artists")
         .select("*", { count: "exact", head: true }),
       supabase
-        .from("categories")
-        .select("*", { count: "exact", head: true }),
+        .from("artworks")
+        .select("*", { count: "exact", head: true })
+        .eq("on_website", true)
+        .eq("description_origin", "human"),
       supabase
-        .from("download_events")
-        .select("*", { count: "exact", head: true }),
+        .from("artworks")
+        .select("*", { count: "exact", head: true })
+        .eq("on_website", true)
+        .not("audio_url", "is", null),
     ]);
 
   return {
-    artworks: artworksRes.count || 0,
+    artworks: activeArtworksRes.count || 0,
+    ephemera: ephemeraRes.count || 0,
     artists: artistsRes.count || 0,
-    categories: categoriesRes.count || 0,
-    downloads: downloadsRes.count || 0,
+    humanDescriptions: humanDescRes.count || 0,
+    audioPieces: audioRes.count || 0,
   };
-}
-
-async function getRecentDownloads() {
-  const supabase = createServerSupabaseClient();
-
-  const { data, error } = await supabase
-    .from("download_events")
-    .select(
-      `
-      id,
-      created_at,
-      user_agent,
-      artwork:artworks(id, title, artist_id, artist:artists(first_name, last_name))
-      `
-    )
-    .order("created_at", { ascending: false })
-    .limit(10);
-
-  if (error) {
-    console.error("Error fetching downloads:", error);
-    return [];
-  }
-
-  return data || [];
 }
 
 export const metadata = {
@@ -59,109 +45,29 @@ export const metadata = {
 };
 
 export default async function AdminDashboard() {
-  const [stats, recentDownloads] = await Promise.all([
-    getStats(),
-    getRecentDownloads(),
-  ]);
+  const stats = await getStats();
 
   return (
     <div>
       <h1 className="text-3xl font-bold text-gray-900 mb-8">Dashboard</h1>
 
-      {/* Stats Grid */}
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-8">
+      {/* Catalog snapshot */}
+      <div className="grid grid-cols-1 md:grid-cols-5 gap-4 mb-8">
+        <StatCard title="Active artworks" value={stats.artworks} color="blue" />
+        <StatCard title="Active ephemera" value={stats.ephemera} color="purple" />
+        <StatCard title="Artists" value={stats.artists} color="green" />
         <StatCard
-          title="Total Artworks"
-          value={stats.artworks}
-          color="blue"
-        />
-        <StatCard
-          title="Total Artists"
-          value={stats.artists}
+          title="Human descriptions"
+          value={stats.humanDescriptions}
           color="green"
         />
-        <StatCard
-          title="Categories"
-          value={stats.categories}
-          color="purple"
-        />
-        <StatCard
-          title="Downloads"
-          value={stats.downloads}
-          color="orange"
-        />
+        <StatCard title="With audio" value={stats.audioPieces} color="orange" />
       </div>
 
-      {/* Recent Downloads */}
-      <div className="bg-white rounded-lg shadow">
-        <div className="p-6 border-b border-gray-200">
-          <h2 className="text-xl font-bold text-gray-900">Recent Downloads</h2>
-        </div>
-
-        {recentDownloads.length > 0 ? (
-          <div className="overflow-x-auto">
-            <table className="w-full">
-              <thead className="bg-gray-50 border-b border-gray-200">
-                <tr>
-                  <th className="px-6 py-3 text-left text-xs font-bold text-gray-600 uppercase tracking-wider">
-                    Artwork
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-bold text-gray-600 uppercase tracking-wider">
-                    Artist
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-bold text-gray-600 uppercase tracking-wider">
-                    Downloaded
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-bold text-gray-600 uppercase tracking-wider">
-                    Device
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-200">
-                {recentDownloads.map((event: any) => {
-                  const artwork = event.artwork as any;
-                  return (
-                    <tr key={event.id} className="hover:bg-gray-50">
-                    <td className="px-6 py-4 text-sm text-gray-900">
-                      {artwork?.title || "Unknown"}
-                    </td>
-                    <td className="px-6 py-4 text-sm text-gray-600">
-                      {artwork?.artist
-                        ? formatArtistName(
-                            artwork.artist.first_name,
-                            artwork.artist.last_name
-                          )
-                        : "Unknown"}
-                    </td>
-                    <td className="px-6 py-4 text-sm text-gray-600">
-                      {new Date(event.created_at).toLocaleDateString(
-                        "en-US",
-                        {
-                          month: "short",
-                          day: "numeric",
-                          hour: "2-digit",
-                          minute: "2-digit",
-                        }
-                      )}
-                    </td>
-                    <td className="px-6 py-4 text-sm text-gray-600">
-                      <span className="text-xs bg-gray-100 px-2 py-1 rounded">
-                        {event.user_agent
-                          ? event.user_agent.substring(0, 40) + "..."
-                          : "Unknown"}
-                      </span>
-                    </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        ) : (
-          <div className="p-6 text-center text-gray-600">
-            No downloads yet.
-          </div>
-        )}
+      <div className="bg-white rounded-lg shadow p-6 text-sm text-gray-600">
+        Visitor analytics (page views, geography, audio plays, etc.) flow into
+        PostHog and aren&apos;t surfaced here yet — see open conversation about
+        which vanity stats to add.
       </div>
     </div>
   );

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,7 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import Link from "next/link";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
+import { hogql } from "@/lib/posthog-query";
+import { formatArtistName } from "@/lib/utils";
 
-async function getStats() {
+// Re-evaluate analytics every 5 minutes so the dashboard stays cheap to
+// load and PostHog isn't queried on every refresh.
+export const revalidate = 300;
+
+async function getCatalogStats() {
   const supabase = createServerSupabaseClient();
 
   const [activeArtworksRes, ephemeraRes, artistsRes, humanDescRes, audioRes] =
@@ -40,35 +47,243 @@ async function getStats() {
   };
 }
 
+async function getDownloadStats() {
+  const supabase = createServerSupabaseClient();
+  const since30 = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+  const since7 = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+  const [allTimeRes, last30Res, last7Res, topArtworksRes] = await Promise.all([
+    supabase.from("download_events").select("*", { count: "exact", head: true }),
+    supabase
+      .from("download_events")
+      .select("*", { count: "exact", head: true })
+      .gte("created_at", since30),
+    supabase
+      .from("download_events")
+      .select("*", { count: "exact", head: true })
+      .gte("created_at", since7),
+    // Top-downloaded artworks last 30 days. Group client-side because
+    // PostgREST aggregates are clunky.
+    supabase
+      .from("download_events")
+      .select("artwork_id, artwork:artworks(id, title, artist:artists(first_name, last_name))")
+      .gte("created_at", since30)
+      .limit(10000),
+  ]);
+
+  const counts = new Map<string, { artwork: any; count: number }>();
+  for (const row of (topArtworksRes.data as any[]) || []) {
+    const id = row.artwork_id;
+    if (!id || !row.artwork) continue;
+    const entry = counts.get(id);
+    if (entry) entry.count++;
+    else counts.set(id, { artwork: row.artwork, count: 1 });
+  }
+  const topArtworks = [...counts.values()].sort((a, b) => b.count - a.count).slice(0, 10);
+
+  return {
+    total: allTimeRes.count || 0,
+    last30: last30Res.count || 0,
+    last7: last7Res.count || 0,
+    topArtworks,
+  };
+}
+
+interface CountRow extends Array<unknown> {
+  0: number | string;
+}
+interface PathCountRow extends Array<unknown> {
+  0: string;
+  1: number | string;
+}
+interface CountryRow extends Array<unknown> {
+  0: string;
+  1: number | string;
+}
+
+async function getVisitorStats() {
+  // Three queries in parallel: total page views, unique visitors,
+  // geography breakdown. Each handles its own null fallback.
+  const [pvRes, uniqRes, geoRes] = await Promise.all([
+    hogql<CountRow>(
+      `SELECT count() FROM events WHERE event = '$pageview' AND timestamp >= now() - INTERVAL 30 DAY`
+    ),
+    hogql<CountRow>(
+      `SELECT uniq(distinct_id) FROM events WHERE event = '$pageview' AND timestamp >= now() - INTERVAL 30 DAY`
+    ),
+    hogql<CountryRow>(
+      `SELECT properties.$geoip_country_name AS country, uniq(distinct_id) AS visitors
+       FROM events
+       WHERE event = '$pageview' AND timestamp >= now() - INTERVAL 30 DAY
+         AND properties.$geoip_country_name != ''
+       GROUP BY country ORDER BY visitors DESC LIMIT 10`
+    ),
+  ]);
+
+  return {
+    pageViews: pvRes ? Number(pvRes.results?.[0]?.[0] ?? 0) : null,
+    uniqueVisitors: uniqRes ? Number(uniqRes.results?.[0]?.[0] ?? 0) : null,
+    geography: geoRes
+      ? geoRes.results.map((r) => ({ country: r[0], visitors: Number(r[1]) }))
+      : null,
+  };
+}
+
+async function getTopViewedArtworks() {
+  const phRes = await hogql<PathCountRow>(
+    `SELECT properties.$pathname AS path, count() AS views
+     FROM events
+     WHERE event = '$pageview'
+       AND timestamp >= now() - INTERVAL 30 DAY
+       AND properties.$pathname LIKE '/artwork/%'
+     GROUP BY path ORDER BY views DESC LIMIT 10`
+  );
+  if (!phRes) return null;
+
+  // Resolve UUIDs back to artwork titles.
+  const supabase = createServerSupabaseClient();
+  const ids = phRes.results
+    .map((r) => (typeof r[0] === "string" ? r[0].split("/artwork/")[1] : null))
+    .filter((id): id is string => !!id && /^[0-9a-f-]{36}$/i.test(id));
+  if (ids.length === 0) return [];
+
+  const { data: artworks } = await supabase
+    .from("artworks")
+    .select("id, title, artist:artists(first_name, last_name)")
+    .in("id", ids);
+  const byId = new Map((artworks || []).map((a: any) => [a.id, a]));
+
+  return phRes.results
+    .map((r) => {
+      const path = String(r[0]);
+      const id = path.split("/artwork/")[1];
+      const artwork = byId.get(id);
+      return artwork
+        ? { id, artwork, views: Number(r[1]) }
+        : { id, artwork: null, views: Number(r[1]) };
+    })
+    .filter((row) => row.artwork);
+}
+
 export const metadata = {
   title: "Dashboard | Admin | Creative Growth Gallery",
 };
 
 export default async function AdminDashboard() {
-  const stats = await getStats();
+  const [stats, downloads, visitors, topViewed] = await Promise.all([
+    getCatalogStats(),
+    getDownloadStats(),
+    getVisitorStats(),
+    getTopViewedArtworks(),
+  ]);
+
+  const phMissing = visitors.pageViews === null;
 
   return (
     <div>
       <h1 className="text-3xl font-bold text-gray-900 mb-8">Dashboard</h1>
 
       {/* Catalog snapshot */}
+      <h2 className="text-sm font-bold text-gray-600 uppercase tracking-wider mb-3">Catalog</h2>
       <div className="grid grid-cols-1 md:grid-cols-5 gap-4 mb-8">
         <StatCard title="Active artworks" value={stats.artworks} color="blue" />
         <StatCard title="Active ephemera" value={stats.ephemera} color="purple" />
         <StatCard title="Artists" value={stats.artists} color="green" />
-        <StatCard
-          title="Human descriptions"
-          value={stats.humanDescriptions}
-          color="green"
-        />
+        <StatCard title="Human descriptions" value={stats.humanDescriptions} color="green" />
         <StatCard title="With audio" value={stats.audioPieces} color="orange" />
       </div>
 
-      <div className="bg-white rounded-lg shadow p-6 text-sm text-gray-600">
-        Visitor analytics (page views, geography, audio plays, etc.) flow into
-        PostHog and aren&apos;t surfaced here yet — see open conversation about
-        which vanity stats to add.
+      {/* Activity */}
+      <h2 className="text-sm font-bold text-gray-600 uppercase tracking-wider mb-3">
+        Visitor activity (last 30 days)
+      </h2>
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-8">
+        <StatCard
+          title="Page views"
+          value={visitors.pageViews}
+          color="blue"
+          fallback={phMissing ? "PostHog not configured" : undefined}
+        />
+        <StatCard
+          title="Unique visitors"
+          value={visitors.uniqueVisitors}
+          color="green"
+          fallback={phMissing ? "PostHog not configured" : undefined}
+        />
+        <StatCard title="Downloads (30d)" value={downloads.last30} color="orange" />
+        <StatCard title="Downloads (7d)" value={downloads.last7} color="orange" />
       </div>
+
+      {/* Top tables */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+        <Card title="Most-viewed artworks (last 30d)">
+          {topViewed === null ? (
+            <EmptyNote>Waiting on PostHog data.</EmptyNote>
+          ) : topViewed.length === 0 ? (
+            <EmptyNote>No artwork pageviews recorded yet.</EmptyNote>
+          ) : (
+            <RankedList
+              items={topViewed.map((row) => ({
+                key: row.id,
+                primary: row.artwork.title,
+                secondary: row.artwork.artist
+                  ? formatArtistName(
+                      row.artwork.artist.first_name,
+                      row.artwork.artist.last_name
+                    )
+                  : "Unknown",
+                value: row.views,
+                href: `/artwork/${row.id}`,
+              }))}
+              valueLabel="views"
+            />
+          )}
+        </Card>
+
+        <Card title="Most-downloaded artworks (last 30d)">
+          {downloads.topArtworks.length === 0 ? (
+            <EmptyNote>No downloads in the last 30 days.</EmptyNote>
+          ) : (
+            <RankedList
+              items={downloads.topArtworks.map(({ artwork, count }) => ({
+                key: artwork.id,
+                primary: artwork.title,
+                secondary: artwork.artist
+                  ? formatArtistName(
+                      artwork.artist.first_name,
+                      artwork.artist.last_name
+                    )
+                  : "Unknown",
+                value: count,
+                href: `/artwork/${artwork.id}`,
+              }))}
+              valueLabel="downloads"
+            />
+          )}
+        </Card>
+      </div>
+
+      {/* Geography */}
+      <Card title="Geography (last 30d)">
+        {visitors.geography === null ? (
+          <EmptyNote>Waiting on PostHog data.</EmptyNote>
+        ) : visitors.geography.length === 0 ? (
+          <EmptyNote>No geo-located pageviews yet.</EmptyNote>
+        ) : (
+          <RankedList
+            items={visitors.geography.map((row) => ({
+              key: row.country,
+              primary: row.country,
+              value: row.visitors,
+            }))}
+            valueLabel="visitors"
+          />
+        )}
+      </Card>
+
+      <p className="text-xs text-gray-500 mt-6">
+        Visitor stats refresh every 5 minutes. Downloads track instantly.
+      </p>
     </div>
   );
 }
@@ -77,10 +292,12 @@ function StatCard({
   title,
   value,
   color,
+  fallback,
 }: {
   title: string;
-  value: number;
+  value: number | null;
   color: "blue" | "green" | "purple" | "orange";
+  fallback?: string;
 }) {
   const colorClasses = {
     blue: "bg-blue-50 text-blue-900 border-blue-200",
@@ -92,7 +309,65 @@ function StatCard({
   return (
     <div className={`${colorClasses[color]} p-6 rounded-lg border`}>
       <p className="text-sm font-medium opacity-75">{title}</p>
-      <p className="text-3xl font-bold mt-2">{value}</p>
+      {value === null ? (
+        <p className="text-sm mt-2 opacity-60 italic">{fallback || "—"}</p>
+      ) : (
+        <p className="text-3xl font-bold mt-2">{value.toLocaleString()}</p>
+      )}
     </div>
+  );
+}
+
+function Card({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="bg-white rounded-lg shadow">
+      <div className="p-6 border-b border-gray-200">
+        <h3 className="text-lg font-bold text-gray-900">{title}</h3>
+      </div>
+      <div className="p-6">{children}</div>
+    </div>
+  );
+}
+
+function EmptyNote({ children }: { children: React.ReactNode }) {
+  return <p className="text-sm text-gray-500 italic">{children}</p>;
+}
+
+interface RankedItem {
+  key: string;
+  primary: string;
+  secondary?: string;
+  value: number;
+  href?: string;
+}
+
+function RankedList({ items, valueLabel }: { items: RankedItem[]; valueLabel: string }) {
+  return (
+    <ol className="space-y-2">
+      {items.map((item, i) => (
+        <li key={item.key} className="flex items-center gap-3 text-sm">
+          <span className="w-6 text-right text-gray-400 font-mono">{i + 1}.</span>
+          <div className="flex-1 min-w-0">
+            {item.href ? (
+              <Link
+                href={item.href}
+                className="text-gray-900 hover:text-blue-600 truncate block"
+              >
+                {item.primary}
+              </Link>
+            ) : (
+              <span className="text-gray-900">{item.primary}</span>
+            )}
+            {item.secondary && (
+              <span className="text-xs text-gray-500">{item.secondary}</span>
+            )}
+          </div>
+          <span className="text-gray-600 font-medium tabular-nums">
+            {item.value.toLocaleString()}{" "}
+            <span className="text-xs font-normal text-gray-400">{valueLabel}</span>
+          </span>
+        </li>
+      ))}
+    </ol>
   );
 }

--- a/src/app/api/admin/artists/[id]/route.ts
+++ b/src/app/api/admin/artists/[id]/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin, adminSupabase } from "@/lib/admin-auth";
+
+export const maxDuration = 30;
+
+/**
+ * PATCH /api/admin/artists/[id]
+ *
+ * Partial update of an artist row. Uses service-role to bypass RLS.
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const unauthed = await requireAdmin();
+  if (unauthed) return unauthed;
+
+  try {
+    const { id } = await params;
+    const body = (await request.json()) as Record<string, unknown>;
+    const { error } = await adminSupabase()
+      .from("artists")
+      .update({ ...body, updated_at: new Date().toISOString() })
+      .eq("id", id);
+    if (error) throw error;
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("admin/artists PATCH error:", err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Update failed" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/admin/artworks/[id]/route.ts
+++ b/src/app/api/admin/artworks/[id]/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin, adminSupabase } from "@/lib/admin-auth";
+
+export const maxDuration = 30;
+
+/**
+ * PATCH /api/admin/artworks/[id]
+ *
+ * Partial update of an artwork row. Uses service-role to bypass RLS
+ * (route is gated by requireAdmin, so this is admin-only).
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const unauthed = await requireAdmin();
+  if (unauthed) return unauthed;
+
+  try {
+    const { id } = await params;
+    const body = (await request.json()) as Record<string, unknown>;
+    const { error } = await adminSupabase()
+      .from("artworks")
+      .update({ ...body, updated_at: new Date().toISOString() })
+      .eq("id", id);
+    if (error) throw error;
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("admin/artworks PATCH error:", err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Update failed" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/artwork/[id]/page.tsx
+++ b/src/app/artwork/[id]/page.tsx
@@ -272,7 +272,9 @@ export default async function ArtworkPage({ params, searchParams }: ArtworkPageP
                   </dd>
                 )}
                 {artwork.alt_text_long && (
-                  <dd className="text-gray-900 leading-relaxed">{artwork.alt_text_long}</dd>
+                  <dd className="text-gray-900 leading-relaxed max-h-72 overflow-y-auto pr-2">
+                    {artwork.alt_text_long}
+                  </dd>
                 )}
               </div>
             )}

--- a/src/lib/posthog-query.ts
+++ b/src/lib/posthog-query.ts
@@ -1,0 +1,50 @@
+/**
+ * Server-side HogQL query helper for the PostHog Query API.
+ * Used by the admin dashboard to surface visitor analytics.
+ *
+ * Reads:
+ *   - POSTHOG_PERSONAL_API_KEY  (auth)
+ *   - POSTHOG_PROJECT_ID        (numeric project id from PostHog → Settings)
+ *   - NEXT_PUBLIC_POSTHOG_HOST  (defaults to https://us.i.posthog.com)
+ *
+ * Returns null when env vars are missing or the request fails — the
+ * caller should treat that as "stats not available right now" and
+ * render gracefully.
+ */
+
+const HOST = process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://us.i.posthog.com";
+
+interface QueryResult<TRow = unknown[]> {
+  results: TRow[];
+}
+
+export async function hogql<TRow = unknown[]>(
+  query: string
+): Promise<QueryResult<TRow> | null> {
+  const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
+  const projectId = process.env.POSTHOG_PROJECT_ID;
+  if (!apiKey || !projectId) return null;
+
+  try {
+    const res = await fetch(`${HOST}/api/projects/${projectId}/query/`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        query: { kind: "HogQLQuery", query },
+      }),
+      // Don't let a slow PostHog block the dashboard for too long.
+      signal: AbortSignal.timeout(10000),
+    });
+    if (!res.ok) {
+      console.error(`PostHog query failed: ${res.status}`, await res.text().catch(() => ""));
+      return null;
+    }
+    return (await res.json()) as QueryResult<TRow>;
+  } catch (err) {
+    console.error("PostHog query error:", err);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

A grab bag of admin and small public-side polish.

### Admin /artworks list
- New search box at the top, single field, substring-matches across SKU + title + artist name. Wired to `?q=` so the URL preserves state. Caps results at 100 with a "refine your search" hint when more rows exist.
- Adds an SKU column so a search hit is easy to confirm at a glance.

### Edit Artwork / Edit Artist save flow
- Stays on the form on save instead of redirecting back to the list. Flashes a green "Saved." banner that auto-clears after ~3s.
- **Underlying fix discovered along the way**: the form save was using the browser anon-key Supabase client, which RLS gated. PostgREST returned 204 even though zero rows changed, so the save *looked* successful but the row never actually persisted. The list-redirect was hiding it; once we kept users on the form, edits visibly didn't stick. New `PATCH /api/admin/artworks/[id]` and `PATCH /api/admin/artists/[id]` routes use the existing service-role helper from the audio routes — same pattern, applied consistently.

### Admin sidebar + dashboard
- Sidebar: hide Categories and Analytics. Routes still exist but won't be discoverable.
- Sidebar: contain the absolute-positioned "View Gallery / Logout" footer to the sidebar (it had been bleeding a horizontal `border-t` across the whole page).
- Dashboard: drop the Downloads stat tile + Recent Downloads table. Replace with catalog-snapshot tiles (active artworks / ephemera / artists / human descriptions / audio coverage) and visitor-activity tiles backed by PostHog (page views, unique visitors) plus DB downloads (30d / 7d). Two ranked lists below: most-viewed artworks (PostHog $pageview events on `/artwork/{id}`, joined back to the DB for titles) and most-downloaded artworks. Geography card by country. Page revalidates every 5 minutes so PostHog isn't hit on every refresh.
- New helper `src/lib/posthog-query.ts` wraps the HogQL endpoint and returns null on missing env vars / errors, so the dashboard degrades gracefully on a fresh PostHog project (the cards say "Waiting on PostHog data" rather than crashing).

### Admin import
- Browser CSV import is stubbed disabled with explanatory copy. The CLI script (`npm run import:csv`) remains the supported path until RBAC lands and a destructive bulk-write through the admin form is appropriately gated.
- Export action is unchanged.

### Public artwork detail
- Cap the long visual-description prose at `max-h-72` with vertical scroll. Pages with very long descriptions were pushing everything else below the fold.

## New env vars

- `POSTHOG_PERSONAL_API_KEY` — auth for the PostHog Query API
- `POSTHOG_PROJECT_ID` — numeric project id (PostHog → Settings)

Both already added to `.env.local` and Vercel.

## Test plan

- [ ] `/admin/artworks?q=NS+399` returns Nicole Storm's piece; `?q=Storm` returns 3 matches; `?q=Untitled` shows the "showing first 100 — refine your search" hint.
- [ ] Edit an artwork title, save, confirm green "Saved." banner appears and the change persists on reload (no redirect).
- [ ] Edit an artist external_url via the picker, save, confirm same.
- [ ] `/admin` dashboard renders all six sections without errors. Visitor-stats cards either show numbers or a graceful "Waiting on PostHog data" message.
- [ ] `/admin/import` shows the CSV import as disabled.
- [ ] No "Categories" or "Analytics" links in the sidebar; no stray horizontal line across the page.
- [ ] Open `/artwork/c4593713-bdc8-441e-9c00-82e38af1d081` and confirm the long visual description is contained in a scrollable box rather than pushing the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)