### PR TITLE
feat(search): "with audio descriptions" toggle + discovery affordances

### DIFF
--- a/docs/superpowers/specs/2026-05-14-search-audio-descriptions-toggle-design.md
+++ b/docs/superpowers/specs/2026-05-14-search-audio-descriptions-toggle-design.md
@@ -1,0 +1,216 @@
+# Search — "With Audio Descriptions" Toggle — Design
+
+**Date:** 2026-05-14
+**Status:** Ready for implementation
+**Branch:** `feat/search-audio-descriptions-toggle`
+
+---
+
+## Goal
+
+Add a single binary filter to the `/collection` (and `/ephemera`) search that narrows results to artworks that have an audio description. The filter is exposed in the existing `FilterBar` as an icon + iOS-style toggle switch + small result-count, and is fully round-trippable via the URL param `audio=1`.
+
+The audio description program is small at launch (~20 of 2,000+ works), so the count is part of the control's visual affordance — it sets expectations before the user toggles.
+
+---
+
+## User flow
+
+1. User loads `/collection`. The audio toggle renders at the right end of the filter-pill row, in the OFF state, with a muted count showing how many works in the current filtered set have audio.
+2. User clicks the toggle. URL updates to `?audio=1` (preserving any other filters), server re-runs the query, results re-render filtered to audio-only works.
+3. User shares the URL. Recipient lands on the same filtered view; the toggle renders ON.
+4. User clicks the toggle again. `audio` param is dropped from the URL, results re-render unfiltered (by audio).
+5. User paginates while the filter is on. Pagination links preserve `audio=1`.
+
+---
+
+## URL state
+
+| Param | Type | Values | Canonical emission |
+|---|---|---|---|
+| `audio` | boolean | absence = false; `1`, `true`, `yes` (case-insensitive) = true; anything else = false | `audio=1` when on; param omitted when off |
+
+**Parsing is liberal; emission is canonical.** This keeps old shared links working if we ever change formats and ensures we never emit `audio=0` / `audio=false` (which would just be noise in the URL).
+
+The param composes with all existing filters (`q`, `theme`, `format`, `medium`, `decade`, `artist`, `sort`, `page`) via standard AND semantics — audio is just another conjunct.
+
+---
+
+## Filter semantics
+
+`(audio_url IS NOT NULL) AND (other filters…)` when `audio=1`. No constraint when off.
+
+`audio_origin` (`'human'` vs `'tts'`) is **not** part of this filter — both count as "has audio descriptions" for v1. A future enhancement could split them.
+
+---
+
+## Visual & interaction
+
+### Layout
+
+The control sits **inline at the right end of the filter-pill row** in `FilterBar`, after the Sort dropdown. On mobile, it wraps naturally with the rest of the filter pills.
+
+```
+[ Search artwork & artists  ⌕ ]  [Theme▾] [Format▾] [Artist▾] [Decade▾] [Sort▾]  🎧 ⚪ 23
+                                                                                  ^^^^^^^
+                                                                            new audio toggle
+```
+
+### Anatomy
+
+A single button containing three sub-elements, left to right:
+
+1. **Headphones icon** from `lucide-react` (16-18px, `currentColor`)
+2. **Toggle switch** — Tailwind-built iOS-style pill: ~32×18px, `bg-gray-300` when off, `bg-emerald-600` when on, white knob translates ~14px on toggle, ~150ms transition
+3. **Count** — small muted text (`text-xs text-gray-500`), e.g. `23`
+
+Whole control is a single `<button role="switch">` for accessibility — clicking anywhere on icon/switch/count toggles. The label "With audio descriptions" lives in `aria-label`; on hover, a native `title` tooltip shows `"With audio descriptions — 23 works"`.
+
+### Count semantics
+
+The count is **the number of works with audio descriptions in the current filtered set, ignoring the audio filter itself.** So:
+
+- On `/collection` with no other filters: shows the total number of audio works in the catalog (~20-23).
+- On `/collection?theme=animals`: shows the number of audio works that also match `theme=animals`.
+- When the toggle is ON, the count equals the result set size.
+- When the toggle is OFF, the count is "how many you'd get if you turned this on, given current filters."
+
+This mirrors the existing facet-count convention used by the multi-select dropdowns (counts assume all *other* filters are applied; the dimension's own filter is excluded from its own counts).
+
+### States
+
+| Condition | Treatment |
+|---|---|
+| `audio` param off, count > 0 | Toggle visible, off, count muted |
+| `audio` param on, count > 0 | Toggle visible, on (green), count in same muted style |
+| Count = 0 | Toggle visibly disabled (`opacity-40`, `cursor-not-allowed`), clicking does nothing. Prevents the user from filtering themselves into an empty state from an active filter combination. |
+| `audio` param on but combined with other filters yields 0 results | Toggle still shows the count (0). User clears the toggle or other filters to escape. |
+
+### No active-filter chip
+
+Unlike the multi-select filters, the audio toggle does **not** render a chip in the `ActiveFilterChips` row below. The toggle's own visual state (green vs gray) is the canonical "is this filter active" affordance — a duplicate chip would be confusingly redundant.
+
+"Clear all" in `ActiveFilterChips` does **not** clear the audio toggle (it's not a chip; consistent with how `q` and `sort` are also preserved). Users clear the toggle by clicking the toggle itself.
+
+---
+
+## Accessibility
+
+- **Role:** `<button role="switch" aria-checked={value}>`
+- **Label:** `aria-label="With audio descriptions"` (the count is *not* part of the label, since it changes constantly and would create chatty announcements; it's announced via `aria-describedby` pointing at the count text)
+- **Disabled state:** `aria-disabled="true"` when count is 0
+- **Keyboard:** Space and Enter toggle; standard button focus behavior; visible focus ring
+- **Color:** off/on distinction is reinforced by the knob position, not color alone (passes WCAG 1.4.1)
+- **Touch target:** minimum 32×32px hit area around the visible switch
+
+---
+
+## Components & files
+
+### New
+
+| File | Purpose |
+|---|---|
+| `src/components/AudioFilterToggle.tsx` | The client component: headphones icon + switch + count. Props: `value: boolean`, `count: number`, `onChange(next: boolean) => void`. Pure presentational + click handling. |
+
+### Modified
+
+| File | Change |
+|---|---|
+| `src/lib/filter-state.ts` | Add `audio: boolean` to `FilterState`. Parse `audio` param liberally (`1`/`true`/`yes` → true). Emit `audio=1` in `toQueryString` only when true (omit otherwise). |
+| `src/lib/collection-query.ts` | When `filters.audio === true`, add `.not("audio_url", "is", null)` to the artwork query. Also compute the audio-works count (number of rows matching all *other* current filters AND `audio_url IS NOT NULL`) and include it in the returned result alongside the existing facet counts. |
+| `src/components/FilterBar.tsx` | Render `<AudioFilterToggle>` at the right end of the filter row, after Sort. Wire `value` to `filters.audio`, `count` to `facetCounts.audio`, `onChange` to update state and trigger `router.push` with the new query string. |
+| `src/components/Pagination.tsx` | Add `audio` to `preserveParams` so page links keep the filter. |
+| `package.json` | Add dependency: `lucide-react@^0.x` (latest stable). |
+
+### Not modified
+
+- `src/components/ActiveFilterChips.tsx` — no change. Audio toggle is not a chip.
+- Database schema — no migrations. `artworks.audio_url` already exists.
+- `/ephemera` route — gets the toggle for free since it reuses `FilterBar`. Ephemera works generally won't have audio, so the count will be 0 most of the time and the control will render disabled. This is correct behavior; no special-case needed.
+
+---
+
+## Edge cases
+
+| Case | Handling |
+|---|---|
+| User visits `/collection?audio=1` but zero audio works exist (e.g., empty DB) | Toggle renders ON, count = 0, results empty. Existing empty-state UI shows. User can click the toggle to clear it, or use "Clear filters" in the empty state. |
+| User has filters active that exclude all audio works | Toggle renders disabled (count = 0). User clears other filters to enable it again. |
+| User passes `audio=0`, `audio=false`, `audio=anything` | Parsed as false. Param is stripped on next URL emission. |
+| User passes `audio=` (empty value) | Parsed as false. Stripped. |
+| `/ephemera` route with no audio works in ephemera | Toggle renders disabled. Correct. |
+| User toggles on, paginates to page 3, then toggles off | Page param resets to 1 (consistent with how every other filter change resets pagination — that behavior already exists in `FilterBar`'s `onChange` flow). |
+
+---
+
+## Testing
+
+### Unit (vitest)
+
+In `src/lib/__tests__/filter-state.test.ts` (or wherever existing tests live):
+
+- `parseSearchParams({ audio: '1' })` → `{ audio: true, ... }`
+- `parseSearchParams({ audio: 'true' })` → `{ audio: true, ... }`
+- `parseSearchParams({ audio: 'yes' })` → `{ audio: true, ... }`
+- `parseSearchParams({ audio: '0' })` → `{ audio: false, ... }`
+- `parseSearchParams({})` → `{ audio: false, ... }`
+- `toQueryString({ audio: true, ... })` includes `audio=1`
+- `toQueryString({ audio: false, ... })` does NOT include `audio` key
+
+In `src/lib/__tests__/collection-query.test.ts` (creating if absent, otherwise extending):
+
+- When `filters.audio === true`, the Supabase query builder calls `.not("audio_url", "is", null)`. Mock the supabase client and assert the call.
+- When `filters.audio === false`, the builder does NOT call `.not("audio_url", ...)`.
+- Facet count returns `audio` key whose value is the count of audio works given other current filters (not counting the audio filter itself).
+
+### Component (vitest + jsdom or react testing library, whichever the project already uses)
+
+- `AudioFilterToggle` renders the count.
+- Clicking fires `onChange(true)` when value is false, `onChange(false)` when true.
+- `aria-checked` matches `value`.
+- `aria-label` is `"With audio descriptions"`.
+- When `count === 0`, the button is `aria-disabled="true"` and click does nothing.
+
+### Manual smoke (in browser, dev server)
+
+1. Visit `/collection`. Verify toggle renders, count is correct, off.
+2. Click toggle. URL becomes `?audio=1`. Results filter to audio works.
+3. Paginate (if there are enough audio works to paginate). URL preserves `audio=1`.
+4. Open artwork detail from filtered results, hit browser back. Toggle state restored.
+5. Copy URL with `?audio=1`, open in incognito. Toggle renders ON.
+6. Apply a theme filter that excludes all audio works. Toggle becomes disabled with count 0.
+7. Apply `theme=animals` + `audio=1`. URL has both params; results match both.
+8. On `/ephemera`, verify toggle renders (likely disabled, count 0).
+
+---
+
+## Out of scope (explicit)
+
+- **Distinguishing human-recorded vs TTS audio** in the filter UI. Both count as "has audio descriptions" for v1. A future split would likely be a small additional control (radio: All / Human / TTS).
+- **Visible audio affordance on artwork result cards.** Showing a small headphones glyph on cards that have audio is a worthy enhancement, but it's a separate visual decision (overlay vs. badge vs. corner icon) that warrants its own design pass.
+- **"Without audio" filter** — no demand and the UI cost (a 3-state control or a separate negation) isn't worth it.
+- **Analytics on toggle usage.** PostHog page-view tracking already captures the URL param indirectly; explicit event tracking can be a follow-up.
+- **Search query expansion to mention "audio" / "audio description" / "narration" matches** — the toggle is the canonical way to find audio works; FTS expansion is unnecessary.
+- **Caching the facet count.** Adding `count(*) WHERE audio_url IS NOT NULL` to each request is cheap at our scale (sub-ms with an appropriate partial index, and probably fine without one given the small audio set). Revisit if the catalog grows 10x.
+
+---
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| `lucide-react` adds a dependency for a single icon | Lucide is tree-shakable (per-icon ESM exports), so the bundle adds only the `Headphones` glyph (~1 KB). Acceptable, and sets us up for the next icon need without re-litigating the library choice. |
+| With only ~20 audio works, users may toggle on and feel the site is broken ("only 20 results?") | The visible count next to the toggle sets expectations before clicking. Mitigation is part of the design, not an after-the-fact fix. |
+| Tailwind-built iOS toggle is fiddly to get pixel-perfect across browsers | Use a tested pattern (Tailwind UI's headless switch idiom or a single-element pill with absolutely-positioned knob). Visual review on Chrome, Safari, Firefox before merging. |
+| Facet count query adds one extra trip to Supabase per page render | The query is `count(*) WHERE audio_url IS NOT NULL AND <other filters>`. At ~3k rows, sub-100ms. If we ever notice it on the timeline, we can fold it into the existing facet-count query block as a parallel promise. |
+| The toggle visually competes with the existing pill buttons (different control type in the same row) | Intentional — it *is* a different control (binary vs multi-select). The icon + count combination gives it a distinct silhouette that reads as "different kind of filter." Visual review during implementation will confirm. |
+
+---
+
+## Notes for the plan
+
+- The `AudioFilterToggle` component should be self-contained and unit-testable in isolation. Don't reach into `FilterState` from within it — it takes `value`/`count`/`onChange` and that's all.
+- When wiring into `FilterBar`, follow the same pattern the existing dropdowns use: update local `FilterState`, call the existing helper that emits the new URL and calls `router.push`. Don't introduce a new state management path.
+- For the iOS toggle styling, prefer a single `<span>` for the track and a single `<span>` for the knob (positioned absolutely). Avoid native `<input type="checkbox">` because styling the native control is brittle and we want full control over the visual.
+- The headphones icon size should match the existing dropdown chevrons' optical weight — start at 16px and adjust.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@supabase/ssr": "^0.10.0",
         "@supabase/supabase-js": "^2.101.1",
         "csv-parse": "^6.2.1",
+        "lucide-react": "^1.16.0",
         "next": "14.2.35",
         "pg": "^8.20.0",
         "playwright": "^1.59.1",
@@ -7822,6 +7823,14 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/lucide-react": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.16.0.tgz",
+      "integrity": "sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@supabase/ssr": "^0.10.0",
     "@supabase/supabase-js": "^2.101.1",
     "csv-parse": "^6.2.1",
+    "lucide-react": "^1.16.0",
     "next": "14.2.35",
     "pg": "^8.20.0",
     "playwright": "^1.59.1",

--- a/src/app/collection/page.tsx
+++ b/src/app/collection/page.tsx
@@ -96,6 +96,7 @@ export default async function CollectionPage({ searchParams }: CollectionPagePro
         mediumOptions={mediumOptions}
         decadeOptions={decadeOptions}
         artistOptions={artistOptions}
+        audioCount={facets.audio}
       />
 
       {artworks.length > 0 ? (
@@ -116,7 +117,7 @@ export default async function CollectionPage({ searchParams }: CollectionPagePro
               currentPage={state.page}
               totalPages={totalPages}
               baseUrl="/collection"
-              preserveParams={["q", "theme", "format", "medium", "decade", "artist", "sort"]}
+              preserveParams={["q", "theme", "format", "medium", "decade", "artist", "sort", "audio"]}
             />
           )}
         </>

--- a/src/app/ephemera/page.tsx
+++ b/src/app/ephemera/page.tsx
@@ -73,6 +73,7 @@ export default async function EphemeraPage({ searchParams }: EphemeraPageProps) 
         mediumOptions={[]}
         decadeOptions={[]}
         artistOptions={artistOptions}
+        audioCount={facets.audio}
       />
 
       {artworks.length > 0 ? (
@@ -93,7 +94,7 @@ export default async function EphemeraPage({ searchParams }: EphemeraPageProps) 
               currentPage={state.page}
               totalPages={totalPages}
               baseUrl="/ephemera"
-              preserveParams={["q", "artist", "sort"]}
+              preserveParams={["q", "artist", "sort", "audio"]}
             />
           )}
         </>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -70,6 +70,19 @@ export default function HomePage() {
           >
             EXPLORE THE ARCHIVE
           </Link>
+
+          <p className="text-sm text-gray-700 leading-relaxed pt-2">
+            A growing selection of works in the archive includes audio
+            descriptions — short narrations of each image for blind and
+            low-vision visitors, so the artwork can be experienced through
+            listening.
+          </p>
+          <Link
+            href="/collection?audio=1"
+            className="button-secondary w-full text-base md:text-lg tracking-widest py-3"
+          >
+            BROWSE WORKS WITH AUDIO DESCRIPTIONS
+          </Link>
         </div>
 
         <figure className="md:pl-4">

--- a/src/components/ArtworkCard.tsx
+++ b/src/components/ArtworkCard.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import Image from "next/image";
+import { Headphones } from "lucide-react";
 import { Artwork } from "@/lib/types";
 import { getAltText, formatArtistName, resolveImageUrl } from "@/lib/utils";
 
@@ -48,6 +49,12 @@ export default function ArtworkCard({ artwork, imageOnly = false }: ArtworkCardP
               {artwork.title}
             </h2>
             <p className="text-sm text-gray-600 mt-1">{artistName}</p>
+            {artwork.audio_url && (
+              <p className="mt-1 text-gray-500" title="Includes audio description">
+                <Headphones size={14} aria-hidden="true" className="inline-block align-text-bottom" />
+                <span className="sr-only">Includes audio description</span>
+              </p>
+            )}
           </>
         )}
       </article>

--- a/src/components/AudioFilterToggle.tsx
+++ b/src/components/AudioFilterToggle.tsx
@@ -1,0 +1,48 @@
+"use client";
+import { Headphones } from "lucide-react";
+
+interface AudioFilterToggleProps {
+  value: boolean;
+  count: number;
+  onChange: (next: boolean) => void;
+}
+
+export default function AudioFilterToggle({ value, count, onChange }: AudioFilterToggleProps) {
+  const disabled = count === 0 && !value;
+  const handleClick = () => {
+    if (disabled) return;
+    onChange(!value);
+  };
+
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={value}
+      aria-disabled={disabled || undefined}
+      aria-label="With audio descriptions"
+      title={`With audio descriptions — ${count} ${count === 1 ? "work" : "works"}`}
+      onClick={handleClick}
+      className={`inline-flex items-center gap-2 px-3 py-2 text-sm rounded-md border focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+        disabled
+          ? "border-gray-200 text-gray-400 cursor-not-allowed"
+          : "border-gray-400 text-gray-900 hover:bg-gray-50 cursor-pointer"
+      }`}
+    >
+      <Headphones size={16} aria-hidden="true" />
+      <span
+        className={`relative inline-block h-[18px] w-[32px] rounded-full transition-colors ${
+          value ? "bg-emerald-600" : disabled ? "bg-gray-200" : "bg-gray-300"
+        }`}
+        aria-hidden="true"
+      >
+        <span
+          className={`absolute top-[2px] h-[14px] w-[14px] rounded-full bg-white shadow transition-transform ${
+            value ? "translate-x-[16px]" : "translate-x-[2px]"
+          }`}
+        />
+      </span>
+      <span className="text-xs text-gray-500 tabular-nums">{count}</span>
+    </button>
+  );
+}

--- a/src/components/AudioFilterToggle.tsx
+++ b/src/components/AudioFilterToggle.tsx
@@ -31,15 +31,23 @@ export default function AudioFilterToggle({ value, count, onChange }: AudioFilte
     >
       <Headphones size={16} aria-hidden="true" />
       <span
-        className={`relative inline-block h-[18px] w-[32px] rounded-full transition-colors ${
-          value ? "bg-emerald-600" : disabled ? "bg-gray-200" : "bg-gray-300"
-        }`}
         aria-hidden="true"
+        className="relative inline-block rounded-full transition-colors flex-shrink-0"
+        style={{
+          width: 32,
+          height: 18,
+          backgroundColor: value ? "#059669" : disabled ? "#e5e7eb" : "#d1d5db",
+        }}
       >
         <span
-          className={`absolute top-[2px] h-[14px] w-[14px] rounded-full bg-white shadow transition-transform ${
-            value ? "translate-x-[16px]" : "translate-x-[2px]"
-          }`}
+          className="absolute rounded-full bg-white shadow"
+          style={{
+            top: 2,
+            left: value ? 16 : 2,
+            width: 14,
+            height: 14,
+            transition: "left 150ms ease",
+          }}
         />
       </span>
       <span className="text-xs text-gray-500 tabular-nums">{count}</span>

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -139,17 +139,17 @@ export default function FilterBar({
             onChange={(decades) => navigate({ ...state, decades })}
           />
         )}
+        <AudioFilterToggle
+          value={state.audio}
+          count={audioCount}
+          onChange={(audio) => navigate({ ...state, audio })}
+        />
 
-        <div className="ml-auto flex items-center gap-3">
+        <div className="ml-auto">
           <SortDropdown
             current={state.sort}
             searchActive={!!state.q}
             onChange={(sort) => navigate({ ...state, sort })}
-          />
-          <AudioFilterToggle
-            value={state.audio}
-            count={audioCount}
-            onChange={(audio) => navigate({ ...state, audio })}
           />
         </div>
       </div>

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -5,6 +5,7 @@ import MultiSelectDropdown from "./MultiSelectDropdown";
 import ArtistTypeaheadDropdown from "./ArtistTypeaheadDropdown";
 import SortDropdown from "./SortDropdown";
 import ActiveFilterChips from "./ActiveFilterChips";
+import AudioFilterToggle from "./AudioFilterToggle";
 import { FilterState, toQueryString } from "@/lib/filter-state";
 
 interface FilterBarProps {
@@ -15,6 +16,7 @@ interface FilterBarProps {
   mediumOptions: { value: string; label: string; count: number }[];
   decadeOptions: { value: string; label: string; count: number }[];
   artistOptions: { slug: string; name: string; available: boolean }[];
+  audioCount: number;
 }
 
 /**
@@ -29,6 +31,7 @@ export default function FilterBar({
   mediumOptions,
   decadeOptions,
   artistOptions,
+  audioCount,
 }: FilterBarProps) {
   const router = useRouter();
   const pathname = usePathname();
@@ -137,11 +140,16 @@ export default function FilterBar({
           />
         )}
 
-        <div className="ml-auto">
+        <div className="ml-auto flex items-center gap-3">
           <SortDropdown
             current={state.sort}
             searchActive={!!state.q}
             onChange={(sort) => navigate({ ...state, sort })}
+          />
+          <AudioFilterToggle
+            value={state.audio}
+            count={audioCount}
+            onChange={(audio) => navigate({ ...state, audio })}
           />
         </div>
       </div>

--- a/src/lib/collection-query.ts
+++ b/src/lib/collection-query.ts
@@ -48,12 +48,13 @@ export interface FacetCounts {
   mediums: Record<string, number>;
   decades: Record<string, number>;
   availableArtistSlugs: Set<string>;
+  audio: number;
 }
 
 const PAGE_SIZE = 24;
 const FETCH_PAGE = 1000;
 
-type ExceptDim = "themes" | "formats" | "mediums" | "decades" | "artist" | "q" | "none";
+type ExceptDim = "themes" | "formats" | "mediums" | "decades" | "artist" | "q" | "audio" | "none";
 
 /**
  * Page through all matching rows. PostgREST has a default `max-rows`
@@ -173,6 +174,9 @@ function applyScalarFilters(
     } else {
       q = q.eq("id", "00000000-0000-0000-0000-000000000000");
     }
+  }
+  if (except !== "audio" && state.audio) {
+    q = q.not("audio_url", "is", null);
   }
   return q;
 }
@@ -302,23 +306,25 @@ export async function getFacetCounts(
 ): Promise<FacetCounts> {
   const artistId = await resolveArtistId(supabase, state.artist);
 
-  const [themeIds, formatIds, mediumIds, decadeIds, artistIds] = await Promise.all([
+  const [themeIds, formatIds, mediumIds, decadeIds, artistIds, audioIds] = await Promise.all([
     candidateIdsExcept(supabase, state, cohort, artistId, "themes"),
     candidateIdsExcept(supabase, state, cohort, artistId, "formats"),
     candidateIdsExcept(supabase, state, cohort, artistId, "mediums"),
     candidateIdsExcept(supabase, state, cohort, artistId, "decades"),
     candidateIdsExcept(supabase, state, cohort, artistId, "artist"),
+    candidateIdsExcept(supabase, state, cohort, artistId, "audio"),
   ]);
 
-  const [themes, formats, mediums, decades, availableArtistSlugs] = await Promise.all([
+  const [themes, formats, mediums, decades, availableArtistSlugs, audio] = await Promise.all([
     countCategoriesForIds(supabase, themeIds, "theme"),
     countCategoriesForIds(supabase, formatIds, "format"),
     countCategoriesForIds(supabase, mediumIds, "medium"),
     countDecadesForIds(supabase, decadeIds),
     artistsForIds(supabase, artistIds),
+    countAudioForIds(supabase, audioIds),
   ]);
 
-  return { themes, formats, mediums, decades, availableArtistSlugs };
+  return { themes, formats, mediums, decades, availableArtistSlugs, audio };
 }
 
 async function candidateIdsExcept(
@@ -413,6 +419,21 @@ async function countDecadesForIds(
     if (row.decade) counts[row.decade] = (counts[row.decade] || 0) + 1;
   }
   return counts;
+}
+
+async function countAudioForIds(
+  supabase: SupabaseClient,
+  candidateIds: Set<string>
+): Promise<number> {
+  if (candidateIds.size === 0) return 0;
+  const rows = await fetchAllRows<{ id: string }>(() =>
+    supabase.from("artworks").select("id").not("audio_url", "is", null)
+  );
+  let n = 0;
+  for (const row of rows) {
+    if (candidateIds.has(row.id)) n++;
+  }
+  return n;
 }
 
 async function artistsForIds(

--- a/src/lib/collection-query.ts
+++ b/src/lib/collection-query.ts
@@ -39,6 +39,7 @@ export interface ArtworkResult {
   alt_text: string | null;
   alt_text_long: string | null;
   description_origin: "human" | "ai" | null;
+  audio_url: string | null;
   artist: { id: string; first_name: string; last_name: string; slug: string } | null;
 }
 
@@ -206,7 +207,7 @@ function applySingleDimEmbeddedFilter(
 }
 
 function buildSelect(hasCategoryEmbed: boolean, fields: "rich" | "id"): string {
-  const richFields = `id, sku, title, medium, date_created, decade, image_url, image_original, alt_text, alt_text_long, description_origin, sort_order, artist:artists(id, first_name, last_name, slug)`;
+  const richFields = `id, sku, title, medium, date_created, decade, image_url, image_original, alt_text, alt_text_long, description_origin, audio_url, sort_order, artist:artists(id, first_name, last_name, slug)`;
   const base = fields === "rich" ? richFields : "id";
   if (!hasCategoryEmbed) return base;
   return `${base}, artwork_categories!inner(category:categories!inner(slug, kind))`;

--- a/src/lib/filter-state.ts
+++ b/src/lib/filter-state.ts
@@ -14,6 +14,7 @@ export interface FilterState {
   decades: string[];
   artist: string | null;
   sort: SortKey | null;
+  audio: boolean;
   page: number;
 }
 
@@ -43,6 +44,11 @@ function parsePage(p: RawParam): number {
   return isNaN(v) || v < 1 ? 1 : v;
 }
 
+function parseBool(p: RawParam): boolean {
+  const v = pickFirst(p).toLowerCase();
+  return v === "1" || v === "true" || v === "yes";
+}
+
 export function parseSearchParams(params: Record<string, RawParam>): FilterState {
   return {
     q: pickFirst(params.q),
@@ -52,6 +58,7 @@ export function parseSearchParams(params: Record<string, RawParam>): FilterState
     decades: parseList(params.decade),
     artist: pickFirst(params.artist) || null,
     sort: parseSort(params.sort),
+    audio: parseBool(params.audio),
     page: parsePage(params.page),
   };
 }
@@ -65,6 +72,7 @@ export function toQueryString(state: FilterState): string {
   if (state.decades.length) out.set("decade", state.decades.join(","));
   if (state.artist) out.set("artist", state.artist);
   if (state.sort) out.set("sort", state.sort);
+  if (state.audio) out.set("audio", "1");
   if (state.page > 1) out.set("page", String(state.page));
   return out.toString();
 }

--- a/tests/lib/filter-state.test.ts
+++ b/tests/lib/filter-state.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { parseSearchParams, toQueryString } from "../../src/lib/filter-state";
+
+const baseState = {
+  q: "",
+  themes: [],
+  formats: [],
+  mediums: [],
+  decades: [],
+  artist: null,
+  sort: null,
+  audio: false,
+  page: 1,
+} as const;
+
+describe("filter-state audio param", () => {
+  it("parses audio=1 as true", () => {
+    expect(parseSearchParams({ audio: "1" }).audio).toBe(true);
+  });
+
+  it("parses audio=true as true", () => {
+    expect(parseSearchParams({ audio: "true" }).audio).toBe(true);
+  });
+
+  it("parses audio=yes (case-insensitive) as true", () => {
+    expect(parseSearchParams({ audio: "YES" }).audio).toBe(true);
+  });
+
+  it("parses absence as false", () => {
+    expect(parseSearchParams({}).audio).toBe(false);
+  });
+
+  it("parses audio=0 as false", () => {
+    expect(parseSearchParams({ audio: "0" }).audio).toBe(false);
+  });
+
+  it("parses audio=garbage as false", () => {
+    expect(parseSearchParams({ audio: "lol" }).audio).toBe(false);
+  });
+
+  it("emits audio=1 when true", () => {
+    const qs = toQueryString({ ...baseState, audio: true });
+    expect(qs).toBe("audio=1");
+  });
+
+  it("omits audio when false", () => {
+    const qs = toQueryString({ ...baseState, audio: false });
+    expect(qs).toBe("");
+  });
+
+  it("composes with other params", () => {
+    const qs = toQueryString({ ...baseState, q: "scott", themes: ["animals"], audio: true });
+    const params = new URLSearchParams(qs);
+    expect(params.get("q")).toBe("scott");
+    expect(params.get("theme")).toBe("animals");
+    expect(params.get("audio")).toBe("1");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a binary "with audio descriptions" filter to the FilterBar on `/collection` and `/ephemera`, exposed as a headphones icon + iOS-style toggle switch + result count, round-trippable via `?audio=1`.
- Adds a secondary "BROWSE WORKS WITH AUDIO DESCRIPTIONS" CTA on the homepage below the EXPLORE button, linking to `/collection?audio=1`, with placeholder context copy.
- Adds a small headphones indicator under the artist name on result cards whose `audio_url` is non-null.

## Detail

- `audio: boolean` added to `FilterState`; liberal parse (`1`/`true`/`yes`), canonical emit (`audio=1`).
- `applyScalarFilters` in `collection-query.ts` adds `.not("audio_url", "is", null)` when the filter is on.
- `FacetCounts` gains an `audio` field — the number of audio works in the current filter set, ignoring the audio filter itself. Sets expectations before the user toggles (~5–20 works of ~3,000 today).
- Toggle disabled at count 0 (e.g., on `/ephemera`, or when other filters yield no audio works).
- Audio param preserved in pagination on both routes.
- `lucide-react` added for the headphones glyph (single icon today; sets up future icon needs).
- Vitest cases cover `audio` param round-trip in `filter-state`.
- Copy on the homepage is placeholder — to be replaced with CG's preferred framing of the audio program.

Includes the design spec at `docs/superpowers/specs/2026-05-14-search-audio-descriptions-toggle-design.md`.

## Test plan

- [ ] `npm test` — vitest passes (existing footer-form tests + new filter-state cases)
- [ ] `npm run lint` clean
- [ ] `npm run build` clean
- [ ] Visit `/collection`; verify the toggle appears at the end of the filter-pill row (Sort still alone on the right), with the headphones icon, switch, and count
- [ ] Click the toggle on/off; URL gains/loses `audio=1`; result count drops to audio-only works
- [ ] Combine with other filters (e.g., `theme=animals&audio=1`) and verify composition
- [ ] Paginate while `audio=1` is active; URL preserves the param
- [ ] Share `/collection?audio=1` to a fresh tab — toggle renders ON
- [ ] Visit `/ephemera`; toggle renders disabled at count 0
- [ ] Result cards with audio show a small headphones icon under the artist name
- [ ] Homepage: secondary CTA renders below EXPLORE, links to `/collection?audio=1`
- [ ] Keyboard: focus the toggle, Space/Enter toggles
- [ ] Screen reader announces "With audio descriptions, switch, on/off"

🤖 Generated with [Claude Code](https://claude.com/claude-code)