### PR TITLE
Style + nav tweaks: full title, green primary button, breadcrumbs

### DIFF
--- a/src/app/artwork/[id]/page.tsx
+++ b/src/app/artwork/[id]/page.tsx
@@ -140,21 +140,32 @@ export default async function ArtworkPage({ params, searchParams }: ArtworkPageP
 
   return (
     <div className="container-max py-12">
-      {/* Site title — links to the welcome page. Not an <h1> because
-       * the artwork's own title owns that role on this page. */}
-      <Link
-        href="/"
-        className="block text-4xl md:text-5xl font-bold text-gray-900 tracking-tight uppercase mb-6 hover:text-blue-600 transition-colors"
+      {/* Site title — plain text on this page; navigation lives in
+       * the breadcrumb below. Not an <h1> because the artwork's own
+       * title owns that role. */}
+      <div
+        className="text-4xl md:text-5xl font-bold text-gray-900 tracking-tight uppercase mb-6"
         style={{ fontFamily: '"Borna", sans-serif' }}
       >
         Creative Growth Public Archive
-      </Link>
+      </div>
 
       {/* Breadcrumb */}
       <nav
         aria-label="Breadcrumb"
         className="text-sm text-gray-600 mb-8 flex gap-2 flex-wrap"
       >
+        <a
+          href="https://www.creativegrowth.org"
+          className="hover:text-blue-600"
+        >
+          Home
+        </a>
+        <span>/</span>
+        <Link href="/" className="hover:text-blue-600">
+          Archive
+        </Link>
+        <span>/</span>
         <Link href="/collection" className="hover:text-blue-600">
           Collection
         </Link>

--- a/src/app/artwork/[id]/page.tsx
+++ b/src/app/artwork/[id]/page.tsx
@@ -315,7 +315,7 @@ export default async function ArtworkPage({ params, searchParams }: ArtworkPageP
       {more.items.length > 0 && (
         <section className="mt-16 pt-16 border-t border-gray-200">
           <h2 className="font-serif text-2xl font-bold text-gray-900 mb-8">
-            More by {artistName}
+            More works by {artistName} in the archive
           </h2>
           <ArtworkGrid columns="3">
             {more.items.map((art) => (

--- a/src/app/artwork/[id]/page.tsx
+++ b/src/app/artwork/[id]/page.tsx
@@ -144,7 +144,7 @@ export default async function ArtworkPage({ params, searchParams }: ArtworkPageP
        * the artwork's own title owns that role on this page. */}
       <Link
         href="/"
-        className="block text-2xl md:text-4xl font-bold text-gray-900 tracking-tight uppercase mb-6 hover:text-blue-600 transition-colors"
+        className="block text-4xl md:text-5xl font-bold text-gray-900 tracking-tight uppercase mb-6 hover:text-blue-600 transition-colors"
         style={{ fontFamily: '"Borna", sans-serif' }}
       >
         Creative Growth Public Archive

--- a/src/app/artwork/[id]/page.tsx
+++ b/src/app/artwork/[id]/page.tsx
@@ -140,6 +140,16 @@ export default async function ArtworkPage({ params, searchParams }: ArtworkPageP
 
   return (
     <div className="container-max py-12">
+      {/* Site title — links to the welcome page. Not an <h1> because
+       * the artwork's own title owns that role on this page. */}
+      <Link
+        href="/"
+        className="block text-2xl md:text-4xl font-bold text-gray-900 tracking-tight uppercase mb-6 hover:text-blue-600 transition-colors"
+        style={{ fontFamily: '"Borna", sans-serif' }}
+      >
+        Creative Growth Public Archive
+      </Link>
+
       {/* Breadcrumb */}
       <nav
         aria-label="Breadcrumb"

--- a/src/app/artwork/[id]/page.tsx
+++ b/src/app/artwork/[id]/page.tsx
@@ -308,6 +308,11 @@ export default async function ArtworkPage({ params, searchParams }: ArtworkPageP
 
           {/* Download Button */}
           <DownloadButton artworkId={artwork.id} title={artwork.title} />
+          <p className="text-xs italic text-gray-600 mt-3 leading-relaxed">
+            The images in this archive are open source and a part of the
+            public domain. Anyone can use these images for educational,
+            scholarly, or charitable purposes.
+          </p>
         </div>
       </div>
 

--- a/src/app/artwork/[id]/page.tsx
+++ b/src/app/artwork/[id]/page.tsx
@@ -195,7 +195,10 @@ export default async function ArtworkPage({ params, searchParams }: ArtworkPageP
 
         {/* Metadata */}
         <div>
-          <h1 className="font-serif text-3xl font-bold text-gray-900 mb-4">
+          <h1
+            className="text-3xl font-bold text-gray-900 mb-4"
+            style={{ fontFamily: '"Borna", sans-serif' }}
+          >
             {artwork.title}
           </h1>
 

--- a/src/app/collection/page.tsx
+++ b/src/app/collection/page.tsx
@@ -65,7 +65,7 @@ export default async function CollectionPage({ searchParams }: CollectionPagePro
     <div className="container-max py-12">
       <div className="flex items-baseline justify-between gap-6 mb-6 flex-wrap">
         <h1
-          className="text-3xl md:text-5xl font-bold text-gray-900 tracking-tight uppercase"
+          className="text-4xl md:text-5xl font-bold text-gray-900 tracking-tight uppercase"
           style={{ fontFamily: '"Borna", sans-serif' }}
         >
           Creative Growth Public Archive

--- a/src/app/collection/page.tsx
+++ b/src/app/collection/page.tsx
@@ -64,7 +64,12 @@ export default async function CollectionPage({ searchParams }: CollectionPagePro
   return (
     <div className="container-max py-12">
       <div className="flex items-baseline justify-between gap-6 mb-6 flex-wrap">
-        <h1 className="font-sans text-5xl font-bold text-gray-900 tracking-tight">CGPA ARCHIVE</h1>
+        <h1
+          className="text-3xl md:text-5xl font-bold text-gray-900 tracking-tight uppercase"
+          style={{ fontFamily: '"Borna", sans-serif' }}
+        >
+          Creative Growth Public Archive
+        </h1>
         <CohortNav active="artwork" />
       </div>
 

--- a/src/app/collection/page.tsx
+++ b/src/app/collection/page.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import Link from "next/link";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import ArtworkGrid from "@/components/ArtworkGrid";
 import ArtworkCard from "@/components/ArtworkCard";
@@ -63,6 +64,20 @@ export default async function CollectionPage({ searchParams }: CollectionPagePro
 
   return (
     <div className="container-max py-12">
+      <nav
+        aria-label="Breadcrumb"
+        className="text-sm text-gray-600 mb-6 flex gap-2 flex-wrap"
+      >
+        <a href="https://www.creativegrowth.org" className="hover:text-blue-600">
+          Home
+        </a>
+        <span>/</span>
+        <Link href="/" className="hover:text-blue-600">
+          Archive
+        </Link>
+        <span>/</span>
+        <span className="text-gray-900 font-semibold">Collection</span>
+      </nav>
       <div className="flex items-baseline justify-between gap-6 mb-6 flex-wrap">
         <h1
           className="text-4xl md:text-5xl font-bold text-gray-900 tracking-tight uppercase"

--- a/src/app/ephemera/page.tsx
+++ b/src/app/ephemera/page.tsx
@@ -42,7 +42,7 @@ export default async function EphemeraPage({ searchParams }: EphemeraPageProps) 
     <div className="container-max py-12">
       <div className="flex items-baseline justify-between gap-6 mb-6 flex-wrap">
         <h1
-          className="text-3xl md:text-5xl font-bold text-gray-900 tracking-tight uppercase"
+          className="text-4xl md:text-5xl font-bold text-gray-900 tracking-tight uppercase"
           style={{ fontFamily: '"Borna", sans-serif' }}
         >
           Creative Growth Public Archive

--- a/src/app/ephemera/page.tsx
+++ b/src/app/ephemera/page.tsx
@@ -41,7 +41,12 @@ export default async function EphemeraPage({ searchParams }: EphemeraPageProps) 
   return (
     <div className="container-max py-12">
       <div className="flex items-baseline justify-between gap-6 mb-6 flex-wrap">
-        <h1 className="font-sans text-5xl font-bold text-gray-900 tracking-tight">CGPA ARCHIVE</h1>
+        <h1
+          className="text-3xl md:text-5xl font-bold text-gray-900 tracking-tight uppercase"
+          style={{ fontFamily: '"Borna", sans-serif' }}
+        >
+          Creative Growth Public Archive
+        </h1>
         <CohortNav active="ephemera" />
       </div>
 

--- a/src/app/ephemera/page.tsx
+++ b/src/app/ephemera/page.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import Link from "next/link";
 import { createServerSupabaseClient } from "@/lib/supabase/server";
 import ArtworkGrid from "@/components/ArtworkGrid";
 import ArtworkCard from "@/components/ArtworkCard";
@@ -40,6 +41,20 @@ export default async function EphemeraPage({ searchParams }: EphemeraPageProps) 
 
   return (
     <div className="container-max py-12">
+      <nav
+        aria-label="Breadcrumb"
+        className="text-sm text-gray-600 mb-6 flex gap-2 flex-wrap"
+      >
+        <a href="https://www.creativegrowth.org" className="hover:text-blue-600">
+          Home
+        </a>
+        <span>/</span>
+        <Link href="/" className="hover:text-blue-600">
+          Archive
+        </Link>
+        <span>/</span>
+        <span className="text-gray-900 font-semibold">Ephemera</span>
+      </nav>
       <div className="flex items-baseline justify-between gap-6 mb-6 flex-wrap">
         <h1
           className="text-4xl md:text-5xl font-bold text-gray-900 tracking-tight uppercase"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -99,8 +99,10 @@ h1, h2, h3, h4, h5, h6 {
     @apply text-blue-600 hover:text-blue-800 underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600;
   }
 
+  /* CG brand green — same #2c8b3d / #1f6c2c pair the donate button
+   * uses, so primary CTAs across the site feel like one family. */
   .button-primary {
-    @apply inline-flex items-center justify-center px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 transition-colors;
+    @apply inline-flex items-center justify-center px-4 py-2 bg-[#2c8b3d] text-white rounded hover:bg-[#1f6c2c] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2c8b3d] transition-colors;
   }
 
   .button-secondary {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -76,13 +76,11 @@ export default function HomePage() {
         </figure>
       </div>
 
-      <Link
-        href="/collection"
-        className="block bg-black text-white text-center italic text-4xl md:text-6xl py-10 md:py-14 mb-12 rounded-2xl hover:bg-gray-800 transition-colors"
-        style={{ fontFamily: '"Borna", sans-serif' }}
-      >
-        Explore the Archive Here
-      </Link>
+      <div className="mb-12">
+        <Link href="/collection" className="button-primary">
+          Explore
+        </Link>
+      </div>
 
       <p className="text-gray-700 leading-relaxed mb-4">
         Thank you to our friends Farley Gwazda, Katherine Sherwood, and Tara

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -59,6 +59,17 @@ export default function HomePage() {
             photographs, and slides. Search by artist, medium, decade,
             ephemera type, and other key categories.
           </p>
+
+          {/* Full-width primary CTA, scoped to the left column so it
+           * sits directly under the closing paragraph above. Same
+           * .button-primary green family as the download button; we
+           * just stretch it edge-to-edge and bump the type. */}
+          <Link
+            href="/collection"
+            className="button-primary w-full text-base md:text-lg tracking-widest py-3 mt-2"
+          >
+            EXPLORE THE ARCHIVE
+          </Link>
         </div>
 
         <figure className="md:pl-4">
@@ -74,12 +85,6 @@ export default function HomePage() {
             Artwork by Annika Miller.
           </figcaption>
         </figure>
-      </div>
-
-      <div className="mb-12">
-        <Link href="/collection" className="button-primary">
-          Explore
-        </Link>
       </div>
 
       <p className="text-gray-700 leading-relaxed mb-4">


### PR DESCRIPTION
## Summary

A pass of small visual + navigation tweaks across the public gallery pages.

### Site title
- Replace "CGPA ARCHIVE" with the full "Creative Growth Public Archive" on \`/collection\` and \`/ephemera\`.
- Add the same title as a banner on artwork-detail pages (plain text, not a link — navigation lives in the breadcrumb).
- Render in Borna everywhere; uniform \`text-4xl md:text-5xl\` size across all four placements.

### Primary button
- Flip \`.button-primary\` from generic blue to CG's brand green (\`#2c8b3d\` / \`#1f6c2c\` hover) — the same family as the donate button. The artwork-detail Download button picks up the new color automatically.
- Replace the giant black "Explore the Archive Here" hero with a wider green "EXPLORE THE ARCHIVE" button scoped to the homepage's left text column, sitting directly under the closing paragraph.

### Artwork detail copy
- Change "More by {artist}" → "More works by {artist} in the archive".
- Render artwork title in Borna.
- Add a small italic public-domain notice under the Download button: "The images in this archive are open source and a part of the public domain. Anyone can use these images for educational, scholarly, or charitable purposes."

### Breadcrumbs
- New breadcrumb on artwork detail: Home (creativegrowth.org) / Archive (/) / Collection (/collection) / {title}
- New breadcrumb on collection: Home / Archive / Collection
- New breadcrumb on ephemera: Home / Archive / Ephemera

## Test plan

- [ ] \`/\` — green "EXPLORE THE ARCHIVE" button spans the left column directly under the last paragraph
- [ ] \`/collection\` — breadcrumb at top; site title in Borna at the same size as homepage
- [ ] \`/ephemera\` — same
- [ ] Any \`/artwork/<id>\` — site title as plain text banner, breadcrumb with all four levels, Borna artwork title, public-domain notice under green Download button, "More works by {artist} in the archive" section heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)