### PR TITLE
Fix: make visual description scroll-box keyboard-focusable (WCAG AA)

### DIFF
--- a/src/app/artwork/[id]/page.tsx
+++ b/src/app/artwork/[id]/page.tsx
@@ -274,7 +274,16 @@ export default async function ArtworkPage({ params, searchParams }: ArtworkPageP
                   </dd>
                 )}
                 {artwork.alt_text_long && (
-                  <dd className="text-gray-900 leading-relaxed max-h-72 overflow-y-auto pr-2">
+                  // Scrollable region needs tabindex=0 so keyboard
+                  // users can focus it and use arrow keys to scroll
+                  // (axe `scrollable-region-focusable`). role+label
+                  // give screen readers a name for the region.
+                  <dd
+                    className="text-gray-900 leading-relaxed max-h-72 overflow-y-auto pr-2"
+                    tabIndex={0}
+                    role="region"
+                    aria-label="Visual description"
+                  >
                     {artwork.alt_text_long}
                   </dd>
                 )}


### PR DESCRIPTION
## Summary

The visual description \`<dd>\` on artwork detail pages uses \`max-h-72 + overflow-y-auto\` for long descriptions, but without \`tabindex\` keyboard users couldn't focus the region to scroll its content. axe's \`scrollable-region-focusable\` rule flagged this on ~112 artwork pages (5 of 100 sampled — the artworks with descriptions long enough to actually trigger scrolling).

Add \`tabIndex={0}\` plus \`role="region"\` + \`aria-label="Visual description"\` so screen readers also announce it as a named landmark.

## Verification

Local axe scan against the two artworks with the longest \`alt_text_long\` (469 chars + 283 chars — both clearly trigger the scroll): zero \`scrollable-region-focusable\` violations.

## Audit progress

| | Initial | After contrast | After dl-wrap | After this fix (estimated) |
|---|---|---|---|---|
| Total extrapolated violations | 4,598 | 2,240 | ~120 | ~8 |

What's left after this:
- 4 critical unlabeled-input warnings on Home + Ephemera (search/filter)
- 2 critical contrast warnings (pa11y G18) on Home + Ephemera
- 2 \`heading-order\` warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)