### PR TITLE
feat(import): R2 url preservation, unpublish-missing, Untitled placeholder, ephemera case fix

### DIFF
--- a/scripts/data/medium-buckets.json
+++ b/scripts/data/medium-buckets.json
@@ -1043,6 +1043,32 @@
       "Oil pastel",
       "Acrylic",
       "Watercolor"
+    ],
+    "Acrylic and wood sculpture": [
+      "Acrylic",
+      "Wood"
+    ],
+    "Book": [
+      "Other"
+    ],
+    "Colored pencil and silkscreen on paper": [
+      "Colored pencil",
+      "Other"
+    ],
+    "Colored pencil, ink, and silkscreen on paper": [
+      "Colored pencil",
+      "Ink",
+      "Other"
+    ],
+    "Showcard": [
+      "Other"
+    ],
+    "Signed poster": [
+      "Other"
+    ],
+    "Textile and wood sculpture": [
+      "Fiber/Yarn",
+      "Wood"
     ]
   }
 }

--- a/scripts/import-csv.ts
+++ b/scripts/import-csv.ts
@@ -3,9 +3,16 @@
  * import-csv.ts
  *
  * Parses the Art Cloud CSV export and upserts artists + artworks into Supabase.
- * Run: npx tsx scripts/import-csv.ts [path-to-csv]
+ * Run: npx tsx scripts/import-csv.ts [path-to-csv] [--unpublish-missing] [--dry-run]
  *
  * Defaults to inventory_2026-04-02.csv in the project root.
+ *
+ * Flags:
+ *   --unpublish-missing  After import, set on_website=false on every row whose
+ *                        inventory_number is not in the CSV (and any visible
+ *                        row with a NULL inventory_number).
+ *   --dry-run            Only meaningful with --unpublish-missing. Reports the
+ *                        diff without writing.
  */
 
 import fs from "fs";
@@ -17,8 +24,14 @@ import { dateToDecade } from "../src/lib/decades";
 import { mediumToBuckets, BucketMap } from "./lib/medium-buckets";
 
 // ─── Config ───────────────────────────────────────────────────────────────
+const args = process.argv.slice(2);
+const flags = new Set(args.filter((a) => a.startsWith("--")));
+const positional = args.filter((a) => !a.startsWith("--"));
+
 const CSV_PATH =
-  process.argv[2] || path.join(__dirname, "..", "inventory_2026-04-02.csv");
+  positional[0] || path.join(__dirname, "..", "inventory_2026-04-02.csv");
+const UNPUBLISH_MISSING = flags.has("--unpublish-missing");
+const DRY_RUN = flags.has("--dry-run");
 
 const SUPABASE_URL =
   process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
