### PR TITLE
chore(descriptions): bump model from sonnet-4-20250514 to sonnet-4-6

### DIFF
--- a/scripts/generate-descriptions.ts
+++ b/scripts/generate-descriptions.ts
@@ -21,7 +21,7 @@ import Anthropic from "@anthropic-ai/sdk";
 // ─── Config ───────────────────────────────────────────────────────────────
 const CONCURRENCY = parseInt(process.env.DESCRIPTION_CONCURRENCY || "3", 10);
 const PROGRESS_FILE = path.join(__dirname, ".description-progress.json");
-const MODEL = "claude-sonnet-4-20250514";
+const MODEL = "claude-sonnet-4-6";
 
 // ─── Clients ──────────────────────────────────────────────────────────────
 const supabase = createClient(


### PR DESCRIPTION
## Summary

- One-line model bump in \`scripts/generate-descriptions.ts\` from \`claude-sonnet-4-20250514\` (the original Sonnet 4 from May) to \`claude-sonnet-4-6\` (latest Sonnet, better image understanding, same pricing tier).
- Already-generated descriptions are unaffected; the next time \`npm run generate:descriptions\` runs, new rows will use 4.6.

## Test plan

- [ ] Optional: kick off a small run (e.g., on 10 untreated rows) and spot-check that 4.6 descriptions are sensible
- [ ] Confirm \`.description-progress.json\` still resumes correctly under the new model

🤖 Generated with [Claude Code](https://claude.com/claude-code)