### PR TITLE
feat(export): add Filename column with R2 image URL to admin CSV export

### DIFF
--- a/src/app/admin/import/page.tsx
+++ b/src/app/admin/import/page.tsx
@@ -4,6 +4,21 @@
 import { useState } from "react";
 import { createClient } from "@/lib/supabase/client";
 
+// Prefer R2 over CDN — image_url is the canonical R2 path post-migration.
+// This inverts resolveImageUrl()'s priority, which falls back to CDN for
+// display continuity on rows still in mid-migration.
+function exportImageUrl(
+  image_url: string | null,
+  image_original: string | null
+): string {
+  if (!image_url) return image_original || "";
+  if (image_url.startsWith("http://") || image_url.startsWith("https://")) {
+    return image_url;
+  }
+  const base = process.env.NEXT_PUBLIC_R2_PUBLIC_URL;
+  return base ? `${base}/${image_url}` : image_url;
+}
+
 export default function ImportPage() {
   const supabase = createClient();
   const [loading, setLoading] = useState(false);
@@ -39,6 +54,7 @@ export default function ImportPage() {
         "Width",
         "Depth",
         "Inventory Number",
+        "Filename",
         "Categories",
         "Tags",
         "On Website",
@@ -56,6 +72,7 @@ export default function ImportPage() {
         artwork.width || "",
         artwork.depth || "",
         artwork.inventory_number || "",
+        exportImageUrl(artwork.image_url, artwork.image_original),
         artwork.categories?.map((c: any) => c.category.name).join("; ") || "",
         artwork.tags?.join("; ") || "",
         artwork.on_website ? "Yes" : "No",


### PR DESCRIPTION
## Summary

- Adds a **Filename** column to the admin Export CSV (in `/admin/import`), positioned after `Inventory Number`.
- Value is the artwork's R2 large_1600 URL for migrated rows, or its original CDN URL as fallback for rows still in mid-migration.
- New `exportImageUrl()` helper inverts `resolveImageUrl()`'s priority — that helper prefers CDN for display continuity, this one explicitly prefers R2 since the export is intended for downstream use.

## Test plan

- [x] Verified locally: clicked Export as CSV in `/admin/import`, downloaded file has the new Filename column populated with R2 URLs for migrated rows
- [ ] Confirm CDN fallback works for any rows pending R2 migration (the in-flight background migration will eliminate these once it completes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)