### PR TITLE
Ephemera grid: image-only cards (no title/artist line)

### DIFF
--- a/src/app/ephemera/page.tsx
+++ b/src/app/ephemera/page.tsx
@@ -64,7 +64,7 @@ export default async function EphemeraPage({ searchParams }: EphemeraPageProps) 
 
           <ArtworkGrid>
             {artworks.map((artwork) => (
-              <ArtworkCard key={artwork.id} artwork={artwork as any} />
+              <ArtworkCard key={artwork.id} artwork={artwork as any} imageOnly />
             ))}
           </ArtworkGrid>
 

--- a/src/components/ArtworkCard.tsx
+++ b/src/components/ArtworkCard.tsx
@@ -5,9 +5,14 @@ import { getAltText, formatArtistName, resolveImageUrl } from "@/lib/utils";
 
 interface ArtworkCardProps {
   artwork: Artwork & { artist?: { first_name: string; last_name: string } };
+  // Hide the title + artist line. Used on the ephemera grid where
+  // items don't have meaningful titles or artists, so showing them
+  // adds noise. The image's alt text still carries the accessible
+  // name for screen readers.
+  imageOnly?: boolean;
 }
 
-export default function ArtworkCard({ artwork }: ArtworkCardProps) {
+export default function ArtworkCard({ artwork, imageOnly = false }: ArtworkCardProps) {
   const altText = getAltText(artwork);
   const imageUrl = resolveImageUrl(artwork);
   const artistName = artwork.artist
@@ -15,9 +20,9 @@ export default function ArtworkCard({ artwork }: ArtworkCardProps) {
     : "Unknown Artist";
 
   return (
-    <Link href={`/artwork/${artwork.id}`}>
+    <Link href={`/artwork/${artwork.id}`} aria-label={imageOnly ? altText : undefined}>
       <article className="group cursor-pointer">
-        <div className="aspect-square relative bg-white overflow-hidden rounded-sm mb-3">
+        <div className={`aspect-square relative bg-white overflow-hidden rounded-sm${imageOnly ? "" : " mb-3"}`}>
           {imageUrl ? (
             <Image
               src={imageUrl}
@@ -33,14 +38,18 @@ export default function ArtworkCard({ artwork }: ArtworkCardProps) {
           )}
         </div>
 
-        {/* h2 (was h3) so the page heading hierarchy doesn't skip levels
-         * on Home + Ephemera, which only have an <h1> above the grid.
-         * On detail pages where this card sits under another <h2>, the
-         * h2→h2 sequence is fine — axe `heading-order` only flags jumps. */}
-        <h2 className="font-serif font-semibold text-gray-900 group-hover:text-blue-600 transition-colors line-clamp-2">
-          {artwork.title}
-        </h2>
-        <p className="text-sm text-gray-600 mt-1">{artistName}</p>
+        {!imageOnly && (
+          <>
+            {/* h2 (was h3) so the page heading hierarchy doesn't skip levels
+             * on Home + Ephemera, which only have an <h1> above the grid.
+             * On detail pages where this card sits under another <h2>, the
+             * h2→h2 sequence is fine — axe `heading-order` only flags jumps. */}
+            <h2 className="font-serif font-semibold text-gray-900 group-hover:text-blue-600 transition-colors line-clamp-2">
+              {artwork.title}
+            </h2>
+            <p className="text-sm text-gray-600 mt-1">{artistName}</p>
+          </>
+        )}
       </article>
     </Link>
   );


### PR DESCRIPTION
## Summary

Ephemera items in our catalog don't have meaningful titles or artists — most are auto-generated identifiers like "Ephemera 203" — so the title + artist line under each grid card was adding noise without information.

Add an \`imageOnly\` prop to \`ArtworkCard\` that suppresses the \`<h2>\` + artist line, and pass it from the ephemera page. Defaults to \`false\` so artwork grid pages (Home, artist detail, "More by Artist") are unchanged.

## Accessibility

- Image \`alt\` text still serves as the accessible name for screen readers (uses \`getAltText\`).
- The wrapping \`<Link>\` picks up that alt text via \`aria-label\` so the click target remains nameable in the accessibility tree.

## Test plan

- [ ] /ephemera — cards show only images, evenly spaced grid
- [ ] / and /artists/{slug} — cards still show title + artist as before
- [ ] Tab through /ephemera grid — each card is focusable and announces a meaningful name (the alt text)

## Audit note

Latest a11y re-run after the recent fixes is in flight. This PR doesn't touch the rules we cleared, so the count should hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)