@@ -186,7 +199,7 @@ async function main() {
         inventory_number: inventoryNumber,
         sku: row.SKU?.trim() || null,
         image_original: row.Image?.trim() || null,
-        image_url: row.Image?.trim() || null, // Will be updated after R2 migration
+        image_url: row.Image?.trim() || null,
         tags: parseTags(row.Tags),
         genre:
           row.Genre?.trim() && row.Genre.trim() !== "Unselected"
@@ -207,48 +220,91 @@ async function main() {
       );
 
       if (withInventory.length > 0) {
-        const { error } = await supabase
+        // Split by existence so we can strip image_url / image_original from
+        // the update path. PostgREST omits unspecified columns from the
+        // ON CONFLICT DO UPDATE SET clause, so existing R2 URLs survive.
+        const allInvNumbers = withInventory.map((r) => r.inventory_number!);
+        const { data: existing } = await supabase
           .from("artworks")
-          .upsert(withInventory, { onConflict: "inventory_number" });
+          .select("inventory_number")
+          .in("inventory_number", allInvNumbers);
+        const existingSet = new Set(
+          (existing || []).map((r) => r.inventory_number)
+        );
 
-        if (error) {
-          console.error(
-            `Error upserting artworks batch ${i / BATCH_SIZE + 1}:`,
-            error
-          );
-        } else {
-          artworkCount += withInventory.length;
+        const newRecords = withInventory.filter(
+          (r) => !existingSet.has(r.inventory_number)
+        );
+        const updateRecords = withInventory
+          .filter((r) => existingSet.has(r.inventory_number))
+          .map((r) => {
+            const u = { ...r };
+            delete u.image_url;
+            delete u.image_original;
+            return u;
+          });
 
+        let batchOk = true;
+
+        if (newRecords.length > 0) {
+          const { error } = await supabase
+            .from("artworks")
+            .upsert(newRecords, { onConflict: "inventory_number" });
+          if (error) {
+            console.error(
+              `Error inserting new artworks batch ${i / BATCH_SIZE + 1}:`,
+              error
+            );
+            batchOk = false;
+          } else {
+            artworkCount += newRecords.length;
+          }
+        }
+
+        if (updateRecords.length > 0) {
+          const { error } = await supabase
+            .from("artworks")
+            .upsert(updateRecords, { onConflict: "inventory_number" });
+          if (error) {
+            console.error(
+              `Error updating existing artworks batch ${i / BATCH_SIZE + 1}:`,
+              error
+            );
+            batchOk = false;
+          } else {
+            artworkCount += updateRecords.length;
+          }
+        }
+
+        if (batchOk && Object.keys(bucketMap).length > 0) {
           // Attach medium categories from the lookup map for any rows whose
           // medium string is in the bucket map. Single batched select gets
           // ids; then a single upsert applies all attachments for the batch.
-          if (Object.keys(bucketMap).length > 0) {
-            const inventoryNumbers = withInventory.map((r) => r.inventory_number!);
-            const { data: artRows } = await supabase
-              .from("artworks")
-              .select("id, inventory_number, medium")
-              .in("inventory_number", inventoryNumbers);
+          const inventoryNumbers = withInventory.map((r) => r.inventory_number!);
+          const { data: artRows } = await supabase
+            .from("artworks")
+            .select("id, inventory_number, medium")
+            .in("inventory_number", inventoryNumbers);
 
-            const acRows: { artwork_id: string; category_id: string }[] = [];
-            const unknownInThisBatch = new Set<string>();
-            for (const a of artRows || []) {
-              const buckets = mediumToBuckets(bucketMap, a.medium);
-              if (buckets.length === 0) {
-                if (a.medium) unknownInThisBatch.add(a.medium);
-                continue;
-              }
-              for (const b of buckets) {
-                const categoryId = bucketIdByName[b];
-                if (categoryId) acRows.push({ artwork_id: a.id, category_id: categoryId });
-              }
+          const acRows: { artwork_id: string; category_id: string }[] = [];
+          const unknownInThisBatch = new Set<string>();
+          for (const a of artRows || []) {
+            const buckets = mediumToBuckets(bucketMap, a.medium);
+            if (buckets.length === 0) {
+              if (a.medium) unknownInThisBatch.add(a.medium);
+              continue;
             }
-            if (acRows.length > 0) {
-              await supabase
-                .from("artwork_categories")
-                .upsert(acRows, { onConflict: "artwork_id,category_id", ignoreDuplicates: true });
+            for (const b of buckets) {
+              const categoryId = bucketIdByName[b];
+              if (categoryId) acRows.push({ artwork_id: a.id, category_id: categoryId });
             }
-            for (const m of unknownInThisBatch) unknownMediums.add(m);
           }
+          if (acRows.length > 0) {
+            await supabase
+              .from("artwork_categories")
+              .upsert(acRows, { onConflict: "artwork_id,category_id", ignoreDuplicates: true });
+          }
+          for (const m of unknownInThisBatch) unknownMediums.add(m);
         }
       }
 
@@ -286,7 +342,80 @@ async function main() {
     console.warn("Re-run `npm run medium:propose` to absorb these into the vocabulary.");
   }
 
-  // ── Step 3: Summary ────────────────────────────────────────────────────
+  // ── Step 3: Unpublish rows not in CSV (opt-in) ─────────────────────────
+  if (UNPUBLISH_MISSING) {
+    console.log(
+      `\n--- Unpublishing rows not in CSV${DRY_RUN ? " (DRY RUN)" : ""} ---`
+    );
+
+    const csvInvSet = new Set(
+      rows.map((r) => r["Inventory Number"]?.trim()).filter(Boolean)
+    );
+
+    // Page through every currently-visible row. We key the update by id so
+    // rows with NULL inventory_number are handled with the same code path.
+    const currentlyVisible: {
+      id: string;
+      inventory_number: string | null;
+      title: string;
+    }[] = [];
+    const PAGE = 1000;
+    let from = 0;
+    while (true) {
+      const { data, error } = await supabase
+        .from("artworks")
+        .select("id, inventory_number, title")
+        .eq("on_website", true)
+        .range(from, from + PAGE - 1);
+      if (error) {
+        console.error("Error paging visible rows:", error);
+        break;
+      }
+      if (!data || data.length === 0) break;
+      currentlyVisible.push(...data);
+      if (data.length < PAGE) break;
+      from += PAGE;
+    }
+
+    const toUnpublish = currentlyVisible.filter(
+      (r) => !r.inventory_number || !csvInvSet.has(r.inventory_number)
+    );
+
+    console.log(
+      `Currently visible: ${currentlyVisible.length}. CSV provides ${csvInvSet.size} inventory numbers. ` +
+        `${toUnpublish.length} rows will be unpublished.`
+    );
+
+    const sample = toUnpublish.slice(0, 10);
+    if (sample.length > 0) {
+      console.log(`Sample (first ${sample.length}):`);
+      for (const r of sample) {
+        console.log(`  ${r.inventory_number ?? "(no inv)"} — ${r.title}`);
+      }
+    }
+
+    if (DRY_RUN) {
+      console.log("(dry run — no changes made)");
+    } else if (toUnpublish.length > 0) {
+      const BATCH = 100;
+      let updated = 0;
+      for (let i = 0; i < toUnpublish.length; i += BATCH) {
+        const ids = toUnpublish.slice(i, i + BATCH).map((r) => r.id);
+        const { error } = await supabase
+          .from("artworks")
+          .update({ on_website: false })
+          .in("id", ids);
+        if (error) {
+          console.error(`Error unpublishing batch:`, error);
+        } else {
+          updated += ids.length;
+        }
+      }
+      console.log(`Unpublished ${updated} rows.`);
+    }
+  }
+
+  // ── Step 4: Summary ────────────────────────────────────────────────────
   const { count: totalArtworks } = await supabase
     .from("artworks")
     .select("*", { count: "exact", head: true });

--- a/scripts/import-csv.ts
+++ b/scripts/import-csv.ts
@@ -63,6 +63,17 @@ if (fs.existsSync(BUCKETS_FILE)) {
   // bucketIdByName is populated below after we resolve category IDs from the DB.
 }
 
+// Tags that the site uses as filter keys are stored lowercase in the DB;
+// Postgres array @> is case-sensitive, so a CSV tag of "Ephemera" wouldn't
+// match `tags @> '{ephemera}'`. Canonicalize at import to keep the data clean.
+const FILTER_MAGIC_TAGS = new Set(["ephemera"]);
+
+function normalizeFilterTags(tags: string[]): string[] {
+  return tags.map((t) =>
+    FILTER_MAGIC_TAGS.has(t.toLowerCase()) ? t.toLowerCase() : t
+  );
+}
+
 // ─── Types ────────────────────────────────────────────────────────────────
 interface CsvRow {
   Image: string;
@@ -166,7 +177,7 @@ async function main() {
   // Process in batches of 100 for Supabase limits
   const BATCH_SIZE = 100;
   let artworkCount = 0;
-  let skippedCount = 0;
+  let placeholderTitleCount = 0;
   const unknownMediums = new Set<string>();
 
   for (let i = 0; i < rows.length; i += BATCH_SIZE) {
@@ -174,10 +185,10 @@ async function main() {
     const artworkRecords = [];
 
     for (const row of batch) {
-      const title = row.Title?.trim();
+      let title = row.Title?.trim();
       if (!title) {
-        skippedCount++;
-        continue;
+        title = "Untitled";
+        placeholderTitleCount++;
       }
 
       const first = row["Artist First Name"]?.trim() || "";
@@ -200,7 +211,7 @@ async function main() {
         sku: row.SKU?.trim() || null,
         image_original: row.Image?.trim() || null,
         image_url: row.Image?.trim() || null,
-        tags: parseTags(row.Tags),
+        tags: normalizeFilterTags(parseTags(row.Tags)),
         genre:
           row.Genre?.trim() && row.Genre.trim() !== "Unselected"
             ? row.Genre.trim()
@@ -333,7 +344,7 @@ async function main() {
   }
 
   console.log(
-    `\n\nDone! Imported ${artworkCount} artworks, skipped ${skippedCount} (no title).`
+    `\n\nDone! Imported ${artworkCount} artworks (${placeholderTitleCount} given "Untitled" placeholder for blank CSV title).`
   );
 
   if (unknownMediums.size > 0) {


### PR DESCRIPTION
## Summary

Four import-pipeline improvements plus a vocabulary refresh:

1. **R2 image_url preservation.** Splits the artwork upsert into new-row vs existing-row paths. Existing rows have `image_url` and `image_original` stripped from the payload before upsert so PostgREST omits them from the `ON CONFLICT DO UPDATE SET` clause — R2 URLs and originals survive re-imports. New rows still get the CSV's Image value as `image_url`.
2. **Opt-in `--unpublish-missing` sweep.** After the import, sets `on_website = false` on every row whose `inventory_number` is not in the CSV (and visible NULL-inventory rows). Use `--dry-run` to preview.
3. **"Untitled" placeholder for blank-title rows.** Previously the script silently skipped any CSV row with a missing Title (98 such rows in the May 15 batch — all skeletal entries with inv + image but no metadata yet). Now they're imported with `title = "Untitled"` so they're in the catalog and editable, instead of vanishing.
4. **Ephemera tag case canonicalization.** Postgres array `@>` is case-sensitive, so a CSV tag of `"Ephemera"` wouldn't match the site's cohort filter (`tags @> '{ephemera}'`) and the work would render in Collection instead of Ephemera. New `normalizeFilterTags()` lowercases any tag whose lowercase form is in the magic set (currently just `"ephemera"`).
5. **7 new medium mappings** added to `scripts/data/medium-buckets.json` for the May 15 inventory CSV's new strings (Showcard, Book, Acrylic+wood sculpture, etc.) using existing buckets — no vocab change.

## Test plan

- [x] Verified `image_url` and `image_original` preserved on existing row (43124) after re-import; AI `alt_text_long` also preserved
- [x] Verified new row (44146) inserted with CSV Image URL as `image_url`
- [x] Ran `--unpublish-missing --dry-run` on full 2573-row CSV: reported 1169 rows to hide
- [x] Ran for real: 1170 rows unpublished; visible count went 3643 → 2474 (matches CSV size minus skipped-no-title rows)
- [x] One-shot data fix: 101 rows with uppercase `"Ephemera"` rewritten to `"ephemera"` (uppercase=0, lowercase=445 after)
- [x] Re-ran import with new code: 2573 imported (98 with `"Untitled"` placeholder); final visible = 2572 after sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)