### PR TITLE
Public search: include SKU substring alongside FTS

### DIFF
--- a/src/lib/collection-query.ts
+++ b/src/lib/collection-query.ts
@@ -152,10 +152,16 @@ function applyScalarFilters(
   q = applyCohort(q, cohort);
 
   if (except !== "q" && state.q) {
-    const safe = state.q.replace(/[&|!()<>:*]/g, " ").trim();
+    // Strip tsquery operators and the comma we use as the .or()
+    // clause separator below.
+    const safe = state.q.replace(/[&|!()<>:*,]/g, " ").trim();
     if (safe) {
       const tsq = safe.split(/\s+/).join(" & ");
-      q = q.textSearch("fts", tsq);
+      // Match either the FTS index (title / medium / alt_text /
+      // alt_text_long) OR an SKU substring. SKU isn't in the
+      // tsvector and visitors often paste "NS 399"-style codes
+      // straight into the search box.
+      q = q.or(`fts.fts.${tsq},sku.ilike.%${safe}%`);
     }
   }
   if (except !== "decades" && state.decades.length) {


### PR DESCRIPTION
## Summary

The public collection search (`?q=...`) uses a Postgres FTS index over title / medium / alt_text / alt_text_long. SKU isn't indexed, so a visitor who pastes a code like \`NS 399\` got zero results even when the artwork is in the catalog.

This PR extends the search clause in \`applyScalarFilters\` to OR the existing FTS hit with a case-insensitive SKU substring match. Same query, no schema change. Also strips commas from the sanitized query (they're now significant as the \`.or()\` clause separator).

## Smoke-tested

| Query | Before | After |
|---|---|---|
| \`NS 399\` | 0 | 1 |
| \`KD 111\` | 0 | 1 |
| \`CLIR2024\` | 0 | 31 |
| \`ink\` | 708 | 708 |
| \`pastel\` | 301 | 301 |
| \`Nicole\` | 2 | 2 |

FTS-only queries are unchanged; SKU queries now resolve.

## Test plan

- [ ] Visit \`/?q=NS+399\` and confirm Nicole Storm's piece appears.
- [ ] Visit \`/?q=ink\` and confirm the existing ~700 results still render.
- [ ] Try a partial SKU prefix like \`?q=CLIR2024\` — should narrow to that subset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)