### PR TITLE
Fix: wrap artwork detail metadata in <dl> (WCAG AA)

### DIFF
--- a/src/app/artwork/[id]/page.tsx
+++ b/src/app/artwork/[id]/page.tsx
@@ -211,8 +211,10 @@ export default async function ArtworkPage({ params, searchParams }: ArtworkPageP
             </div>
           )}
 
-          {/* Details */}
-          <div className="space-y-4 mb-6 pb-6 border-b border-gray-200">
+          {/* Details — wrapper is <dl> so each <dt>/<dd> pair has a
+           * proper definition-list ancestor (required by axe's
+           * `dlitem` rule). Inner <div> grouping is legal per HTML5. */}
+          <dl className="space-y-4 mb-6 pb-6 border-b border-gray-200">
             {artwork.date_created && (
               <div>
                 <dt className="text-sm font-semibold text-gray-600">Date</dt>
@@ -278,7 +280,7 @@ export default async function ArtworkPage({ params, searchParams }: ArtworkPageP
                 )}
               </div>
             )}
-          </div>
+          </dl>
 
           {/* Download Button */}
           <DownloadButton artworkId={artwork.id} title={artwork.title} />


### PR DESCRIPTION
## Summary

The artwork detail page renders its metadata block (Date / Medium / Dimensions / Categories / Visual description) as \`<dt>/<dd>\` pairs, but the outer wrapper was a plain \`<div>\`. axe's \`dlitem\` rule requires each \`<dt>/<dd>\` to have a \`<dl>\` ancestor — flagged ~2,120 instances across the catalog (95 of 100 sampled pages in the latest audit).

Single-line fix: change the outer wrapper from \`<div>\` to \`<dl>\`. Inner \`<div>\` per-row groupings stay (HTML5 explicitly allows them inside \`<dl>\`), so the visual layout is unchanged.

## Verification

Local axe scan against two artwork detail pages: zero \`dlitem\` violations. Will re-run the full audit after merge.

## Audit progress

| | Initial | After contrast fix | After this fix (estimated) |
|---|---|---|---|
| Total extrapolated violations | 4,598 | 2,240 | ~120 |

What's left after this:
- \`scrollable-region-focusable\` on the description scroll-box (~112)
- 4 critical unlabeled-input + contrast issues on Home + Ephemera (8 total)
- 2 \`heading-order\` warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)