### PR TITLE
Fix: clear remaining Home + Ephemera a11y violations

### DIFF
--- a/src/components/ArtworkCard.tsx
+++ b/src/components/ArtworkCard.tsx
@@ -33,9 +33,13 @@ export default function ArtworkCard({ artwork }: ArtworkCardProps) {
           )}
         </div>
 
-        <h3 className="font-serif font-semibold text-gray-900 group-hover:text-blue-600 transition-colors line-clamp-2">
+        {/* h2 (was h3) so the page heading hierarchy doesn't skip levels
+         * on Home + Ephemera, which only have an <h1> above the grid.
+         * On detail pages where this card sits under another <h2>, the
+         * h2→h2 sequence is fine — axe `heading-order` only flags jumps. */}
+        <h2 className="font-serif font-semibold text-gray-900 group-hover:text-blue-600 transition-colors line-clamp-2">
           {artwork.title}
-        </h3>
+        </h2>
         <p className="text-sm text-gray-600 mt-1">{artistName}</p>
       </article>
     </Link>

--- a/src/components/CohortNav.tsx
+++ b/src/components/CohortNav.tsx
@@ -5,18 +5,29 @@ interface CohortNavProps {
 }
 
 export default function CohortNav({ active }: CohortNavProps) {
+  // Separator is a CSS border (no text node) so there's no character
+  // to fail color-contrast checks. Decorative-only by construction.
   return (
-    <div className="flex items-center gap-2 text-sm">
+    <div className="flex items-center text-sm">
       <Link
         href="/"
-        className={active === "artwork" ? "text-green-700 font-semibold" : "text-gray-500 hover:text-gray-900"}
+        className={
+          "pr-3 " +
+          (active === "artwork"
+            ? "text-green-700 font-semibold"
+            : "text-gray-500 hover:text-gray-900")
+        }
       >
         Artwork
       </Link>
-      <span className="text-gray-300">|</span>
       <Link
         href="/ephemera"
-        className={active === "ephemera" ? "text-green-700 font-semibold" : "text-gray-500 hover:text-gray-900"}
+        className={
+          "pl-3 border-l border-gray-300 " +
+          (active === "ephemera"
+            ? "text-green-700 font-semibold"
+            : "text-gray-500 hover:text-gray-900")
+        }
       >
         Ephemera
       </Link>

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -91,6 +91,7 @@ export default function FilterBar({
             value={searchInput}
             onChange={(e) => setSearchInput(e.target.value)}
             placeholder="Search artwork & artists"
+            aria-label="Search artwork and artists"
             className="border border-gray-400 rounded-md pl-4 pr-10 py-2 text-sm w-80 focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
           <button type="submit" className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-700" aria-label="Search">


### PR DESCRIPTION
## Summary

Three small, targeted fixes for the last batch of audit issues:

1. **ArtworkCard heading** — \`<h3>\` → \`<h2>\`. Home and Ephemera have only an \`<h1>\` above the grid, so cards-as-h3 was a heading-level skip (axe \`heading-order\`). On artwork/artist detail pages where cards sit under another \`<h2>\`, the resulting h2→h2 sequence is fine — axe only flags jumps.

2. **Search input label** — added \`aria-label="Search artwork and artists"\` to the input in \`FilterBar\`. Was relying on placeholder alone, which doesn't satisfy pa11y's \`H91.InputText.Name\` or \`F68\` rules.

3. **Cohort nav separator** — replaced the \`text-gray-300\` pipe character with a CSS \`border-l\` on the second link. The pipe was 1.47:1 contrast on white (well below AA); a CSS border has no text node so contrast checkers don't flag it.

## Verification

Both axe and pa11y locally on Home and Ephemera: **zero violations** on either page.

## Audit progress

| | Initial | After contrast | After dl-wrap | After scrollable | After this fix (estimated) |
|---|---|---|---|---|---|
| Total extrapolated violations | 4,598 | 2,240 | ~120 | ~8 | **0** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)