### PR TITLE
Fix: footer email link color contrast (WCAG AA)

### DIFF
--- a/public/cg-footer.css
+++ b/public/cg-footer.css
@@ -78,6 +78,22 @@
   color: inherit;
 }
 
+/* WCAG AA color-contrast fix.
+ *
+ * CG's footer markup hardcodes the email link to rgba(40,176,77,1)
+ * (#28b04d). Against the footer's #f0f0f0 background that's a 2.48:1
+ * ratio — well below AA's 4.5:1 minimum and the single largest source
+ * of contrast violations in our axe audit (~2,355 instances across
+ * artwork + artist + index pages).
+ *
+ * Swap to #1f6c2c — the darker green CG already uses for the donate
+ * button hover state, so it stays brand-coherent — which gives a
+ * 5.6:1 ratio (AA pass for normal text). Inline style takes precedence
+ * unless we use !important. */
+.cg-footer-wrapper span[style*="rgba(40,176,77"] {
+  color: #1f6c2c !important;
+}
+
 /* Donate button — solid green pill, matches CG */
 .cg-footer-wrapper .btn--whitelabel {
   display: inline-block;


### PR DESCRIPTION
## Summary

Single-rule fix that clears the largest source of accessibility violations in our latest audit: the \`gallery@creativegrowth.org\` link in the footer.

CG's markup hardcodes the link to \`rgba(40,176,77,1)\` (\`#28b04d\`) inline. Against our \`#f0f0f0\` footer background that's a 2.49:1 contrast ratio — well below WCAG AA's 4.5:1 minimum, and showing up as ~2,355 instances across every artwork, artist, and index page in the audit.

Swapped to \`#1f6c2c\` — the darker green CG already uses for the donate-button hover state, so it stays brand-coherent — for a 5.69:1 ratio (AA comfortably passes).

## Verification

Local axe-core scan (system Chrome) against /, /artists, /ephemera, an artist detail, and an artwork detail: **zero** remaining \`color-contrast\` violations. Will re-run the full \`cg_a11y_v2\` audit against the deploy preview after merge to confirm DB numbers match.

## Audit baseline → after estimate

| | Before | After (estimated) |
|---|---|---|
| Total extrapolated violations | 4,598 | ~2,243 |
| color-contrast (serious) | ~2,358 | 0 |

Other open work tracked separately:
- \`dlitem\` on artwork detail (~2,120)
- \`scrollable-region-focusable\` on description scroll-box (~112)
- Unlabeled inputs + heading-order on Home/Ephemera (8 critical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)