### PR TITLE
Fix: drop invalid role/aria-label from description <dd>

### DIFF
--- a/src/app/artwork/[id]/page.tsx
+++ b/src/app/artwork/[id]/page.tsx
@@ -274,15 +274,17 @@ export default async function ArtworkPage({ params, searchParams }: ArtworkPageP
                   </dd>
                 )}
                 {artwork.alt_text_long && (
-                  // Scrollable region needs tabindex=0 so keyboard
-                  // users can focus it and use arrow keys to scroll
-                  // (axe `scrollable-region-focusable`). role+label
-                  // give screen readers a name for the region.
+                  // tabindex=0 makes the scrollable region keyboard
+                  // focusable (axe `scrollable-region-focusable`).
+                  // Don't add role="region" / aria-label here — <dd>
+                  // doesn't accept arbitrary roles (axe
+                  // `aria-allowed-role`) and an explicit role would
+                  // also break the parent <dl>'s valid-child contract
+                  // (axe `definition-list`). The dd is already named
+                  // by its sibling <dt> "Visual description" above.
                   <dd
                     className="text-gray-900 leading-relaxed max-h-72 overflow-y-auto pr-2"
                     tabIndex={0}
-                    role="region"
-                    aria-label="Visual description"
                   >
                     {artwork.alt_text_long}
                   </dd>


### PR DESCRIPTION
## Summary

Latest audit (892 violations remaining, all on Artwork Detail) caught two regressions from the earlier scrollable-region fix:

- \`aria-allowed-role\` (~446) — \`<dd>\` doesn't accept arbitrary roles like \`"region"\`; its implicit role is \`"definition"\`
- \`definition-list\` (~446) — adding an explicit role on the \`<dd>\` broke the parent \`<dl>\`'s valid-child contract; axe no longer counted it as a real dd

Both were caused by the \`role="region"\` + \`aria-label\` I added to the description \`<dd>\`. Keep the \`tabIndex={0}\` (the only thing axe \`scrollable-region-focusable\` actually needs); the dd is already named for screen readers by its sibling \`<dt>\` "Visual description" via the dl association.

## Verification

Local axe scan against artwork pages with long + short descriptions: **zero** violations. Will re-run the full audit after merge to confirm the count lands at zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)