### PR TITLE
Fix: admin subscribers page returning empty (force dynamic)

### DIFF
--- a/src/app/admin/subscribers/page.tsx
+++ b/src/app/admin/subscribers/page.tsx
@@ -4,6 +4,11 @@ export const metadata = {
   title: "Subscribers | Admin | Creative Growth Gallery",
 };
 
+// Always render fresh — the table changes on every public signup,
+// and Next would otherwise cache the build-time snapshot (which is
+// empty because the build env can't reach prod data).
+export const dynamic = "force-dynamic";
+
 interface SignupRow {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary

Hotfix — \`/admin/subscribers\` was being statically rendered at build time, so it served an empty snapshot regardless of how many signups landed in the DB. Marking it \`force-dynamic\` so each request re-queries.

Caught when a real public signup landed cleanly in the DB but didn't appear on the admin page.

## Test plan

- [ ] Sign up via the footer form
- [ ] Visit \`/admin/subscribers\` — row should appear immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)